### PR TITLE
fix: rewrite parseStance() and parseForcedDecision() with structured parsing (#96, #110)

### DIFF
--- a/src/l2/moderator.ts
+++ b/src/l2/moderator.ts
@@ -539,42 +539,129 @@ ${snippetSection}
 Evaluate the evidence and provide your verdict.`;
 }
 
-function parseStance(response: string): 'agree' | 'disagree' | 'neutral' {
+type Stance = 'agree' | 'disagree' | 'neutral';
+type Severity = 'HARSHLY_CRITICAL' | 'CRITICAL' | 'WARNING' | 'SUGGESTION' | 'DISMISSED';
+
+/**
+ * Parse supporter stance from LLM response.
+ *
+ * Priority:
+ * 1. Structured patterns: "Stance: AGREE", "**Verdict:** disagree", JSON "stance": "agree"
+ * 2. First-line keyword (DISAGREE checked before AGREE to avoid substring match)
+ * 3. Weighted section scan (headings and bold markers get extra weight)
+ * 4. Default: neutral
+ */
+export function parseStance(response: string): Stance {
+  // P1: Structured field patterns (case-insensitive)
+  const structuredMatch = response.match(
+    /(?:stance|verdict|decision|judgment|판단)\s*[:=]\s*\*{0,2}\s*(agree|disagree|neutral|동의|반대|중립)/im
+  );
+  if (structuredMatch) {
+    return normalizeStance(structuredMatch[1]);
+  }
+
+  // P1b: JSON-like pattern: "stance": "agree"
+  const jsonMatch = response.match(/"stance"\s*:\s*"(agree|disagree|neutral)"/i);
+  if (jsonMatch) {
+    return jsonMatch[1].toLowerCase() as Stance;
+  }
+
+  // P2: First-line explicit keyword (check DISAGREE before AGREE)
   const firstLine = response.split('\n')[0].toUpperCase().trim();
+  if (/\bDISAGREE\b/.test(firstLine)) return 'disagree';
+  if (/\bAGREE\b/.test(firstLine)) return 'agree';
+  if (/\bNEUTRAL\b/.test(firstLine)) return 'neutral';
 
-  // First line explicit stance declaration takes priority.
-  // Check DISAGREE before AGREE since "DISAGREE" contains "AGREE" as a substring.
-  if (firstLine.includes('DISAGREE')) return 'disagree';
-  if (firstLine.includes('AGREE')) return 'agree';
-  if (firstLine.includes('NEUTRAL')) return 'neutral';
+  // P3: Weighted keyword scan — headings/bold get 3x weight
+  const lines = response.split('\n');
+  let agreeScore = 0;
+  let disagreeScore = 0;
 
-  // Fallback: keyword counting on full response
-  const lower = response.toLowerCase();
-  // Count disagree first (it contains "agree" as substring)
-  const disagreeCount = (lower.match(/\bdisagree\b/g) ?? []).length;
-  // Pure agree = total agree matches minus those that are part of "disagree"
-  const agreeCount = (lower.match(/\bagree\b/g) ?? []).length - disagreeCount;
+  for (const line of lines) {
+    const isEmphasis = /^#{1,3}\s|^\*\*/.test(line.trim());
+    const weight = isEmphasis ? 3 : 1;
+    const lower = line.toLowerCase();
 
-  if (agreeCount > disagreeCount) return 'agree';
-  if (disagreeCount > agreeCount) return 'disagree';
+    // Count word-boundary matches; \bagree\b won't match inside "disagree"
+    const dMatches = (lower.match(/\bdisagree\b|반대/g) ?? []).length;
+    const aMatches = (lower.match(/\bagree\b|동의/g) ?? []).length;
+
+    disagreeScore += dMatches * weight;
+    agreeScore += aMatches * weight;
+  }
+
+  if (agreeScore > disagreeScore) return 'agree';
+  if (disagreeScore > agreeScore) return 'disagree';
   return 'neutral';
 }
 
-function parseForcedDecision(response: string): { severity: 'HARSHLY_CRITICAL' | 'CRITICAL' | 'WARNING' | 'SUGGESTION' | 'DISMISSED'; reasoning: string } {
-  // Check first few lines for explicit severity keyword
-  const firstLines = response.split('\n').slice(0, 5).join('\n').toLowerCase();
+function normalizeStance(raw: string): Stance {
+  const lower = raw.toLowerCase().trim();
+  if (lower === 'disagree' || lower === '반대') return 'disagree';
+  if (lower === 'agree' || lower === '동의') return 'agree';
+  return 'neutral';
+}
 
-  let severity: 'HARSHLY_CRITICAL' | 'CRITICAL' | 'WARNING' | 'SUGGESTION' | 'DISMISSED' = 'WARNING';
+/**
+ * Parse moderator forced decision from LLM response.
+ *
+ * Priority:
+ * 1. Structured patterns: "Severity: WARNING", "**Severity:** CRITICAL"
+ * 2. JSON-like: "severity": "WARNING"
+ * 3. Keyword scan on full response (most specific first)
+ * 4. Default: WARNING
+ */
+export function parseForcedDecision(response: string): { severity: Severity; reasoning: string } {
+  const SEVERITY_ORDER: Severity[] = [
+    'HARSHLY_CRITICAL', 'CRITICAL', 'WARNING', 'SUGGESTION', 'DISMISSED',
+  ];
 
-  // Match most specific first (harshly_critical before critical)
-  if (/\b(harshly[_\s]critical)\b/.test(firstLines)) severity = 'HARSHLY_CRITICAL';
-  else if (/\bseverity:\s*critical\b/.test(firstLines) || /^critical\b/m.test(firstLines)) severity = 'CRITICAL';
-  else if (/\bcritical\b/.test(firstLines) && !/\bnot\s+critical\b/.test(firstLines)) severity = 'CRITICAL';
-  else if (/\bwarning\b/.test(firstLines)) severity = 'WARNING';
-  else if (/\bdismissed?\b/.test(firstLines)) severity = 'DISMISSED';
+  // P1: Structured field pattern
+  const structuredMatch = response.match(
+    /(?:severity|심각도)\s*[:=]\s*\*{0,2}\s*(harshly[_\s]critical|critical|warning|suggestion|dismissed?)/im
+  );
+  if (structuredMatch) {
+    const normalized = normalizeSeverity(structuredMatch[1]);
+    if (normalized) return { severity: normalized, reasoning: response.trim() };
+  }
 
-  return {
-    severity,
-    reasoning: response.trim(),
+  // P1b: JSON-like pattern
+  const jsonMatch = response.match(
+    /"severity"\s*:\s*"(HARSHLY_CRITICAL|CRITICAL|WARNING|SUGGESTION|DISMISSED)"/i
+  );
+  if (jsonMatch) {
+    const normalized = normalizeSeverity(jsonMatch[1]);
+    if (normalized) return { severity: normalized, reasoning: response.trim() };
+  }
+
+  // P2: First 10 lines keyword scan, most specific first
+  const scanLines = response.split('\n').slice(0, 10).join('\n').toLowerCase();
+
+  for (const sev of SEVERITY_ORDER) {
+    const pattern = sev === 'HARSHLY_CRITICAL'
+      ? /\bharshly[_\s]critical\b/
+      : sev === 'DISMISSED'
+        ? /\bdismissed?\b/
+        : new RegExp(`\\b${sev.toLowerCase()}\\b`);
+
+    if (pattern.test(scanLines)) {
+      // Guard against false "critical" in phrases like "not critical"
+      if (sev === 'CRITICAL' && /\bnot\s+critical\b/.test(scanLines)) continue;
+      return { severity: sev, reasoning: response.trim() };
+    }
+  }
+
+  return { severity: 'WARNING', reasoning: response.trim() };
+}
+
+function normalizeSeverity(raw: string): Severity | null {
+  const lower = raw.toLowerCase().replace(/\s+/g, '_').replace(/dismissed$/, 'dismissed');
+  const map: Record<string, Severity> = {
+    harshly_critical: 'HARSHLY_CRITICAL',
+    critical: 'CRITICAL',
+    warning: 'WARNING',
+    suggestion: 'SUGGESTION',
+    dismissed: 'DISMISSED',
   };
+  return map[lower] ?? null;
 }

--- a/src/tests/l2-parser-rewrite.test.ts
+++ b/src/tests/l2-parser-rewrite.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for parseStance() and parseForcedDecision() structured parsing
+ * Issues #96, #110: replace naive keyword counting with structured output parsing
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseStance, parseForcedDecision } from '../l2/moderator.js';
+
+describe('parseStance', () => {
+  describe('P1: structured field patterns', () => {
+    it('parses "Stance: AGREE"', () => {
+      expect(parseStance('Stance: AGREE\nThe evidence is solid.')).toBe('agree');
+    });
+
+    it('parses "**Verdict:** disagree"', () => {
+      expect(parseStance('**Verdict:** disagree\nThe code is fine.')).toBe('disagree');
+    });
+
+    it('parses "Decision: neutral"', () => {
+      expect(parseStance('Decision: neutral\nNeed more info.')).toBe('neutral');
+    });
+
+    it('parses Korean "판단: 동의"', () => {
+      expect(parseStance('판단: 동의\n근거가 타당합니다.')).toBe('agree');
+    });
+
+    it('parses Korean "판단: 반대"', () => {
+      expect(parseStance('판단: 반대\n근거가 부족합니다.')).toBe('disagree');
+    });
+
+    it('parses JSON-like {"stance": "agree"}', () => {
+      expect(parseStance('{"stance": "agree", "reasoning": "valid"}')).toBe('agree');
+    });
+  });
+
+  describe('P2: first-line keyword', () => {
+    it('detects AGREE on first line', () => {
+      expect(parseStance('AGREE\nI think the issue is valid.')).toBe('agree');
+    });
+
+    it('detects DISAGREE on first line (not confused with AGREE substring)', () => {
+      expect(parseStance('DISAGREE\nThe code looks correct to me.')).toBe('disagree');
+    });
+
+    it('detects NEUTRAL on first line', () => {
+      expect(parseStance('NEUTRAL\nI need more information.')).toBe('neutral');
+    });
+  });
+
+  describe('P3: weighted keyword scan', () => {
+    it('heading "agree" outweighs body "disagree"', () => {
+      const response = '## I agree with this assessment\nSome might disagree but the evidence is clear.';
+      expect(parseStance(response)).toBe('agree');
+    });
+
+    it('more disagree keywords wins', () => {
+      const response = 'I disagree with the premise.\nI also disagree with the evidence.\nOne might agree on the approach.';
+      expect(parseStance(response)).toBe('disagree');
+    });
+
+    it('equal counts returns neutral (no first-line keyword)', () => {
+      const response = 'Looking at the evidence:\nI agree on point A.\nI disagree on point B.';
+      expect(parseStance(response)).toBe('neutral');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('empty response returns neutral', () => {
+      expect(parseStance('')).toBe('neutral');
+    });
+
+    it('response with no stance keywords returns neutral', () => {
+      expect(parseStance('The code has some issues that need attention.')).toBe('neutral');
+    });
+
+    it('"I strongly disagree" is not confused by "agree" substring', () => {
+      expect(parseStance('I strongly disagree with this finding.')).toBe('disagree');
+    });
+  });
+});
+
+describe('parseForcedDecision', () => {
+  describe('P1: structured field patterns', () => {
+    it('parses "Severity: CRITICAL"', () => {
+      const result = parseForcedDecision('Severity: CRITICAL\nThis is a real issue.');
+      expect(result.severity).toBe('CRITICAL');
+    });
+
+    it('parses "**Severity:** WARNING"', () => {
+      const result = parseForcedDecision('**Severity:** WARNING\nMinor concern.');
+      expect(result.severity).toBe('WARNING');
+    });
+
+    it('parses "Severity: SUGGESTION"', () => {
+      const result = parseForcedDecision('Severity: SUGGESTION\nCould be improved.');
+      expect(result.severity).toBe('SUGGESTION');
+    });
+
+    it('parses "Severity: DISMISSED"', () => {
+      const result = parseForcedDecision('Severity: DISMISSED\nNot a real issue.');
+      expect(result.severity).toBe('DISMISSED');
+    });
+
+    it('parses "Severity: HARSHLY_CRITICAL"', () => {
+      const result = parseForcedDecision('Severity: HARSHLY_CRITICAL\nSecurity vulnerability.');
+      expect(result.severity).toBe('HARSHLY_CRITICAL');
+    });
+
+    it('parses JSON-like severity', () => {
+      const result = parseForcedDecision('{"severity": "WARNING", "reasoning": "minor"}');
+      expect(result.severity).toBe('WARNING');
+    });
+  });
+
+  describe('P2: keyword scan', () => {
+    it('detects "critical" in text', () => {
+      const result = parseForcedDecision('This is a critical issue that needs attention.');
+      expect(result.severity).toBe('CRITICAL');
+    });
+
+    it('ignores "not critical"', () => {
+      const result = parseForcedDecision('This is not critical, just a minor warning.');
+      expect(result.severity).toBe('WARNING');
+    });
+
+    it('detects "suggestion" in text', () => {
+      const result = parseForcedDecision('This is merely a suggestion for improvement.');
+      expect(result.severity).toBe('SUGGESTION');
+    });
+
+    it('detects "dismissed" in text', () => {
+      const result = parseForcedDecision('The issue should be dismissed as false positive.');
+      expect(result.severity).toBe('DISMISSED');
+    });
+
+    it('prefers harshly_critical over critical', () => {
+      const result = parseForcedDecision('This is a harshly critical security flaw.');
+      expect(result.severity).toBe('HARSHLY_CRITICAL');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('defaults to WARNING for unrecognized response', () => {
+      const result = parseForcedDecision('The code has some issues.');
+      expect(result.severity).toBe('WARNING');
+    });
+
+    it('empty response defaults to WARNING', () => {
+      const result = parseForcedDecision('');
+      expect(result.severity).toBe('WARNING');
+    });
+
+    it('preserves full response as reasoning', () => {
+      const response = '  Severity: CRITICAL\n  This is a real issue.  ';
+      const result = parseForcedDecision(response);
+      expect(result.reasoning).toBe(response.trim());
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Critical bug fix**: Replaces naive keyword counting in `parseStance()` and regex-only parsing in `parseForcedDecision()` with priority-based structured parsing
- Both parsers now support: structured field patterns, JSON-like patterns, first-line keywords, weighted keyword scan
- Adds Korean language support (동의/반대/중립) and SUGGESTION severity support
- Exported both functions for testability
- 29 comprehensive unit tests

## Changes

| File | Change |
|------|--------|
| `src/l2/moderator.ts` | Rewrite `parseStance()` and `parseForcedDecision()` with 4-priority parsing |
| `src/tests/l2-parser-rewrite.test.ts` | New: 29 tests covering structured, keyword, edge cases |

Closes #96, Closes #110

## Test Plan

- [x] Structured patterns: `Stance: AGREE`, `Severity: CRITICAL`
- [x] JSON patterns: `"stance": "agree"`
- [x] Korean patterns: `판단: 동의`
- [x] First-line keyword detection
- [x] Weighted keyword scan (headings get 3x)
- [x] DISAGREE not confused with AGREE substring
- [x] "not critical" guard
- [x] SUGGESTION and DISMISSED severity support
- [x] Empty/unrecognized response defaults