### PR TITLE
fix: validate SARIF output path to prevent path traversal (#107)

### DIFF
--- a/src/github-action.ts
+++ b/src/github-action.ts
@@ -15,6 +15,7 @@ import { mapToGitHubReview } from './github/mapper.js';
 import { postReview, setCommitStatus, handleNeedsHuman } from './github/poster.js';
 import { buildSarifReport, serializeSarif } from './github/sarif.js';
 import { loadConfig } from './config/loader.js';
+import { validateDiffPath } from './utils/path-validation.js';
 
 // ============================================================================
 // Input Parsing
@@ -138,11 +139,18 @@ async function main(): Promise<void> {
     });
   }
 
-  // Generate SARIF output
-  const sarifPath = config?.github?.sarifOutputPath ?? '/tmp/codeagora-results.sarif';
-  const sarifReport = buildSarifReport(evidenceDocs, result.sessionId, result.date);
-  await fs.writeFile(sarifPath, serializeSarif(sarifReport));
-  console.log(`SARIF report written to ${sarifPath}`);
+  // Generate SARIF output — validate path to prevent traversal attacks
+  const rawSarifPath = config?.github?.sarifOutputPath ?? '/tmp/codeagora-results.sarif';
+  const sarifValidation = validateDiffPath(rawSarifPath, {
+    allowedRoots: [process.cwd(), '/tmp'],
+  });
+  if (sarifValidation.success) {
+    const sarifReport = buildSarifReport(evidenceDocs, result.sessionId, result.date);
+    await fs.writeFile(sarifValidation.data, serializeSarif(sarifReport));
+    console.log(`SARIF report written to ${sarifValidation.data}`);
+  } else {
+    console.error(`::warning::SARIF output path rejected: ${sarifValidation.error}`);
+  }
 
   console.log('::endgroup::');
 

--- a/src/tests/github-action-sarif-path.test.ts
+++ b/src/tests/github-action-sarif-path.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for SARIF output path validation in github-action.ts
+ * Issue #107: validate sarifOutputPath to prevent path traversal
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateDiffPath } from '../utils/path-validation.js';
+
+describe('SARIF output path validation', () => {
+  const allowedRoots = ['/workspace/project', '/tmp'];
+
+  it('accepts default /tmp path', () => {
+    const result = validateDiffPath('/tmp/codeagora-results.sarif', { allowedRoots });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts path under project root', () => {
+    const result = validateDiffPath('/workspace/project/.ca/results.sarif', { allowedRoots });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects path outside allowed roots', () => {
+    const result = validateDiffPath('/etc/evil.sarif', { allowedRoots });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects path with traversal segments', () => {
+    const result = validateDiffPath('/tmp/../etc/passwd', { allowedRoots });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects path with null bytes', () => {
+    const result = validateDiffPath('/tmp/safe.sarif\x00.evil', { allowedRoots });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty path', () => {
+    const result = validateDiffPath('', { allowedRoots });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **Security fix**: Validates `sarifOutputPath` in `github-action.ts` using `validateDiffPath()` before writing
- Allowed roots: `process.cwd()` and `/tmp` (default SARIF location)
- Rejects paths with traversal segments, null bytes, or outside allowed directories
- Logs `::warning::` instead of writing to invalid paths

## Changes

| File | Change |
|------|--------|
| `src/github-action.ts` | Add `validateDiffPath` check before `fs.writeFile` for SARIF output |
| `src/tests/github-action-sarif-path.test.ts` | New: 6 tests for SARIF path validation |

Closes #107

## Test Plan

- [x] Default `/tmp` path accepted
- [x] Path under project root accepted
- [x] Path outside allowed roots rejected
- [x] Path with `..` traversal rejected
- [x] Path with null bytes rejected
- [x] Empty path rejected