### PR TITLE
fix: resolve all remaining test failures after monorepo migration

### DIFF
--- a/packages/tui/src/components/ModelSelector.tsx
+++ b/packages/tui/src/components/ModelSelector.tsx
@@ -53,7 +53,7 @@ let _cachedModels: ModelEntry[] | null = null;
 function loadModelRankings(): ModelEntry[] {
   if (_cachedModels) return _cachedModels;
   try {
-    const raw = readFileSync(path.join(__dirname, '../../data/model-rankings.json'), 'utf-8');
+    const raw = readFileSync(path.join(__dirname, '../../../shared/src/data/model-rankings.json'), 'utf-8');
     const data = JSON.parse(raw) as { models?: ModelEntry[] };
     _cachedModels = data.models ?? [];
     return _cachedModels;

--- a/src/tests/orchestrator-branches.test.ts
+++ b/src/tests/orchestrator-branches.test.ts
@@ -314,7 +314,7 @@ describe('Orchestrator Branches', () => {
     (getBanditStore as Mock).mockReturnValue(null);
 
     // Mock the dynamic import of BanditStore
-    vi.doMock('../l0/bandit-store.js', () => ({
+    vi.doMock('../../packages/core/src/l0/bandit-store.js', () => ({
       BanditStore: vi.fn().mockImplementation(() => mockBanditInstance),
     }));
 
@@ -373,7 +373,7 @@ describe('Orchestrator Branches', () => {
     (normalizeConfig as Mock).mockReturnValue(configWithAutoApprove);
 
     // Mock analyzeTrivialDiff via the auto-approve module
-    vi.doMock('../pipeline/auto-approve.js', () => ({
+    vi.doMock('../../packages/core/src/pipeline/auto-approve.js', () => ({
       analyzeTrivialDiff: vi.fn().mockReturnValue({ isTrivial: true, reason: 'only-docs' }),
     }));
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
+import fs from 'fs';
+
+const resolveReal = (mod: string) => fs.realpathSync(path.resolve(__dirname, 'node_modules', mod));
 
 export default defineConfig({
   resolve: {
@@ -10,21 +13,18 @@ export default defineConfig({
       '@codeagora/notifications': path.resolve(__dirname, 'packages/notifications/src'),
       '@codeagora/cli': path.resolve(__dirname, 'packages/cli/src'),
       '@codeagora/tui': path.resolve(__dirname, 'packages/tui/src'),
-      // Pin shared dependencies to root node_modules to prevent duplicates
-      'react': path.resolve(__dirname, 'node_modules/react'),
-      'ink': path.resolve(__dirname, 'node_modules/ink'),
-      'ink-select-input': path.resolve(__dirname, 'node_modules/ink-select-input'),
-      'ai': path.resolve(__dirname, 'node_modules/ai'),
-      '@ai-sdk/groq': path.resolve(__dirname, 'node_modules/@ai-sdk/groq'),
-      '@ai-sdk/google': path.resolve(__dirname, 'node_modules/@ai-sdk/google'),
-      '@ai-sdk/openai': path.resolve(__dirname, 'node_modules/@ai-sdk/openai'),
-      '@ai-sdk/openai-compatible': path.resolve(__dirname, 'node_modules/@ai-sdk/openai-compatible'),
-      '@ai-sdk/anthropic': path.resolve(__dirname, 'node_modules/@ai-sdk/anthropic'),
-      '@openrouter/ai-sdk-provider': path.resolve(__dirname, 'node_modules/@openrouter/ai-sdk-provider'),
-      '@octokit/rest': path.resolve(__dirname, 'node_modules/@octokit/rest'),
-      'zod': path.resolve(__dirname, 'node_modules/zod'),
-      'yaml': path.resolve(__dirname, 'node_modules/yaml'),
+      // Pin npm deps to real pnpm store paths for vi.mock interception
+      'ai': resolveReal('ai'),
+      '@ai-sdk/groq': resolveReal('@ai-sdk/groq'),
+      '@ai-sdk/google': resolveReal('@ai-sdk/google'),
+      '@ai-sdk/openai': resolveReal('@ai-sdk/openai'),
+      '@ai-sdk/openai-compatible': resolveReal('@ai-sdk/openai-compatible'),
+      '@ai-sdk/anthropic': resolveReal('@ai-sdk/anthropic'),
+      '@openrouter/ai-sdk-provider': resolveReal('@openrouter/ai-sdk-provider'),
+      '@octokit/rest': resolveReal('@octokit/rest'),
     },
+    // Deduplicate React/Ink to single instance (prevents "multiple copies" in monorepo)
+    dedupe: ['react', 'ink', 'ink-select-input', 'ink-testing-library', 'zod', 'yaml'],
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

Fixes all 10 remaining test failures from monorepo migration:

- **TUI tests (9 files)**: Use Vite `resolve.dedupe` for react/ink/ink-select-input to prevent duplicate React instances. Fix `ModelSelector` data path depth.
- **Orchestrator tests (1 file)**: Fix `vi.doMock` paths for `bandit-store.js` and `auto-approve.js`
- **vitest.config.ts**: Replace explicit react/ink aliases with `resolve.dedupe`, use `fs.realpathSync` for pnpm store path resolution

## Results

- **TypeScript: 0 errors**
- **Tests: 99/99 files pass (1506/1506 = 100%)**

## Test Plan

- [x] All 1506 tests pass
- [x] TypeScript compiles clean
- [x] TUI rendering works (React singleton verified)
- [x] Orchestrator branching logic works (mock interception verified)