### PR TITLE
refactor: readFileSync → async readFile in cost-estimator and chunker

### DIFF
--- a/src/pipeline/chunker.ts
+++ b/src/pipeline/chunker.ts
@@ -6,7 +6,7 @@
  * Single chunk when total tokens ≤ maxTokens (backward compat).
  */
 
-import fs from 'fs';
+import { readFile } from 'fs/promises';
 import path from 'path';
 
 // ============================================================================
@@ -317,10 +317,10 @@ export function filterIgnoredFiles<T extends { filePath: string }>(
  * Read .reviewignore patterns from CWD.
  * Returns empty array if file doesn't exist.
  */
-export function loadReviewIgnorePatterns(cwd?: string): string[] {
+export async function loadReviewIgnorePatterns(cwd?: string): Promise<string[]> {
   const filePath = path.join(cwd ?? process.cwd(), '.reviewignore');
   try {
-    const content = fs.readFileSync(filePath, 'utf-8');
+    const content = await readFile(filePath, 'utf-8');
     return content
       .split('\n')
       .map((line) => line.trim())
@@ -338,7 +338,7 @@ export function loadReviewIgnorePatterns(cwd?: string): string[] {
  * Split a diff into token-budget-respecting chunks.
  * If total tokens <= maxTokens, returns a single chunk (backward compat).
  */
-export function chunkDiff(diffContent: string, options?: ChunkOptions): DiffChunk[] {
+export async function chunkDiff(diffContent: string, options?: ChunkOptions): Promise<DiffChunk[]> {
   const maxTokens = options?.maxTokens ?? 8000;
 
   if (!diffContent.trim()) return [];
@@ -348,7 +348,7 @@ export function chunkDiff(diffContent: string, options?: ChunkOptions): DiffChun
   if (parsedFiles.length === 0) return [];
 
   // 2. Apply .reviewignore filter
-  const ignorePatterns = loadReviewIgnorePatterns(options?.cwd);
+  const ignorePatterns = await loadReviewIgnorePatterns(options?.cwd);
   const filteredFiles = filterIgnoredFiles(parsedFiles, ignorePatterns);
   if (filteredFiles.length === 0) return [];
 

--- a/src/pipeline/cost-estimator.ts
+++ b/src/pipeline/cost-estimator.ts
@@ -3,7 +3,7 @@
  * Estimates LLM API call costs based on token usage and provider/model pricing.
  */
 
-import { readFileSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import type { TokenUsage } from './telemetry.js';
@@ -24,23 +24,32 @@ export interface CostEstimate {
 }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PRICING: Record<string, PricingEntry> = JSON.parse(
-  readFileSync(path.join(__dirname, '../data/pricing.json'), 'utf-8')
-);
+
+// Lazy-loaded pricing cache (avoids blocking readFileSync at module level)
+let _pricingCache: Record<string, PricingEntry> | null = null;
+
+async function getPricing(): Promise<Record<string, PricingEntry>> {
+  if (!_pricingCache) {
+    const raw = await readFile(path.join(__dirname, '../data/pricing.json'), 'utf-8');
+    _pricingCache = JSON.parse(raw);
+  }
+  return _pricingCache!;
+}
 
 // Load pricing table from data/pricing.json
-export function loadPricing(): Record<string, PricingEntry> {
-  return PRICING;
+export async function loadPricing(): Promise<Record<string, PricingEntry>> {
+  return getPricing();
 }
 
 // Estimate cost for a single call
-export function estimateCost(
+export async function estimateCost(
   usage: TokenUsage,
   provider: string,
   model: string
-): CostEstimate {
+): Promise<CostEstimate> {
+  const pricing = await getPricing();
   const key = `${provider}/${model}`;
-  const entry = PRICING[key];
+  const entry = pricing[key];
 
   if (!entry) {
     return {

--- a/src/pipeline/dryrun.ts
+++ b/src/pipeline/dryrun.ts
@@ -72,7 +72,7 @@ export function estimateTokensFromDiff(diffContent: string): number {
  * Run a dry-run analysis: no file I/O, no LLM calls.
  * Returns execution plan and cost estimates based on config + diff size.
  */
-export function dryRun(config: Config, diffContent: string): DryRunResult {
+export async function dryRun(config: Config, diffContent: string): Promise<DryRunResult> {
   const warnings: string[] = [];
 
   // ---- Resolve reviewer entries (handles both array and declarative formats) ----
@@ -149,9 +149,9 @@ export function dryRun(config: Config, diffContent: string): DryRunResult {
     totalTokens: estimatedL3Tokens,
   };
 
-  const l1Cost = estimateCost(l1Usage, reprProvider, reprModel);
-  const l2Cost = estimateCost(l2Usage, modProvider, modModel);
-  const l3Cost = estimateCost(l3Usage, modProvider, modModel);
+  const l1Cost = await estimateCost(l1Usage, reprProvider, reprModel);
+  const l2Cost = await estimateCost(l2Usage, modProvider, modModel);
+  const l3Cost = await estimateCost(l3Usage, modProvider, modModel);
 
   // Total: sum valid costs only (skip -1 unknowns)
   const validCosts = [l1Cost, l2Cost, l3Cost].filter((c) => c.totalCost >= 0);

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -141,7 +141,7 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
     }
 
     // === DIFF CHUNKING ===
-    const chunks = chunkDiff(diffContent, { maxTokens: config.chunking?.maxTokens ?? 8000 });
+    const chunks = await chunkDiff(diffContent, { maxTokens: config.chunking?.maxTokens ?? 8000 });
 
     // Guard: empty diff produces no chunks
     if (chunks.length === 0) {

--- a/src/pipeline/report.ts
+++ b/src/pipeline/report.ts
@@ -29,7 +29,7 @@ export interface PerformanceReport {
   mostExpensive: { reviewerId: string; cost: string } | null;
 }
 
-export function generateReport(telemetry: PipelineTelemetry): PerformanceReport {
+export async function generateReport(telemetry: PipelineTelemetry): Promise<PerformanceReport> {
   const json = telemetry.toJSON() as {
     records: BackendCallRecord[];
     summary: ReturnType<PipelineTelemetry['getSummary']>;
@@ -52,7 +52,7 @@ export function generateReport(telemetry: PipelineTelemetry): PerformanceReport 
 
     // Accumulate cost only when usage is available
     if (rec.usage) {
-      const estimate = estimateCost(rec.usage, rec.provider, rec.model);
+      const estimate = await estimateCost(rec.usage, rec.provider, rec.model);
       const prev = reviewerCostRaw.get(rec.reviewerId) ?? 0;
       if (estimate.totalCost < 0) {
         // N/A — mark as unknown if not already set to a real cost
@@ -98,7 +98,7 @@ export function generateReport(telemetry: PipelineTelemetry): PerformanceReport 
   let hasUnknownCost = false;
   for (const rec of records) {
     if (rec.usage) {
-      const estimate = estimateCost(rec.usage, rec.provider, rec.model);
+      const estimate = await estimateCost(rec.usage, rec.provider, rec.model);
       if (estimate.totalCost < 0) {
         hasUnknownCost = true;
       } else {

--- a/src/tests/pipeline-chunker.test.ts
+++ b/src/tests/pipeline-chunker.test.ts
@@ -302,17 +302,17 @@ describe('chunkDiffFiles', () => {
 // ============================================================================
 
 describe('chunkDiff', () => {
-  it('returns empty array for empty diff', () => {
-    expect(chunkDiff('', { maxTokens: 8000 })).toEqual([]);
+  it('returns empty array for empty diff', async () => {
+    expect(await chunkDiff('', { maxTokens: 8000 })).toEqual([]);
   });
 
-  it('returns empty array for whitespace-only diff', () => {
-    expect(chunkDiff('   \n\n  ', { maxTokens: 8000 })).toEqual([]);
+  it('returns empty array for whitespace-only diff', async () => {
+    expect(await chunkDiff('   \n\n  ', { maxTokens: 8000 })).toEqual([]);
   });
 
-  it('returns single chunk for small diff', () => {
+  it('returns single chunk for small diff', async () => {
     const diff = makeDiffSection('src/auth.ts', 5);
-    const chunks = chunkDiff(diff, { maxTokens: 8000 });
+    const chunks = await chunkDiff(diff, { maxTokens: 8000 });
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].index).toBe(0);
@@ -320,9 +320,9 @@ describe('chunkDiff', () => {
     expect(chunks[0].estimatedTokens).toBeLessThanOrEqual(8000);
   });
 
-  it('splits large diff into multiple chunks within budget', () => {
+  it('splits large diff into multiple chunks within budget', async () => {
     const diff = generateLargeDiff(100, 20);
-    const chunks = chunkDiff(diff, { maxTokens: 8000 });
+    const chunks = await chunkDiff(diff, { maxTokens: 8000 });
 
     expect(chunks.length).toBeGreaterThan(1);
 
@@ -331,27 +331,27 @@ describe('chunkDiff', () => {
     }
   });
 
-  it('preserves all file paths across chunks', () => {
+  it('preserves all file paths across chunks', async () => {
     const diff = generateLargeDiff(30, 20);
-    const chunks = chunkDiff(diff, { maxTokens: 8000 });
+    const chunks = await chunkDiff(diff, { maxTokens: 8000 });
 
     const allFiles = chunks.flatMap((c) => c.files);
     // All 30 files should be represented
     expect(allFiles.length).toBeGreaterThanOrEqual(30);
   });
 
-  it('each chunk has non-empty diffContent', () => {
+  it('each chunk has non-empty diffContent', async () => {
     const diff = generateLargeDiff(20, 10);
-    const chunks = chunkDiff(diff, { maxTokens: 8000 });
+    const chunks = await chunkDiff(diff, { maxTokens: 8000 });
 
     for (const chunk of chunks) {
       expect(chunk.diffContent.length).toBeGreaterThan(0);
     }
   });
 
-  it('uses default maxTokens of 8000 when options omitted', () => {
+  it('uses default maxTokens of 8000 when options omitted', async () => {
     const diff = generateLargeDiff(100, 20);
-    const chunks = chunkDiff(diff);
+    const chunks = await chunkDiff(diff);
 
     for (const chunk of chunks) {
       expect(chunk.estimatedTokens).toBeLessThanOrEqual(8000);

--- a/src/tests/pipeline-cost.test.ts
+++ b/src/tests/pipeline-cost.test.ts
@@ -12,13 +12,13 @@ import type { TokenUsage, CostEstimate } from '../pipeline/cost-estimator.js';
 
 describe('Cost Estimator', () => {
   // Test 1: groq/llama-3.3-70b — pricing lookup 성공, 비용 계산 정확
-  it('groq/llama-3.3-70b pricing lookup 성공 및 비용 계산 정확', () => {
+  it('groq/llama-3.3-70b pricing lookup 성공 및 비용 계산 정확', async () => {
     const usage: TokenUsage = {
       promptTokens: 1000,
       completionTokens: 500,
       totalTokens: 1500,
     };
-    const result = estimateCost(usage, 'groq', 'llama-3.3-70b-versatile');
+    const result = await estimateCost(usage, 'groq', 'llama-3.3-70b-versatile');
     expect(result.provider).toBe('groq');
     expect(result.model).toBe('llama-3.3-70b-versatile');
     expect(result.inputCost).toBeCloseTo((1000 / 1000) * 0.00059, 8);
@@ -28,24 +28,24 @@ describe('Cost Estimator', () => {
   });
 
   // Test 2: 알 수 없는 모델 — totalCost = -1
-  it('알 수 없는 모델은 totalCost = -1 반환', () => {
+  it('알 수 없는 모델은 totalCost = -1 반환', async () => {
     const usage: TokenUsage = {
       promptTokens: 1000,
       completionTokens: 500,
       totalTokens: 1500,
     };
-    const result = estimateCost(usage, 'unknown-provider', 'unknown-model');
+    const result = await estimateCost(usage, 'unknown-provider', 'unknown-model');
     expect(result.totalCost).toBe(-1);
   });
 
   // Test 3: token usage → 비용 계산 공식
-  it('비용 계산 공식: inputTokens * inputPrice / 1000 + outputTokens * outputPrice / 1000', () => {
+  it('비용 계산 공식: inputTokens * inputPrice / 1000 + outputTokens * outputPrice / 1000', async () => {
     const usage: TokenUsage = {
       promptTokens: 2000,
       completionTokens: 1000,
       totalTokens: 3000,
     };
-    const result = estimateCost(usage, 'groq', 'llama-3.1-8b-instant');
+    const result = await estimateCost(usage, 'groq', 'llama-3.1-8b-instant');
     const expectedInput = (2000 / 1000) * 0.00005;
     const expectedOutput = (1000 / 1000) * 0.00008;
     expect(result.inputCost).toBeCloseTo(expectedInput, 8);
@@ -54,12 +54,12 @@ describe('Cost Estimator', () => {
   });
 
   // Test 4: 여러 provider 혼합 비용 합산
-  it('여러 provider 혼합 비용 합산', () => {
+  it('여러 provider 혼합 비용 합산', async () => {
     const usage1: TokenUsage = { promptTokens: 1000, completionTokens: 500, totalTokens: 1500 };
     const usage2: TokenUsage = { promptTokens: 2000, completionTokens: 1000, totalTokens: 3000 };
 
-    const cost1 = estimateCost(usage1, 'google', 'gemini-2.5-flash');
-    const cost2 = estimateCost(usage2, 'mistral', 'mistral-large-latest');
+    const cost1 = await estimateCost(usage1, 'google', 'gemini-2.5-flash');
+    const cost2 = await estimateCost(usage2, 'mistral', 'mistral-large-latest');
 
     expect(cost1.totalCost).toBeGreaterThanOrEqual(0);
     expect(cost2.totalCost).toBeGreaterThanOrEqual(0);
@@ -71,13 +71,13 @@ describe('Cost Estimator', () => {
   });
 
   // Test 5: 무료 tier 모델 (cerebras) — $0.0000
-  it('무료 tier 모델 (cerebras) — totalCost = 0', () => {
+  it('무료 tier 모델 (cerebras) — totalCost = 0', async () => {
     const usage: TokenUsage = {
       promptTokens: 5000,
       completionTokens: 2000,
       totalTokens: 7000,
     };
-    const result = estimateCost(usage, 'cerebras', 'llama-3.3-70b');
+    const result = await estimateCost(usage, 'cerebras', 'llama-3.3-70b');
     expect(result.totalCost).toBe(0);
     expect(formatCost(result)).toBe('$0.0000');
   });
@@ -109,8 +109,8 @@ describe('Cost Estimator', () => {
   });
 
   // Test 8: loadPricing — pricing table에 key가 존재하는지
-  it('loadPricing — pricing table에 기대하는 key들이 존재', () => {
-    const pricing = loadPricing();
+  it('loadPricing — pricing table에 기대하는 key들이 존재', async () => {
+    const pricing = await loadPricing();
     expect(pricing).toHaveProperty('groq/llama-3.3-70b-versatile');
     expect(pricing).toHaveProperty('groq/llama-3.1-8b-instant');
     expect(pricing).toHaveProperty('groq/deepseek-r1-distill-llama-70b');

--- a/src/tests/pipeline-dryrun.test.ts
+++ b/src/tests/pipeline-dryrun.test.ts
@@ -109,11 +109,11 @@ index abc..def 100644
 // ============================================================================
 
 describe('estimateTokensFromDiff', () => {
-  it('empty diff returns 0', () => {
+  it('empty diff returns 0', async () => {
     expect(estimateTokensFromDiff('')).toBe(0);
   });
 
-  it('short diff returns reasonable estimate', () => {
+  it('short diff returns reasonable estimate', async () => {
     const tokens = estimateTokensFromDiff(SAMPLE_DIFF);
     // SAMPLE_DIFF is ~190 chars → ~48 tokens
     expect(tokens).toBeGreaterThan(0);
@@ -122,7 +122,7 @@ describe('estimateTokensFromDiff', () => {
     expect(tokens).toBe(Math.ceil(SAMPLE_DIFF.length / 4));
   });
 
-  it('longer diff scales linearly', () => {
+  it('longer diff scales linearly', async () => {
     const longDiff = SAMPLE_DIFF.repeat(10);
     const tokens = estimateTokensFromDiff(longDiff);
     expect(tokens).toBe(Math.ceil(longDiff.length / 4));
@@ -145,12 +145,12 @@ describe('dryRun', () => {
     process.env = originalEnv;
   });
 
-  it('returns correct reviewer list from array config', () => {
+  it('returns correct reviewer list from array config', async () => {
     delete process.env.GROQ_API_KEY;
     delete process.env.GOOGLE_API_KEY;
     delete process.env.MISTRAL_API_KEY;
 
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
 
     expect(result.reviewers).toHaveLength(3);
     expect(result.reviewers[0].id).toBe('r1-groq');
@@ -159,10 +159,10 @@ describe('dryRun', () => {
     expect(result.reviewers[0].isAuto).toBe(false);
   });
 
-  it('cost estimates are positive values', () => {
+  it('cost estimates are positive values', async () => {
     process.env.GROQ_API_KEY = 'test-key';
 
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
 
     expect(result.estimation.estimatedL1Tokens).toBeGreaterThan(0);
     expect(result.estimation.estimatedL2Tokens).toBeGreaterThan(0);
@@ -173,12 +173,12 @@ describe('dryRun', () => {
     expect(result.estimation.totalEstimatedCost).toMatch(/^\$[\d.]+$|^N\/A$/);
   });
 
-  it('provider with no API key gets no-api-key health status', () => {
+  it('provider with no API key gets no-api-key health status', async () => {
     delete process.env.GROQ_API_KEY;
     delete process.env.GOOGLE_API_KEY;
     delete process.env.MISTRAL_API_KEY;
 
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
 
     const groqHealth = result.health.find((h) => h.provider === 'groq');
     expect(groqHealth).toBeDefined();
@@ -189,12 +189,12 @@ describe('dryRun', () => {
     expect(googleHealth!.status).toBe('no-api-key');
   });
 
-  it('provider with API key set gets available health status', () => {
+  it('provider with API key set gets available health status', async () => {
     process.env.GROQ_API_KEY = 'test-key-groq';
     delete process.env.GOOGLE_API_KEY;
     delete process.env.MISTRAL_API_KEY;
 
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
 
     const groqHealth = result.health.find((h) => h.provider === 'groq');
     expect(groqHealth!.status).toBe('available');
@@ -203,12 +203,12 @@ describe('dryRun', () => {
     expect(googleHealth!.status).toBe('no-api-key');
   });
 
-  it('missing API key adds warning message', () => {
+  it('missing API key adds warning message', async () => {
     delete process.env.GROQ_API_KEY;
     delete process.env.GOOGLE_API_KEY;
     delete process.env.MISTRAL_API_KEY;
 
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
 
     expect(result.warnings.length).toBeGreaterThan(0);
     // At least one warning mentions an env var
@@ -216,7 +216,7 @@ describe('dryRun', () => {
     expect(hasKeyWarning).toBe(true);
   });
 
-  it('auto reviewer entry has isAuto: true', () => {
+  it('auto reviewer entry has isAuto: true', async () => {
     delete process.env.GROQ_API_KEY;
 
     const config = makeConfig({
@@ -234,7 +234,7 @@ describe('dryRun', () => {
       ],
     });
 
-    const result = dryRun(config, SAMPLE_DIFF);
+    const result = await dryRun(config, SAMPLE_DIFF);
 
     const autoReviewers = result.reviewers.filter((r) => r.isAuto);
     expect(autoReviewers).toHaveLength(2);
@@ -246,15 +246,15 @@ describe('dryRun', () => {
     expect(staticReviewers[0].isAuto).toBe(false);
   });
 
-  it('config summary reflects reviewerCount and supporterCount', () => {
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+  it('config summary reflects reviewerCount and supporterCount', async () => {
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
 
     expect(result.config.reviewerCount).toBe(3);
     expect(result.config.supporterCount).toBe(2);
     expect(result.config.maxDiscussionRounds).toBe(3);
   });
 
-  it('declarative reviewers config: static + auto slots', () => {
+  it('declarative reviewers config: static + auto slots', async () => {
     delete process.env.GROQ_API_KEY;
 
     const config: Config = {
@@ -277,7 +277,7 @@ describe('dryRun', () => {
       errorHandling: makeConfig().errorHandling,
     } as Config;
 
-    const result = dryRun(config, SAMPLE_DIFF);
+    const result = await dryRun(config, SAMPLE_DIFF);
 
     expect(result.config.reviewerCount).toBe(4);
 
@@ -287,8 +287,8 @@ describe('dryRun', () => {
     expect(autoR).toHaveLength(3);
   });
 
-  it('zero-length diff produces 0 L1 tokens', () => {
-    const result = dryRun(makeConfig(), '');
+  it('zero-length diff produces 0 L1 tokens', async () => {
+    const result = await dryRun(makeConfig(), '');
 
     expect(result.estimation.estimatedL1Tokens).toBe(0);
   });
@@ -309,8 +309,8 @@ describe('formatDryRunText', () => {
     // clean up any keys set during tests
   });
 
-  it('output contains all major section headers', () => {
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+  it('output contains all major section headers', async () => {
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
     const text = formatDryRunText(result);
 
     expect(text).toContain('Pipeline Dry Run Report');
@@ -320,8 +320,8 @@ describe('formatDryRunText', () => {
     expect(text).toContain('Provider Health:');
   });
 
-  it('output contains reviewer ids', () => {
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+  it('output contains reviewer ids', async () => {
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
     const text = formatDryRunText(result);
 
     expect(text).toContain('r1-groq');
@@ -329,8 +329,8 @@ describe('formatDryRunText', () => {
     expect(text).toContain('r3-mistral');
   });
 
-  it('output contains L1/L2/L3 cost lines', () => {
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+  it('output contains L1/L2/L3 cost lines', async () => {
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
     const text = formatDryRunText(result);
 
     expect(text).toContain('L1 (Review)');
@@ -339,8 +339,8 @@ describe('formatDryRunText', () => {
     expect(text).toContain('Total');
   });
 
-  it('output contains Warnings section when warnings exist', () => {
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+  it('output contains Warnings section when warnings exist', async () => {
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
     // All API keys missing → warnings should be present
     expect(result.warnings.length).toBeGreaterThan(0);
 
@@ -348,26 +348,26 @@ describe('formatDryRunText', () => {
     expect(text).toContain('Warnings:');
   });
 
-  it('output does not contain Warnings section when no warnings', () => {
+  it('output does not contain Warnings section when no warnings', async () => {
     process.env.GROQ_API_KEY = 'key1';
     process.env.GOOGLE_API_KEY = 'key2';
     process.env.MISTRAL_API_KEY = 'key3';
 
-    const result = dryRun(makeConfig(), SAMPLE_DIFF);
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
     const text = formatDryRunText(result);
 
     // Warnings section should be absent when there are none
     expect(text).not.toContain('Warnings:');
   });
 
-  it('auto reviewer shows "auto" label in output', () => {
+  it('auto reviewer shows "auto" label in output', async () => {
     const config = makeConfig({
       reviewers: [
         { id: 'auto-1', auto: true as const, enabled: true },
       ],
     });
 
-    const result = dryRun(config, SAMPLE_DIFF);
+    const result = await dryRun(config, SAMPLE_DIFF);
     const text = formatDryRunText(result);
 
     expect(text).toContain('auto-1');

--- a/src/tests/pipeline-report.test.ts
+++ b/src/tests/pipeline-report.test.ts
@@ -13,8 +13,8 @@ describe('generateReport', () => {
     telemetry = new PipelineTelemetry();
   });
 
-  it('빈 telemetry → 빈 리포트', () => {
-    const report = generateReport(telemetry);
+  it('빈 telemetry → 빈 리포트', async () => {
+    const report = await generateReport(telemetry);
     expect(report.summary.totalCalls).toBe(0);
     expect(report.summary.totalLatencyMs).toBe(0);
     expect(report.summary.totalTokens).toBe(0);
@@ -25,7 +25,7 @@ describe('generateReport', () => {
     expect(report.mostExpensive).toBeNull();
   });
 
-  it('단일 reviewer → 올바른 집계', () => {
+  it('단일 reviewer → 올바른 집계', async () => {
     telemetry.record({
       reviewerId: 'reviewer-a',
       provider: 'groq',
@@ -35,7 +35,7 @@ describe('generateReport', () => {
       success: true,
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     expect(report.summary.totalCalls).toBe(1);
     expect(report.summary.totalLatencyMs).toBe(500);
     expect(report.summary.totalTokens).toBe(1500);
@@ -54,7 +54,7 @@ describe('generateReport', () => {
     expect(r.error).toBeUndefined();
   });
 
-  it('다중 reviewer → perReviewer 배열, slowest, mostExpensive 정확', () => {
+  it('다중 reviewer → perReviewer 배열, slowest, mostExpensive 정확', async () => {
     telemetry.record({
       reviewerId: 'fast-cheap',
       provider: 'groq',
@@ -80,7 +80,7 @@ describe('generateReport', () => {
       success: true,
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     expect(report.summary.totalCalls).toBe(3);
     expect(report.perReviewer).toHaveLength(3);
 
@@ -92,7 +92,7 @@ describe('generateReport', () => {
     expect(report.mostExpensive!.reviewerId).toBe('slow-expensive');
   });
 
-  it('실패한 reviewer 포함 → success: false, error 표시', () => {
+  it('실패한 reviewer 포함 → success: false, error 표시', async () => {
     telemetry.record({
       reviewerId: 'failing-reviewer',
       provider: 'groq',
@@ -102,14 +102,14 @@ describe('generateReport', () => {
       error: 'timeout after 30s',
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     expect(report.perReviewer).toHaveLength(1);
     const r = report.perReviewer[0];
     expect(r.success).toBe(false);
     expect(r.error).toBe('timeout after 30s');
   });
 
-  it('알 수 없는 모델 (pricing 없음) → cost "N/A"', () => {
+  it('알 수 없는 모델 (pricing 없음) → cost "N/A"', async () => {
     telemetry.record({
       reviewerId: 'unknown-reviewer',
       provider: 'unknown-provider',
@@ -119,14 +119,14 @@ describe('generateReport', () => {
       success: true,
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     expect(report.perReviewer[0].cost).toBe('N/A');
     expect(report.summary.totalCost).toBe('N/A');
     // No real cost → mostExpensive is null
     expect(report.mostExpensive).toBeNull();
   });
 
-  it('averageLatencyMs 계산 정확', () => {
+  it('averageLatencyMs 계산 정확', async () => {
     telemetry.record({
       reviewerId: 'r1',
       provider: 'groq',
@@ -144,11 +144,11 @@ describe('generateReport', () => {
       success: true,
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     expect(report.summary.averageLatencyMs).toBe(500); // (300+700)/2
   });
 
-  it('usage 없는 record → cost N/A', () => {
+  it('usage 없는 record → cost N/A', async () => {
     telemetry.record({
       reviewerId: 'cli-reviewer',
       provider: 'cli',
@@ -158,13 +158,13 @@ describe('generateReport', () => {
       // no usage
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     expect(report.perReviewer[0].cost).toBe('N/A');
   });
 });
 
 describe('formatReportText', () => {
-  it('마크다운 테이블 포맷 검증', () => {
+  it('마크다운 테이블 포맷 검증', async () => {
     const telemetry = new PipelineTelemetry();
     telemetry.record({
       reviewerId: 'reviewer-a',
@@ -175,7 +175,7 @@ describe('formatReportText', () => {
       success: true,
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     const text = formatReportText(report);
 
     expect(text).toContain('## Performance Report');
@@ -191,7 +191,7 @@ describe('formatReportText', () => {
     expect(text).toContain('Total calls: 1');
   });
 
-  it('실패한 reviewer → FAIL: <error> 표시', () => {
+  it('실패한 reviewer → FAIL: <error> 표시', async () => {
     const telemetry = new PipelineTelemetry();
     telemetry.record({
       reviewerId: 'broken',
@@ -202,14 +202,14 @@ describe('formatReportText', () => {
       error: 'connection refused',
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     const text = formatReportText(report);
     expect(text).toContain('FAIL: connection refused');
   });
 
-  it('빈 리포트 → 테이블 헤더만 있고 Summary는 0 값', () => {
+  it('빈 리포트 → 테이블 헤더만 있고 Summary는 0 값', async () => {
     const telemetry = new PipelineTelemetry();
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     const text = formatReportText(report);
 
     expect(text).toContain('| Reviewer | Provider | Model | Latency | Tokens | Cost | Status |');
@@ -219,7 +219,7 @@ describe('formatReportText', () => {
 });
 
 describe('formatReportJson', () => {
-  it('valid JSON 반환', () => {
+  it('valid JSON 반환', async () => {
     const telemetry = new PipelineTelemetry();
     telemetry.record({
       reviewerId: 'reviewer-a',
@@ -230,7 +230,7 @@ describe('formatReportJson', () => {
       success: true,
     });
 
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     const json = formatReportJson(report);
 
     expect(() => JSON.parse(json)).not.toThrow();
@@ -242,9 +242,9 @@ describe('formatReportJson', () => {
     expect(parsed.perReviewer).toHaveLength(1);
   });
 
-  it('빈 리포트도 valid JSON', () => {
+  it('빈 리포트도 valid JSON', async () => {
     const telemetry = new PipelineTelemetry();
-    const report = generateReport(telemetry);
+    const report = await generateReport(telemetry);
     const json = formatReportJson(report);
     expect(() => JSON.parse(json)).not.toThrow();
     const parsed = JSON.parse(json);


### PR DESCRIPTION
## Summary

- **Stability**: Converts blocking `readFileSync` to async `readFile` in two pipeline modules
- `cost-estimator.ts`: Lazy async pricing cache replaces module-level sync read
- `chunker.ts`: `loadReviewIgnorePatterns` now async
- Cascading async: `estimateCost`, `loadPricing`, `chunkDiff`, `dryRun`, `generateReport` all async
- Updated all callers in orchestrator, report, dryrun and 4 test files

## Changes

| File | Change |
|------|--------|
| `src/pipeline/cost-estimator.ts` | Async lazy pricing cache, async `estimateCost` |
| `src/pipeline/chunker.ts` | Async `loadReviewIgnorePatterns`, async `chunkDiff` |
| `src/pipeline/report.ts` | Async `generateReport` |
| `src/pipeline/dryrun.ts` | Async `dryRun` |
| `src/pipeline/orchestrator.ts` | `await chunkDiff` |
| `src/tests/pipeline-*.test.ts` | Updated 4 test files to await async calls |

## Test Plan

- [x] 79 tests pass across 4 test files
- [x] TypeScript typecheck clean
- [x] Zero `readFileSync` remaining in pipeline/