### PR TITLE
fix: enforce .ca/ directory permissions to 0o700 (#75)

### DIFF
--- a/src/tests/utils-ca-root-permissions.test.ts
+++ b/src/tests/utils-ca-root-permissions.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for .ca/ directory permission enforcement
+ * Issue #75: validate .ca/ directory permissions (0o700)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+import { ensureCaRoot } from '../utils/fs.js';
+
+describe('ensureCaRoot', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ca-perm-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates .ca/ directory if it does not exist', async () => {
+    await ensureCaRoot(tmpDir);
+    const stat = await fs.stat(path.join(tmpDir, '.ca'));
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  if (process.platform !== 'win32') {
+    it('sets .ca/ directory to 0o700 on creation', async () => {
+      await ensureCaRoot(tmpDir);
+      const stat = await fs.stat(path.join(tmpDir, '.ca'));
+      const mode = stat.mode & 0o777;
+      expect(mode).toBe(0o700);
+    });
+
+    it('fixes permissions if .ca/ exists with wrong mode', async () => {
+      const caDir = path.join(tmpDir, '.ca');
+      await fs.mkdir(caDir, { mode: 0o755 });
+
+      // Verify initial wrong permissions
+      const before = await fs.stat(caDir);
+      expect(before.mode & 0o777).toBe(0o755);
+
+      // ensureCaRoot should fix them
+      await ensureCaRoot(tmpDir);
+
+      const after = await fs.stat(caDir);
+      expect(after.mode & 0o777).toBe(0o700);
+    });
+
+    it('leaves correct permissions unchanged', async () => {
+      const caDir = path.join(tmpDir, '.ca');
+      await fs.mkdir(caDir, { mode: 0o700 });
+
+      await ensureCaRoot(tmpDir);
+
+      const stat = await fs.stat(caDir);
+      expect(stat.mode & 0o777).toBe(0o700);
+    });
+  }
+});

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -72,10 +72,37 @@ export async function ensureDir(dirPath: string): Promise<void> {
   }
 }
 
+/**
+ * Ensure the .ca/ root directory exists with secure permissions (0o700).
+ * Fixes permissions if already exists with wrong mode.
+ * Skipped on Windows.
+ */
+export async function ensureCaRoot(baseDir: string = '.'): Promise<void> {
+  const caDir = path.join(baseDir, CA_ROOT);
+
+  await ensureDir(caDir);
+
+  // Enforce 0o700 permissions on Unix
+  if (process.platform !== 'win32') {
+    try {
+      const stat = await fs.stat(caDir);
+      const mode = stat.mode & 0o777;
+      if (mode !== 0o700) {
+        await fs.chmod(caDir, 0o700);
+      }
+    } catch {
+      // Best effort — directory may have just been created
+    }
+  }
+}
+
 export async function initSessionDirs(
   date: string,
   sessionId: string
 ): Promise<void> {
+  // Ensure .ca/ root has secure permissions first
+  await ensureCaRoot();
+
   const dirs = [
     getSessionDir(date, sessionId),
     getReviewsDir(date, sessionId),


### PR DESCRIPTION
## Summary

- **Security fix**: Adds `ensureCaRoot()` to enforce `0o700` permissions on `.ca/` directory
- Creates directory with secure permissions on first run
- Fixes existing directories with wrong permissions (e.g., 0o755 → 0o700)
- Wired into `initSessionDirs()` so permissions are enforced on every session creation
- Skipped on Windows (no Unix permission model)

## Changes

| File | Change |
|------|--------|
| `src/utils/fs.ts` | Add `ensureCaRoot()`, call from `initSessionDirs()` |
| `src/tests/utils-ca-root-permissions.test.ts` | New: 4 tests with real filesystem |

Closes #75

## Test Plan

- [x] Creates .ca/ if not exists
- [x] Sets 0o700 on creation
- [x] Fixes wrong permissions (0o755 → 0o700)
- [x] Leaves correct permissions unchanged