### PR TITLE
fix: config not found → suggest agora init (#79)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -46,9 +46,9 @@ export async function loadConfigFrom(baseDir: string): Promise<Config> {
     return loadYamlConfig(yamlFilePath);
   }
 
-  // Neither exists — preserve original error message
+  // Neither exists — suggest running init
   throw new Error(
-    `Config file not found at ${jsonPath}. Run setup first.`
+    `Config file not found. Run \`agora init\` to create one.`
   );
 }
 

--- a/src/tests/config-not-found.test.ts
+++ b/src/tests/config-not-found.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Tests for config not found error message
+ * Issue #79: suggest agora init when config file is not found
+ */
+
+import { describe, it, expect } from 'vitest';
+import { loadConfigFrom } from '../config/loader.js';
+import os from 'os';
+import path from 'path';
+
+describe('Config not found', () => {
+  it('suggests agora init when config file is missing', async () => {
+    const emptyDir = path.join(os.tmpdir(), `no-config-${Date.now()}`);
+    await expect(loadConfigFrom(emptyDir)).rejects.toThrow('agora init');
+  });
+});


### PR DESCRIPTION
## Summary

- **UX fix**: When config file is not found, error message now suggests `agora init`
- Before: "Config file not found at ... Run setup first."
- After: "Config file not found. Run \`agora init\` to create one."

## Changes

| File | Change |
|------|--------|
| `src/config/loader.ts` | Updated error message |
| `src/tests/config-not-found.test.ts` | New: 1 test verifying suggestion |

Closes #79

## Test Plan

- [x] Error message contains "agora init"