### PR TITLE
fix: stdin temp file cleanup on error via try-finally (#77)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -89,6 +89,8 @@ program
     pr?: string;
     postReview: boolean;
   }) => {
+    // Hoist stdinTmpPath so finally block can clean it up (#77)
+    let stdinTmpPath: string | undefined;
     try {
       if (options.quiet && options.verbose) {
         options.verbose = false; // --quiet takes precedence
@@ -99,7 +101,6 @@ program
 
       // Handle --pr: fetch diff from GitHub
       let resolvedPath: string;
-      let stdinTmpPath: string | undefined;
       let prContext: { owner: string; repo: string; prNumber: number; headSha: string; diff: string } | undefined;
 
       if (options.pr) {
@@ -302,11 +303,6 @@ program
         }
       }
 
-      // Clean up stdin temp file if created
-      if (stdinTmpPath) {
-        try { await fs.unlink(stdinTmpPath); } catch { /* ignore */ }
-      }
-
       if (result.summary?.decision === 'REJECT') {
         process.exit(1);
       }
@@ -319,6 +315,11 @@ program
       console.error(formatError(error, options.verbose));
       const { exitCode } = classifyError(error);
       process.exit(exitCode);
+    } finally {
+      // Clean up stdin/PR temp file — guaranteed even on error (#77)
+      if (stdinTmpPath) {
+        try { await fs.unlink(stdinTmpPath); } catch { /* ignore */ }
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- **Stability fix**: Moves temp file cleanup from inside `try` to `finally` block
- Hoists `stdinTmpPath` declaration before `try` so `finally` can access it
- Ensures temp files from `--pr` and stdin input are always deleted, even on error

## Changes

| File | Change |
|------|--------|
| `src/cli/index.ts` | Hoist `stdinTmpPath`, move cleanup to `finally` block |

Closes #77

## Test Plan

- [x] TypeScript typecheck passes
- [x] Variable accessible in `finally` block