### PR TITLE
chore: monorepo workspace scaffolding (#123)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,15 @@
   },
   "scripts": {
     "build": "tsup && cp -r src/data dist/",
+    "build:ws": "pnpm -r build",
     "typecheck": "tsc --noEmit",
+    "typecheck:ws": "pnpm -r typecheck",
     "test": "vitest",
+    "test:ws": "pnpm -r test",
     "lint": "eslint src/",
-    "cli": "tsx src/cli/index.ts"
+    "lint:ws": "pnpm -r lint",
+    "cli": "tsx src/cli/index.ts",
+    "dev": "pnpm --filter @codeagora/cli dev"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@codeagora/cli",
+  "version": "2.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "codeagora": "./dist/index.js",
+    "agora": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@codeagora/core": "workspace:*",
+    "@codeagora/github": "workspace:*",
+    "@codeagora/notifications": "workspace:*",
+    "@codeagora/shared": "workspace:*",
+    "commander": "^14.0.3",
+    "ora": "^9.3.0",
+    "@clack/prompts": "^1.1.0"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,1 @@
+// @codeagora/cli — placeholder (source files moved in subsequent PRs)

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../core" },
+    { "path": "../github" },
+    { "path": "../notifications" },
+    { "path": "../shared" }
+  ],
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@codeagora/core",
+  "version": "2.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@codeagora/shared": "workspace:*",
+    "ai": "^6.0.111",
+    "@ai-sdk/anthropic": "^3.0.58",
+    "@ai-sdk/google": "^3.0.43",
+    "@ai-sdk/groq": "^3.0.27",
+    "@ai-sdk/openai": "^3.0.41",
+    "@ai-sdk/openai-compatible": "^2.0.33",
+    "@openrouter/ai-sdk-provider": "^2.2.3",
+    "yaml": "^2.8.2",
+    "zod": "^3.22.4",
+    "commander": "^14.0.3"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,1 @@
+// @codeagora/core — placeholder (source files moved in subsequent PRs)

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../shared" }
+  ],
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@codeagora/github",
+  "version": "2.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@codeagora/core": "workspace:*",
+    "@codeagora/shared": "workspace:*",
+    "@octokit/rest": "^22.0.1"
+  }
+}

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -1,0 +1,1 @@
+// @codeagora/github — placeholder (source files moved in subsequent PRs)

--- a/packages/github/tsconfig.json
+++ b/packages/github/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../core" },
+    { "path": "../shared" }
+  ],
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@codeagora/notifications",
+  "version": "2.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@codeagora/core": "workspace:*",
+    "@codeagora/shared": "workspace:*"
+  }
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,0 +1,1 @@
+// @codeagora/notifications — placeholder (source files moved in subsequent PRs)

--- a/packages/notifications/tsconfig.json
+++ b/packages/notifications/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../core" },
+    { "path": "../shared" }
+  ],
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@codeagora/shared",
+  "version": "2.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "picocolors": "^1.1.1",
+    "zod": "^3.22.4"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+// @codeagora/shared — placeholder (source files moved in subsequent PRs)

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@codeagora/tui",
+  "version": "2.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@codeagora/core": "workspace:*",
+    "@codeagora/shared": "workspace:*",
+    "ink": "^6.8.0",
+    "ink-select-input": "^6.2.0",
+    "react": "^19.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "ink-testing-library": "^4.0.0"
+  }
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,0 +1,1 @@
+// @codeagora/tui — placeholder (source files moved in subsequent PRs)

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx"
+  },
+  "references": [
+    { "path": "../core" },
+    { "path": "../shared" }
+  ],
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2023"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary

- Creates pnpm workspace foundation for monorepo migration
- 6 package stubs with correct dependency graph:
  ```
                   shared
                  /  |  \
                core  |   |
               / | \  |   |
          github | notifications
               \ | /
                cli ← tui
  ```
- Per-package `package.json`, `tsconfig.json`, placeholder `src/index.ts`
- Root workspace scripts (`build:ws`, `test:ws`, `typecheck:ws`, `lint:ws`)
- Zero impact on existing monolith — all 1506 tests pass

## Changes

| File | Change |
|------|--------|
| `pnpm-workspace.yaml` | New: workspace config |
| `tsconfig.base.json` | New: shared compiler options |
| `packages/*/package.json` | New: 6 package stubs |
| `packages/*/tsconfig.json` | New: 6 tsconfig with project references |
| `packages/*/src/index.ts` | New: 6 placeholder entry points |
| `package.json` | Added workspace scripts |

Closes #123

## Test Plan

- [x] All 1506 existing tests pass
- [x] Package structure matches design doc
- [x] Dependency graph is correct