### PR TITLE
fix: loadPersona() path traversal — use validateDiffPath utility (#102)

### DIFF
--- a/src/l2/moderator.ts
+++ b/src/l2/moderator.ts
@@ -10,6 +10,7 @@ import { writeDiscussionRound, writeDiscussionVerdict, writeSupportersLog } from
 import { checkForObjections, handleObjections } from './objection.js';
 import { readFile } from 'fs/promises';
 import path from 'path';
+import { validateDiffPath } from '../utils/path-validation.js';
 
 // ============================================================================
 // Supporter Selection
@@ -85,25 +86,27 @@ function randomElement<T>(array: T[]): T | undefined {
 // ============================================================================
 
 /**
- * Load persona file content
+ * Load persona file content.
+ * Uses validateDiffPath for robust path traversal prevention
+ * (null byte check, ".." segment detection, allowed-root containment).
  */
-async function loadPersona(personaPath: string): Promise<string> {
+export async function loadPersona(personaPath: string): Promise<string> {
   try {
-    // Block absolute paths to prevent path traversal
+    // Block absolute paths explicitly before validation
     if (path.isAbsolute(personaPath)) {
       console.warn(`[Persona] Absolute path blocked: ${personaPath}`);
       return '';
     }
 
-    // Resolve relative to project root and verify it stays within
+    // Validate using shared utility — checks null bytes, "..", and containment
     const projectRoot = process.cwd();
-    const fullPath = path.resolve(projectRoot, personaPath);
-    if (!fullPath.startsWith(projectRoot + path.sep) && fullPath !== projectRoot) {
-      console.warn(`[Persona] Path traversal blocked: ${personaPath}`);
+    const result = validateDiffPath(personaPath, { allowedRoots: [projectRoot] });
+    if (!result.success) {
+      console.warn(`[Persona] Path validation failed: ${result.error}`);
       return '';
     }
 
-    const content = await readFile(fullPath, 'utf-8');
+    const content = await readFile(result.data, 'utf-8');
     return content.trim();
   } catch (error) {
     console.warn(`[Persona] Failed to load ${personaPath}:`, error instanceof Error ? error.message : error);

--- a/src/tests/l2-loadpersona.test.ts
+++ b/src/tests/l2-loadpersona.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for loadPersona() path traversal prevention
+ * Issue #102: restrict persona loading to project root
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import { loadPersona } from '../l2/moderator.js';
+
+// Mock fs/promises
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from 'fs/promises';
+const mockReadFile = vi.mocked(readFile);
+
+describe('loadPersona', () => {
+  const originalCwd = process.cwd;
+  const fakeRoot = '/fake/project';
+
+  beforeEach(() => {
+    process.cwd = () => fakeRoot;
+    mockReadFile.mockReset();
+  });
+
+  afterEach(() => {
+    process.cwd = originalCwd;
+  });
+
+  it('loads a valid relative persona file', async () => {
+    mockReadFile.mockResolvedValue('You are a security expert.');
+    const result = await loadPersona('prompts/security.md');
+    expect(result).toBe('You are a security expert.');
+    expect(mockReadFile).toHaveBeenCalledWith(
+      path.resolve(fakeRoot, 'prompts/security.md'),
+      'utf-8'
+    );
+  });
+
+  it('blocks absolute paths', async () => {
+    const result = await loadPersona('/etc/passwd');
+    expect(result).toBe('');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('blocks path traversal with ".." segments', async () => {
+    const result = await loadPersona('../../../etc/passwd');
+    expect(result).toBe('');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('blocks paths with null bytes', async () => {
+    const result = await loadPersona('prompts/valid.md\x00.txt');
+    expect(result).toBe('');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('blocks paths that resolve outside project root', async () => {
+    // Even without explicit "..", some paths could resolve outside
+    const result = await loadPersona('../sibling-project/persona.md');
+    expect(result).toBe('');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns empty string on file read error', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    const result = await loadPersona('prompts/nonexistent.md');
+    expect(result).toBe('');
+  });
+
+  it('trims whitespace from loaded content', async () => {
+    mockReadFile.mockResolvedValue('  persona content  \n');
+    const result = await loadPersona('prompts/valid.md');
+    expect(result).toBe('persona content');
+  });
+
+  it('returns empty string for empty path', async () => {
+    const result = await loadPersona('');
+    expect(result).toBe('');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Security fix**: Refactored `loadPersona()` in `src/l2/moderator.ts` to use the shared `validateDiffPath()` utility instead of inline path checks
- Adds robust protection: null byte detection, `..` segment blocking, and allowed-root containment check
- Exported `loadPersona` for testability
- Added 8 unit tests covering all path traversal attack vectors

## Changes

| File | Change |
|------|--------|
| `src/l2/moderator.ts` | Import `validateDiffPath`, replace inline checks with shared utility |
| `src/tests/l2-loadpersona.test.ts` | New: 8 tests for path traversal prevention |

Closes #102

## Test Plan

- [x] Valid relative path loads correctly
- [x] Absolute paths blocked
- [x] `..` traversal blocked
- [x] Null byte injection blocked
- [x] Paths resolving outside project root blocked
- [x] File read errors return empty string
- [x] Content whitespace trimmed
- [x] Empty path returns empty string