### PR TITLE
fix: validate credentials file permissions before loading (#83)

### DIFF
--- a/src/config/credentials.ts
+++ b/src/config/credentials.ts
@@ -4,7 +4,7 @@
  * Similar to gh CLI (~/.config/gh/) and aws CLI (~/.aws/credentials).
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'fs';
 import path from 'path';
 import os from 'os';
 
@@ -17,6 +17,11 @@ const CREDENTIALS_PATH = path.join(CONFIG_DIR, 'credentials');
  */
 export function loadCredentials(): void {
   if (!existsSync(CREDENTIALS_PATH)) return;
+
+  // Verify file permissions are 0o600 (owner read/write only)
+  if (!checkFilePermissions(CREDENTIALS_PATH, 0o600)) {
+    return;
+  }
 
   const content = readFileSync(CREDENTIALS_PATH, 'utf-8');
   for (const line of content.split('\n')) {
@@ -70,4 +75,31 @@ export function saveCredential(key: string, value: string): void {
  */
 export function getCredentialsPath(): string {
   return CREDENTIALS_PATH;
+}
+
+/**
+ * Check that a file has the expected permission mode.
+ * On Windows this check is skipped (always returns true).
+ * Warns and returns false if permissions are too loose.
+ */
+export function checkFilePermissions(filePath: string, expectedMode: number): boolean {
+  // Skip permission checks on Windows (no Unix permission model)
+  if (process.platform === 'win32') return true;
+
+  try {
+    const stat = statSync(filePath);
+    const actualMode = stat.mode & 0o777;
+    if (actualMode !== expectedMode) {
+      const actual = `0o${actualMode.toString(8)}`;
+      const expected = `0o${expectedMode.toString(8)}`;
+      console.warn(
+        `[Security] ${filePath} has permissions ${actual}, expected ${expected}. ` +
+        `Fix with: chmod ${expectedMode.toString(8)} "${filePath}"`
+      );
+      return false;
+    }
+    return true;
+  } catch {
+    return true; // If stat fails, let the caller handle the read error
+  }
 }

--- a/src/tests/config-credentials-permissions.test.ts
+++ b/src/tests/config-credentials-permissions.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for credentials file permission check
+ * Issue #83: validate credentials file permissions (0o600)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkFilePermissions } from '../config/credentials.js';
+import { statSync } from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    statSync: vi.fn(),
+  };
+});
+
+const mockStatSync = vi.mocked(statSync);
+
+describe('checkFilePermissions', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('returns true when permissions match expected mode', () => {
+    mockStatSync.mockReturnValue({ mode: 0o100600 } as ReturnType<typeof statSync>);
+    expect(checkFilePermissions('/path/to/creds', 0o600)).toBe(true);
+  });
+
+  it('returns false and warns when permissions are too loose', () => {
+    mockStatSync.mockReturnValue({ mode: 0o100644 } as ReturnType<typeof statSync>);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(checkFilePermissions('/path/to/creds', 0o600)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('permissions 0o644, expected 0o600')
+    );
+  });
+
+  it('returns false when file is world-readable', () => {
+    mockStatSync.mockReturnValue({ mode: 0o100666 } as ReturnType<typeof statSync>);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(checkFilePermissions('/path/to/creds', 0o600)).toBe(false);
+  });
+
+  it('returns true on Windows (skip check)', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    // statSync should NOT be called on Windows
+    expect(checkFilePermissions('/path/to/creds', 0o600)).toBe(true);
+    expect(mockStatSync).not.toHaveBeenCalled();
+  });
+
+  it('returns true when stat throws (let caller handle)', () => {
+    mockStatSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    expect(checkFilePermissions('/nonexistent', 0o600)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Security fix**: Checks `~/.config/codeagora/credentials` has `0o600` permissions before reading
- Warns with actionable `chmod` fix command if permissions are too loose
- Skipped on Windows (no Unix permission model)
- Exported `checkFilePermissions()` for reuse in `.ca/` directory check (#75)

## Changes

| File | Change |
|------|--------|
| `src/config/credentials.ts` | Add permission check in `loadCredentials()`, add `checkFilePermissions()` helper |
| `src/tests/config-credentials-permissions.test.ts` | New: 5 tests for permission validation |

Closes #83

## Test Plan

- [x] Correct permissions (0o600) pass
- [x] Loose permissions (0o644) warn and reject
- [x] World-readable (0o666) rejected
- [x] Windows: check skipped, returns true
- [x] stat failure: returns true (let caller handle)