### PR TITLE
feat: Sprint 7.2 — review results dashboard

### DIFF
--- a/packages/web/src/frontend/components/DiffViewer.tsx
+++ b/packages/web/src/frontend/components/DiffViewer.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { SeverityBadge } from './SeverityBadge.js';
+import { parseDiffLines } from '../utils/review-helpers.js';
+import type { DiffIssueMarker, ParsedDiffLine } from '../utils/review-helpers.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface DiffViewerProps {
+  diffText: string;
+  issues?: DiffIssueMarker[];
+  onIssueClick?: (issueTitle: string) => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function getLineClass(type: ParsedDiffLine['type']): string {
+  switch (type) {
+    case 'added':
+      return 'diff-line diff-added';
+    case 'removed':
+      return 'diff-line diff-removed';
+    case 'header':
+      return 'diff-line diff-header';
+    default:
+      return 'diff-line diff-context';
+  }
+}
+
+function findIssuesForLine(lineNumber: number | null, issues: DiffIssueMarker[]): DiffIssueMarker[] {
+  if (lineNumber === null) return [];
+  return issues.filter((issue) => lineNumber >= issue.lineStart && lineNumber <= issue.lineEnd);
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function DiffViewer({ diffText, issues = [], onIssueClick }: DiffViewerProps): React.JSX.Element {
+  const lines = parseDiffLines(diffText);
+
+  return (
+    <div className="diff-viewer">
+      <table className="diff-viewer__table">
+        <tbody>
+          {lines.map((line, idx) => {
+            const lineNumber = line.newLineNumber ?? line.oldLineNumber;
+            const matchedIssues = findIssuesForLine(lineNumber, issues);
+            const hasIssue = matchedIssues.length > 0;
+
+            return (
+              <React.Fragment key={idx}>
+                <tr className={`${getLineClass(line.type)} ${hasIssue ? 'diff-line--has-issue' : ''}`}>
+                  <td className="diff-line__number diff-line__number--old">
+                    {line.oldLineNumber ?? ''}
+                  </td>
+                  <td className="diff-line__number diff-line__number--new">
+                    {line.newLineNumber ?? ''}
+                  </td>
+                  <td className="diff-line__content">
+                    <code>{line.content}</code>
+                  </td>
+                </tr>
+                {hasIssue &&
+                  matchedIssues.map((issue, issueIdx) => (
+                    <tr key={`issue-${idx}-${issueIdx}`} className="diff-line diff-line--issue-marker">
+                      <td className="diff-line__number" colSpan={2} />
+                      <td className="diff-line__content">
+                        <button
+                          className="diff-issue-marker"
+                          onClick={() => onIssueClick?.(issue.issueTitle)}
+                          type="button"
+                        >
+                          <SeverityBadge severity={issue.severity} />
+                          <span className="diff-issue-marker__title">{issue.issueTitle}</span>
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+              </React.Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/web/src/frontend/components/IssueCard.tsx
+++ b/packages/web/src/frontend/components/IssueCard.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { SeverityBadge } from './SeverityBadge.js';
+import type { Severity } from '../utils/review-helpers.js';
+
+interface IssueCardProps {
+  issueTitle: string;
+  problem: string;
+  evidence: string[];
+  severity: Severity;
+  suggestion: string;
+  filePath: string;
+  lineRange: [number, number];
+  confidence?: number;
+  reviewers: string[];
+}
+
+export function IssueCard({
+  issueTitle,
+  problem,
+  evidence,
+  severity,
+  suggestion,
+  filePath,
+  lineRange,
+  confidence,
+  reviewers,
+}: IssueCardProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className={`issue-card ${expanded ? 'issue-card--expanded' : ''}`}>
+      <button
+        className="issue-card__header"
+        onClick={() => setExpanded(!expanded)}
+        type="button"
+        aria-expanded={expanded}
+      >
+        <div className="issue-card__header-left">
+          <SeverityBadge severity={severity} />
+          <span className="issue-card__title">{issueTitle}</span>
+        </div>
+        <div className="issue-card__header-right">
+          {confidence !== undefined && (
+            <span className="issue-card__confidence">{Math.round(confidence * 100)}%</span>
+          )}
+          <span className="issue-card__location">
+            {filePath}:{lineRange[0]}-{lineRange[1]}
+          </span>
+          <span className="issue-card__toggle">{expanded ? '\u25B2' : '\u25BC'}</span>
+        </div>
+      </button>
+      {expanded && (
+        <div className="issue-card__body">
+          <div className="issue-card__section">
+            <h4 className="issue-card__section-title">Problem</h4>
+            <p className="issue-card__text">{problem}</p>
+          </div>
+          {evidence.length > 0 && (
+            <div className="issue-card__section">
+              <h4 className="issue-card__section-title">Evidence</h4>
+              <ul className="issue-card__evidence-list">
+                {evidence.map((item, i) => (
+                  <li key={i}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div className="issue-card__section">
+            <h4 className="issue-card__section-title">Suggestion</h4>
+            <p className="issue-card__text">{suggestion}</p>
+          </div>
+          <div className="issue-card__section">
+            <h4 className="issue-card__section-title">Flagged by</h4>
+            <div className="issue-card__reviewers">
+              {reviewers.map((r) => (
+                <span key={r} className="issue-card__reviewer-tag">{r}</span>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/frontend/components/SeverityBadge.tsx
+++ b/packages/web/src/frontend/components/SeverityBadge.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { severityClassMap, severityLabelMap } from '../utils/review-helpers.js';
+import type { Severity } from '../utils/review-helpers.js';
+
+interface SeverityBadgeProps {
+  severity: Severity;
+  variant?: 'small' | 'large';
+}
+
+export function SeverityBadge({ severity, variant = 'small' }: SeverityBadgeProps): React.JSX.Element {
+  const className = [
+    'severity-badge',
+    severityClassMap[severity],
+    variant === 'large' ? 'severity-badge--large' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return <span className={className}>{severityLabelMap[severity]}</span>;
+}
+
+export type { Severity };

--- a/packages/web/src/frontend/components/SeveritySummary.tsx
+++ b/packages/web/src/frontend/components/SeveritySummary.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import type { Severity } from '../utils/review-helpers.js';
+
+interface SeveritySummaryProps {
+  counts: Record<Severity, number>;
+}
+
+const severityOrder: Severity[] = ['HARSHLY_CRITICAL', 'CRITICAL', 'WARNING', 'SUGGESTION'];
+
+const severitySegmentClass: Record<Severity, string> = {
+  HARSHLY_CRITICAL: 'severity-summary__segment--harshly-critical',
+  CRITICAL: 'severity-summary__segment--critical',
+  WARNING: 'severity-summary__segment--warning',
+  SUGGESTION: 'severity-summary__segment--suggestion',
+};
+
+const severitySegmentLabel: Record<Severity, string> = {
+  HARSHLY_CRITICAL: 'Harshly Critical',
+  CRITICAL: 'Critical',
+  WARNING: 'Warning',
+  SUGGESTION: 'Suggestion',
+};
+
+export function SeveritySummary({ counts }: SeveritySummaryProps): React.JSX.Element {
+  const total = severityOrder.reduce((sum, s) => sum + counts[s], 0);
+
+  return (
+    <div className="severity-summary">
+      <div className="severity-summary__bar">
+        {severityOrder.map((severity) => {
+          const count = counts[severity];
+          if (count === 0) return null;
+          const widthPercent = total > 0 ? (count / total) * 100 : 0;
+          return (
+            <div
+              key={severity}
+              className={`severity-summary__segment ${severitySegmentClass[severity]}`}
+              style={{ width: `${widthPercent}%` }}
+              title={`${severitySegmentLabel[severity]}: ${count}`}
+            >
+              {count}
+            </div>
+          );
+        })}
+      </div>
+      <div className="severity-summary__legend">
+        {severityOrder.map((severity) => (
+          <span key={severity} className="severity-summary__legend-item">
+            <span className={`severity-summary__legend-dot ${severitySegmentClass[severity]}`} />
+            {severitySegmentLabel[severity]}: {counts[severity]}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/frontend/components/VerdictBanner.tsx
+++ b/packages/web/src/frontend/components/VerdictBanner.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { decisionClassMap, decisionLabelMap } from '../utils/review-helpers.js';
+import type { Decision } from '../utils/review-helpers.js';
+
+interface VerdictBannerProps {
+  decision: Decision;
+  reasoning: string;
+  questionsForHuman?: string[];
+}
+
+export function VerdictBanner({ decision, reasoning, questionsForHuman }: VerdictBannerProps): React.JSX.Element {
+  return (
+    <div className={`verdict-banner ${decisionClassMap[decision]}`}>
+      <div className="verdict-banner__header">
+        <span className="verdict-banner__decision">{decisionLabelMap[decision]}</span>
+      </div>
+      <p className="verdict-banner__reasoning">{reasoning}</p>
+      {questionsForHuman && questionsForHuman.length > 0 && (
+        <div className="verdict-banner__questions">
+          <h4 className="verdict-banner__questions-title">Questions for Human</h4>
+          <ul className="verdict-banner__questions-list">
+            {questionsForHuman.map((q, i) => (
+              <li key={i}>{q}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type { Decision };

--- a/packages/web/src/frontend/pages/ReviewDetail.tsx
+++ b/packages/web/src/frontend/pages/ReviewDetail.tsx
@@ -1,10 +1,190 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useApi } from '../hooks/useApi.js';
+import { VerdictBanner } from '../components/VerdictBanner.js';
+import { SeveritySummary } from '../components/SeveritySummary.js';
+import { DiffViewer } from '../components/DiffViewer.js';
+import { IssueCard } from '../components/IssueCard.js';
+import {
+  aggregateIssues,
+  computeSeverityCounts,
+  issuesToMarkers,
+  formatDuration,
+  formatDate,
+} from '../utils/review-helpers.js';
+import type {
+  Severity,
+  ReviewEntry,
+  DiffIssueMarker,
+} from '../utils/review-helpers.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface Discussion {
+  discussionId: string;
+  filePath: string;
+  lineRange: [number, number];
+  finalSeverity: string;
+  reasoning: string;
+  consensusReached: boolean;
+  rounds: number;
+}
+
+interface SessionDetail {
+  metadata: {
+    sessionId: string;
+    date: string;
+    timestamp: number;
+    diffPath: string;
+    status: 'in_progress' | 'completed' | 'failed';
+    startedAt: number;
+    completedAt?: number;
+  };
+  reviews: ReviewEntry[];
+  discussions: Discussion[];
+  verdict: {
+    decision: 'ACCEPT' | 'REJECT' | 'NEEDS_HUMAN';
+    reasoning: string;
+    questionsForHuman?: string[];
+  } | null;
+  diff?: string;
+}
+
+// ============================================================================
+// Status class map
+// ============================================================================
+
+const statusClassMap: Record<string, string> = {
+  completed: 'review-status--completed',
+  in_progress: 'review-status--in-progress',
+  failed: 'review-status--failed',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
 
 export function ReviewDetail(): React.JSX.Element {
+  const { date, id } = useParams<{ date: string; id: string }>();
+  const { data: session, loading, error } = useApi<SessionDetail>(
+    `/api/sessions/${date}/${id}`,
+  );
+
+  if (loading) {
+    return (
+      <div className="page">
+        <p>Loading session...</p>
+      </div>
+    );
+  }
+
+  if (error || !session) {
+    return (
+      <div className="page">
+        <h2>Error</h2>
+        <p>{error ?? 'Session not found'}</p>
+      </div>
+    );
+  }
+
+  const issues = aggregateIssues(session.reviews);
+  const severityCounts = computeSeverityCounts(issues);
+  const diffMarkers = issuesToMarkers(issues);
+
   return (
-    <div className="page">
-      <h2>Review Detail</h2>
-      <p>Coming soon</p>
+    <div className="page review-detail">
+      {/* Session Metadata Header */}
+      <div className="review-detail__header">
+        <h2>Review: {session.metadata.sessionId}</h2>
+        <div className="review-detail__meta">
+          <span className="review-detail__meta-item">
+            Date: {session.metadata.date}
+          </span>
+          <span className="review-detail__meta-item">
+            Started: {formatDate(session.metadata.startedAt)}
+          </span>
+          <span className="review-detail__meta-item">
+            Duration: {formatDuration(session.metadata.startedAt, session.metadata.completedAt)}
+          </span>
+          <span className={`review-detail__meta-item review-status ${statusClassMap[session.metadata.status] ?? ''}`}>
+            {session.metadata.status}
+          </span>
+        </div>
+      </div>
+
+      {/* Verdict Banner */}
+      {session.verdict && (
+        <VerdictBanner
+          decision={session.verdict.decision}
+          reasoning={session.verdict.reasoning}
+          questionsForHuman={session.verdict.questionsForHuman}
+        />
+      )}
+
+      {/* Severity Summary */}
+      <section className="review-detail__section">
+        <h3>Issue Summary</h3>
+        <SeveritySummary counts={severityCounts} />
+      </section>
+
+      {/* Diff Viewer */}
+      {session.diff && (
+        <section className="review-detail__section">
+          <h3>Annotated Diff</h3>
+          <DiffViewer diffText={session.diff} issues={diffMarkers} />
+        </section>
+      )}
+
+      {/* Issues List */}
+      <section className="review-detail__section">
+        <h3>Issues ({issues.length})</h3>
+        {issues.length === 0 ? (
+          <p className="review-detail__empty">No issues found.</p>
+        ) : (
+          <div className="review-detail__issues">
+            {issues.map((issue, idx) => (
+              <IssueCard
+                key={`${issue.filePath}-${issue.lineRange[0]}-${idx}`}
+                issueTitle={issue.issueTitle}
+                problem={issue.problem}
+                evidence={issue.evidence}
+                severity={issue.severity}
+                suggestion={issue.suggestion}
+                filePath={issue.filePath}
+                lineRange={issue.lineRange}
+                confidence={issue.confidence}
+                reviewers={issue.reviewers}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Discussions */}
+      {session.discussions.length > 0 && (
+        <section className="review-detail__section">
+          <h3>Discussions ({session.discussions.length})</h3>
+          <div className="review-detail__discussions">
+            {session.discussions.map((disc) => (
+              <div key={disc.discussionId} className="discussion-card">
+                <div className="discussion-card__header">
+                  <span className="discussion-card__file">
+                    {disc.filePath}:{disc.lineRange[0]}-{disc.lineRange[1]}
+                  </span>
+                  <span className="discussion-card__rounds">{disc.rounds} rounds</span>
+                  <span className={`discussion-card__consensus ${disc.consensusReached ? 'discussion-card__consensus--reached' : ''}`}>
+                    {disc.consensusReached ? 'Consensus' : 'No consensus'}
+                  </span>
+                </div>
+                <p className="discussion-card__reasoning">{disc.reasoning}</p>
+                <span className="discussion-card__severity">Final: {disc.finalSeverity}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/packages/web/src/frontend/styles/globals.css
+++ b/packages/web/src/frontend/styles/globals.css
@@ -137,3 +137,532 @@ a:hover {
   color: var(--color-accent-hover);
   text-decoration: underline;
 }
+
+/* ============================================================================
+   Severity Badges
+   ============================================================================ */
+
+.severity-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  line-height: 1.4;
+}
+
+.severity-badge--large {
+  padding: 4px 12px;
+  font-size: 13px;
+  border-radius: 14px;
+}
+
+.severity-badge--harshly-critical {
+  background-color: rgba(188, 107, 255, 0.15);
+  color: #bc6bff;
+}
+
+.severity-badge--critical {
+  background-color: rgba(248, 81, 73, 0.15);
+  color: var(--color-error);
+}
+
+.severity-badge--warning {
+  background-color: rgba(210, 153, 34, 0.15);
+  color: var(--color-warning);
+}
+
+.severity-badge--suggestion {
+  background-color: rgba(63, 185, 80, 0.15);
+  color: var(--color-success);
+}
+
+/* ============================================================================
+   Verdict Banner
+   ============================================================================ */
+
+.verdict-banner {
+  padding: 16px 20px;
+  border-radius: 8px;
+  margin-bottom: 24px;
+  border: 1px solid var(--color-border);
+}
+
+.verdict-banner--accept {
+  background-color: rgba(63, 185, 80, 0.1);
+  border-color: rgba(63, 185, 80, 0.3);
+}
+
+.verdict-banner--reject {
+  background-color: rgba(248, 81, 73, 0.1);
+  border-color: rgba(248, 81, 73, 0.3);
+}
+
+.verdict-banner--needs-human {
+  background-color: rgba(210, 153, 34, 0.1);
+  border-color: rgba(210, 153, 34, 0.3);
+}
+
+.verdict-banner__header {
+  margin-bottom: 8px;
+}
+
+.verdict-banner__decision {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.verdict-banner--accept .verdict-banner__decision {
+  color: var(--color-success);
+}
+
+.verdict-banner--reject .verdict-banner__decision {
+  color: var(--color-error);
+}
+
+.verdict-banner--needs-human .verdict-banner__decision {
+  color: var(--color-warning);
+}
+
+.verdict-banner__reasoning {
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.verdict-banner__questions {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+}
+
+.verdict-banner__questions-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-warning);
+  margin-bottom: 8px;
+}
+
+.verdict-banner__questions-list {
+  list-style: disc;
+  padding-left: 20px;
+  color: var(--color-text-secondary);
+}
+
+.verdict-banner__questions-list li {
+  margin-bottom: 4px;
+}
+
+/* ============================================================================
+   Severity Summary Bar
+   ============================================================================ */
+
+.severity-summary {
+  margin-bottom: 24px;
+}
+
+.severity-summary__bar {
+  display: flex;
+  height: 28px;
+  border-radius: 6px;
+  overflow: hidden;
+  background-color: var(--color-bg-tertiary);
+  margin-bottom: 8px;
+}
+
+.severity-summary__segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text);
+  min-width: 28px;
+}
+
+.severity-summary__segment--harshly-critical {
+  background-color: rgba(188, 107, 255, 0.6);
+}
+
+.severity-summary__segment--critical {
+  background-color: rgba(248, 81, 73, 0.6);
+}
+
+.severity-summary__segment--warning {
+  background-color: rgba(210, 153, 34, 0.6);
+}
+
+.severity-summary__segment--suggestion {
+  background-color: rgba(63, 185, 80, 0.6);
+}
+
+.severity-summary__legend {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.severity-summary__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.severity-summary__legend-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+/* ============================================================================
+   Diff Viewer
+   ============================================================================ */
+
+.diff-viewer {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow-x: auto;
+  background-color: var(--color-bg-secondary);
+}
+
+.diff-viewer__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.diff-line {
+  border: none;
+}
+
+.diff-line__number {
+  width: 50px;
+  min-width: 50px;
+  padding: 0 8px;
+  text-align: right;
+  color: var(--color-text-secondary);
+  user-select: none;
+  vertical-align: top;
+  opacity: 0.6;
+}
+
+.diff-line__content {
+  padding: 0 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.diff-line__content code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+.diff-added {
+  background-color: rgba(63, 185, 80, 0.1);
+}
+
+.diff-added .diff-line__content {
+  border-left: 3px solid var(--color-success);
+}
+
+.diff-removed {
+  background-color: rgba(248, 81, 73, 0.1);
+}
+
+.diff-removed .diff-line__content {
+  border-left: 3px solid var(--color-error);
+}
+
+.diff-context {
+  background-color: transparent;
+}
+
+.diff-context .diff-line__content {
+  border-left: 3px solid transparent;
+}
+
+.diff-header {
+  background-color: rgba(88, 166, 255, 0.08);
+  color: var(--color-text-secondary);
+}
+
+.diff-header .diff-line__content {
+  border-left: 3px solid var(--color-accent);
+  font-style: italic;
+}
+
+.diff-line--has-issue {
+  background-color: rgba(210, 153, 34, 0.08);
+}
+
+.diff-line--issue-marker {
+  background-color: var(--color-bg-tertiary);
+}
+
+.diff-issue-marker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  transition: background-color 0.15s;
+}
+
+.diff-issue-marker:hover {
+  background-color: var(--color-bg-secondary);
+}
+
+.diff-issue-marker__title {
+  font-weight: 500;
+}
+
+/* ============================================================================
+   Issue Card
+   ============================================================================ */
+
+.issue-card {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  margin-bottom: 8px;
+  background-color: var(--color-bg-secondary);
+  overflow: hidden;
+}
+
+.issue-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  text-align: left;
+  transition: background-color 0.15s;
+}
+
+.issue-card__header:hover {
+  background-color: var(--color-bg-tertiary);
+}
+
+.issue-card__header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.issue-card__header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.issue-card__title {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issue-card__confidence {
+  font-size: 12px;
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.issue-card__location {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.issue-card__toggle {
+  font-size: 10px;
+  color: var(--color-text-secondary);
+}
+
+.issue-card__body {
+  padding: 0 16px 16px;
+  border-top: 1px solid var(--color-border);
+}
+
+.issue-card__section {
+  margin-top: 12px;
+}
+
+.issue-card__section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.issue-card__text {
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+.issue-card__evidence-list {
+  list-style: disc;
+  padding-left: 20px;
+  color: var(--color-text);
+}
+
+.issue-card__evidence-list li {
+  margin-bottom: 4px;
+  line-height: 1.5;
+}
+
+.issue-card__reviewers {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.issue-card__reviewer-tag {
+  display: inline-block;
+  padding: 2px 8px;
+  background-color: var(--color-bg-tertiary);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
+/* ============================================================================
+   Review Detail Page
+   ============================================================================ */
+
+.review-detail__header {
+  margin-bottom: 20px;
+}
+
+.review-detail__meta {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.review-detail__meta-item {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.review-status {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.review-status--completed {
+  color: var(--color-success);
+  background-color: rgba(63, 185, 80, 0.1);
+}
+
+.review-status--in-progress {
+  color: var(--color-accent);
+  background-color: rgba(88, 166, 255, 0.1);
+}
+
+.review-status--failed {
+  color: var(--color-error);
+  background-color: rgba(248, 81, 73, 0.1);
+}
+
+.review-detail__section {
+  margin-bottom: 28px;
+}
+
+.review-detail__section h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: var(--color-text);
+}
+
+.review-detail__empty {
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.review-detail__issues {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ============================================================================
+   Discussion Card
+   ============================================================================ */
+
+.discussion-card {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin-bottom: 8px;
+  background-color: var(--color-bg-secondary);
+}
+
+.discussion-card__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.discussion-card__file {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--color-accent);
+}
+
+.discussion-card__rounds {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.discussion-card__consensus {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.discussion-card__consensus--reached {
+  color: var(--color-success);
+}
+
+.discussion-card__reasoning {
+  color: var(--color-text);
+  line-height: 1.5;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.discussion-card__severity {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}

--- a/packages/web/src/frontend/utils/review-helpers.ts
+++ b/packages/web/src/frontend/utils/review-helpers.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure utility functions for the review detail dashboard.
+ * Separated from React components so they can be unit-tested in Node environment.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type Severity = 'HARSHLY_CRITICAL' | 'CRITICAL' | 'WARNING' | 'SUGGESTION';
+
+interface EvidenceDoc {
+  issueTitle: string;
+  problem: string;
+  evidence: string[];
+  severity: Severity;
+  suggestion: string;
+  filePath: string;
+  lineRange: [number, number];
+  confidence?: number;
+}
+
+interface ReviewEntry {
+  reviewerId: string;
+  model: string;
+  group: string;
+  evidenceDocs: EvidenceDoc[];
+  status: 'success' | 'forfeit' | 'error';
+}
+
+interface AggregatedIssue {
+  issueTitle: string;
+  problem: string;
+  evidence: string[];
+  severity: Severity;
+  suggestion: string;
+  filePath: string;
+  lineRange: [number, number];
+  confidence?: number;
+  reviewers: string[];
+}
+
+interface DiffIssueMarker {
+  issueTitle: string;
+  severity: Severity;
+  lineStart: number;
+  lineEnd: number;
+}
+
+interface ParsedDiffLine {
+  type: 'added' | 'removed' | 'context' | 'header';
+  content: string;
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
+}
+
+// ============================================================================
+// Severity maps
+// ============================================================================
+
+const severityClassMap: Record<Severity, string> = {
+  HARSHLY_CRITICAL: 'severity-badge--harshly-critical',
+  CRITICAL: 'severity-badge--critical',
+  WARNING: 'severity-badge--warning',
+  SUGGESTION: 'severity-badge--suggestion',
+};
+
+const severityLabelMap: Record<Severity, string> = {
+  HARSHLY_CRITICAL: 'Harshly Critical',
+  CRITICAL: 'Critical',
+  WARNING: 'Warning',
+  SUGGESTION: 'Suggestion',
+};
+
+// ============================================================================
+// Decision maps
+// ============================================================================
+
+type Decision = 'ACCEPT' | 'REJECT' | 'NEEDS_HUMAN';
+
+const decisionClassMap: Record<Decision, string> = {
+  ACCEPT: 'verdict-banner--accept',
+  REJECT: 'verdict-banner--reject',
+  NEEDS_HUMAN: 'verdict-banner--needs-human',
+};
+
+const decisionLabelMap: Record<Decision, string> = {
+  ACCEPT: 'Accepted',
+  REJECT: 'Rejected',
+  NEEDS_HUMAN: 'Needs Human Review',
+};
+
+// ============================================================================
+// Diff parser
+// ============================================================================
+
+function parseDiffLines(diffText: string): ParsedDiffLine[] {
+  const rawLines = diffText.split('\n');
+  const parsed: ParsedDiffLine[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+
+  for (const raw of rawLines) {
+    if (raw.startsWith('@@')) {
+      const match = raw.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (match) {
+        oldLine = parseInt(match[1], 10);
+        newLine = parseInt(match[2], 10);
+      }
+      parsed.push({ type: 'header', content: raw, oldLineNumber: null, newLineNumber: null });
+    } else if (raw.startsWith('---') || raw.startsWith('+++') || raw.startsWith('diff ') || raw.startsWith('index ')) {
+      parsed.push({ type: 'header', content: raw, oldLineNumber: null, newLineNumber: null });
+    } else if (raw.startsWith('+')) {
+      parsed.push({ type: 'added', content: raw.slice(1), oldLineNumber: null, newLineNumber: newLine });
+      newLine++;
+    } else if (raw.startsWith('-')) {
+      parsed.push({ type: 'removed', content: raw.slice(1), oldLineNumber: oldLine, newLineNumber: null });
+      oldLine++;
+    } else {
+      const content = raw.startsWith(' ') ? raw.slice(1) : raw;
+      parsed.push({ type: 'context', content, oldLineNumber: oldLine, newLineNumber: newLine });
+      oldLine++;
+      newLine++;
+    }
+  }
+
+  return parsed;
+}
+
+// ============================================================================
+// Issue aggregation
+// ============================================================================
+
+function aggregateIssues(reviews: ReviewEntry[]): AggregatedIssue[] {
+  const issueMap = new Map<string, AggregatedIssue>();
+
+  for (const review of reviews) {
+    if (review.status !== 'success') continue;
+    for (const doc of review.evidenceDocs) {
+      const key = `${doc.filePath}:${doc.lineRange[0]}-${doc.lineRange[1]}:${doc.issueTitle}`;
+      const existing = issueMap.get(key);
+      if (existing) {
+        existing.reviewers.push(review.reviewerId);
+      } else {
+        issueMap.set(key, {
+          ...doc,
+          reviewers: [review.reviewerId],
+        });
+      }
+    }
+  }
+
+  return Array.from(issueMap.values());
+}
+
+function computeSeverityCounts(issues: AggregatedIssue[]): Record<Severity, number> {
+  const counts: Record<Severity, number> = {
+    HARSHLY_CRITICAL: 0,
+    CRITICAL: 0,
+    WARNING: 0,
+    SUGGESTION: 0,
+  };
+  for (const issue of issues) {
+    counts[issue.severity]++;
+  }
+  return counts;
+}
+
+function issuesToMarkers(issues: AggregatedIssue[]): DiffIssueMarker[] {
+  return issues.map((issue) => ({
+    issueTitle: issue.issueTitle,
+    severity: issue.severity,
+    lineStart: issue.lineRange[0],
+    lineEnd: issue.lineRange[1],
+  }));
+}
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+function formatDuration(startMs: number, endMs?: number): string {
+  const end = endMs ?? Date.now();
+  const seconds = Math.round((end - startMs) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  parseDiffLines,
+  aggregateIssues,
+  computeSeverityCounts,
+  issuesToMarkers,
+  formatDuration,
+  formatDate,
+  severityClassMap,
+  severityLabelMap,
+  decisionClassMap,
+  decisionLabelMap,
+};
+
+export type {
+  Severity,
+  Decision,
+  EvidenceDoc,
+  ReviewEntry,
+  AggregatedIssue,
+  DiffIssueMarker,
+  ParsedDiffLine,
+};

--- a/packages/web/tests/frontend/review-detail.test.ts
+++ b/packages/web/tests/frontend/review-detail.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Review Detail Frontend Tests
+ * Tests utility/parsing functions used by the review dashboard components.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseDiffLines,
+  severityClassMap,
+  severityLabelMap,
+  decisionClassMap,
+  decisionLabelMap,
+  aggregateIssues,
+  computeSeverityCounts,
+  issuesToMarkers,
+  formatDuration,
+  formatDate,
+} from '../../src/frontend/utils/review-helpers.js';
+import type { Severity, ReviewEntry, AggregatedIssue } from '../../src/frontend/utils/review-helpers.js';
+
+// ============================================================================
+// DiffViewer — parseDiffLines
+// ============================================================================
+
+describe('parseDiffLines', () => {
+  it('should parse added, removed, and context lines', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' const a = 1;',
+      '-const b = 2;',
+      '+const b = 3;',
+      ' const c = 4;',
+    ].join('\n');
+
+    const lines = parseDiffLines(diff);
+
+    // Header
+    expect(lines[0].type).toBe('header');
+    expect(lines[0].content).toContain('@@');
+
+    // Context line
+    expect(lines[1].type).toBe('context');
+    expect(lines[1].content).toBe('const a = 1;');
+    expect(lines[1].oldLineNumber).toBe(1);
+    expect(lines[1].newLineNumber).toBe(1);
+
+    // Removed line
+    expect(lines[2].type).toBe('removed');
+    expect(lines[2].content).toBe('const b = 2;');
+    expect(lines[2].oldLineNumber).toBe(2);
+    expect(lines[2].newLineNumber).toBeNull();
+
+    // Added line
+    expect(lines[3].type).toBe('added');
+    expect(lines[3].content).toBe('const b = 3;');
+    expect(lines[3].oldLineNumber).toBeNull();
+    expect(lines[3].newLineNumber).toBe(2);
+
+    // Trailing context
+    expect(lines[4].type).toBe('context');
+    expect(lines[4].oldLineNumber).toBe(3);
+    expect(lines[4].newLineNumber).toBe(3);
+  });
+
+  it('should parse hunk headers with correct line numbers', () => {
+    const diff = '@@ -10,5 +20,7 @@ function foo() {\n context\n+added';
+
+    const lines = parseDiffLines(diff);
+
+    expect(lines[0].type).toBe('header');
+    // Context line after hunk should start at old=10, new=20
+    expect(lines[1].type).toBe('context');
+    expect(lines[1].oldLineNumber).toBe(10);
+    expect(lines[1].newLineNumber).toBe(20);
+
+    // Added line
+    expect(lines[2].type).toBe('added');
+    expect(lines[2].newLineNumber).toBe(21);
+  });
+
+  it('should handle diff file headers as header type', () => {
+    const diff = [
+      'diff --git a/file.ts b/file.ts',
+      'index abc..def 100644',
+      '--- a/file.ts',
+      '+++ b/file.ts',
+      '@@ -1,2 +1,2 @@',
+      '-old',
+      '+new',
+    ].join('\n');
+
+    const lines = parseDiffLines(diff);
+
+    expect(lines[0].type).toBe('header');
+    expect(lines[1].type).toBe('header');
+    expect(lines[2].type).toBe('header');
+    expect(lines[3].type).toBe('header');
+    expect(lines[4].type).toBe('header'); // @@ header
+    expect(lines[5].type).toBe('removed');
+    expect(lines[6].type).toBe('added');
+  });
+
+  it('should return a line for empty diff text', () => {
+    const lines = parseDiffLines('');
+    expect(lines.length).toBe(1);
+    expect(lines[0].type).toBe('context');
+  });
+});
+
+// ============================================================================
+// SeverityBadge — class/label maps
+// ============================================================================
+
+describe('SeverityBadge maps', () => {
+  it('should map all severity levels to CSS classes', () => {
+    const severities: Severity[] = ['HARSHLY_CRITICAL', 'CRITICAL', 'WARNING', 'SUGGESTION'];
+
+    for (const severity of severities) {
+      expect(severityClassMap[severity]).toBeDefined();
+      expect(severityClassMap[severity]).toContain('severity-badge--');
+    }
+  });
+
+  it('should provide human-readable labels for all severities', () => {
+    expect(severityLabelMap.HARSHLY_CRITICAL).toBe('Harshly Critical');
+    expect(severityLabelMap.CRITICAL).toBe('Critical');
+    expect(severityLabelMap.WARNING).toBe('Warning');
+    expect(severityLabelMap.SUGGESTION).toBe('Suggestion');
+  });
+});
+
+// ============================================================================
+// VerdictBanner — class/label maps
+// ============================================================================
+
+describe('VerdictBanner maps', () => {
+  it('should map all decisions to CSS classes', () => {
+    expect(decisionClassMap.ACCEPT).toBe('verdict-banner--accept');
+    expect(decisionClassMap.REJECT).toBe('verdict-banner--reject');
+    expect(decisionClassMap.NEEDS_HUMAN).toBe('verdict-banner--needs-human');
+  });
+
+  it('should provide human-readable labels for all decisions', () => {
+    expect(decisionLabelMap.ACCEPT).toBe('Accepted');
+    expect(decisionLabelMap.REJECT).toBe('Rejected');
+    expect(decisionLabelMap.NEEDS_HUMAN).toBe('Needs Human Review');
+  });
+});
+
+// ============================================================================
+// ReviewDetail — aggregateIssues
+// ============================================================================
+
+describe('aggregateIssues', () => {
+  const makeReview = (
+    reviewerId: string,
+    issues: Array<{
+      issueTitle: string;
+      filePath: string;
+      lineRange: [number, number];
+      severity: Severity;
+    }>,
+  ): ReviewEntry => ({
+    reviewerId,
+    model: 'test-model',
+    group: 'src/',
+    status: 'success',
+    evidenceDocs: issues.map((i) => ({
+      ...i,
+      problem: 'test problem',
+      evidence: ['evidence 1'],
+      suggestion: 'fix it',
+    })),
+  });
+
+  it('should aggregate the same issue from multiple reviewers', () => {
+    const reviews: ReviewEntry[] = [
+      makeReview('r1', [
+        { issueTitle: 'Bug', filePath: 'file.ts', lineRange: [10, 12], severity: 'CRITICAL' },
+      ]),
+      makeReview('r2', [
+        { issueTitle: 'Bug', filePath: 'file.ts', lineRange: [10, 12], severity: 'CRITICAL' },
+      ]),
+    ];
+
+    const aggregated = aggregateIssues(reviews);
+
+    expect(aggregated).toHaveLength(1);
+    expect(aggregated[0].reviewers).toEqual(['r1', 'r2']);
+    expect(aggregated[0].issueTitle).toBe('Bug');
+  });
+
+  it('should keep distinct issues separate', () => {
+    const reviews: ReviewEntry[] = [
+      makeReview('r1', [
+        { issueTitle: 'Bug A', filePath: 'file.ts', lineRange: [10, 12], severity: 'CRITICAL' },
+        { issueTitle: 'Bug B', filePath: 'other.ts', lineRange: [5, 8], severity: 'WARNING' },
+      ]),
+    ];
+
+    const aggregated = aggregateIssues(reviews);
+
+    expect(aggregated).toHaveLength(2);
+  });
+
+  it('should skip forfeit and error reviews', () => {
+    const reviews: ReviewEntry[] = [
+      {
+        reviewerId: 'r1',
+        model: 'test',
+        group: 'src/',
+        status: 'forfeit',
+        evidenceDocs: [
+          {
+            issueTitle: 'Ghost',
+            problem: 'p',
+            evidence: [],
+            severity: 'CRITICAL',
+            suggestion: 's',
+            filePath: 'f.ts',
+            lineRange: [1, 2],
+          },
+        ],
+      },
+    ];
+
+    const aggregated = aggregateIssues(reviews);
+    expect(aggregated).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// ReviewDetail — computeSeverityCounts
+// ============================================================================
+
+describe('computeSeverityCounts', () => {
+  it('should count severity levels correctly', () => {
+    const issues: AggregatedIssue[] = [
+      { issueTitle: 'A', problem: 'p', evidence: [], severity: 'CRITICAL', suggestion: 's', filePath: 'f.ts', lineRange: [1, 2], reviewers: ['r1'] },
+      { issueTitle: 'B', problem: 'p', evidence: [], severity: 'CRITICAL', suggestion: 's', filePath: 'f.ts', lineRange: [3, 4], reviewers: ['r1'] },
+      { issueTitle: 'C', problem: 'p', evidence: [], severity: 'WARNING', suggestion: 's', filePath: 'f.ts', lineRange: [5, 6], reviewers: ['r1'] },
+      { issueTitle: 'D', problem: 'p', evidence: [], severity: 'SUGGESTION', suggestion: 's', filePath: 'f.ts', lineRange: [7, 8], reviewers: ['r1'] },
+      { issueTitle: 'E', problem: 'p', evidence: [], severity: 'HARSHLY_CRITICAL', suggestion: 's', filePath: 'f.ts', lineRange: [9, 10], reviewers: ['r1'] },
+    ];
+
+    const counts = computeSeverityCounts(issues);
+
+    expect(counts.HARSHLY_CRITICAL).toBe(1);
+    expect(counts.CRITICAL).toBe(2);
+    expect(counts.WARNING).toBe(1);
+    expect(counts.SUGGESTION).toBe(1);
+  });
+
+  it('should return all zeros for empty issues array', () => {
+    const counts = computeSeverityCounts([]);
+
+    expect(counts.HARSHLY_CRITICAL).toBe(0);
+    expect(counts.CRITICAL).toBe(0);
+    expect(counts.WARNING).toBe(0);
+    expect(counts.SUGGESTION).toBe(0);
+  });
+});
+
+// ============================================================================
+// ReviewDetail — issuesToMarkers
+// ============================================================================
+
+describe('issuesToMarkers', () => {
+  it('should convert aggregated issues to diff markers', () => {
+    const issues: AggregatedIssue[] = [
+      { issueTitle: 'Bug', problem: 'p', evidence: [], severity: 'CRITICAL', suggestion: 's', filePath: 'f.ts', lineRange: [10, 15], reviewers: ['r1'] },
+    ];
+
+    const markers = issuesToMarkers(issues);
+
+    expect(markers).toHaveLength(1);
+    expect(markers[0].issueTitle).toBe('Bug');
+    expect(markers[0].severity).toBe('CRITICAL');
+    expect(markers[0].lineStart).toBe(10);
+    expect(markers[0].lineEnd).toBe(15);
+  });
+});
+
+// ============================================================================
+// ReviewDetail — formatDuration
+// ============================================================================
+
+describe('formatDuration', () => {
+  it('should format short durations in seconds', () => {
+    const start = 1000000;
+    const end = start + 45_000;
+    expect(formatDuration(start, end)).toBe('45s');
+  });
+
+  it('should format longer durations in minutes and seconds', () => {
+    const start = 1000000;
+    const end = start + 125_000;
+    expect(formatDuration(start, end)).toBe('2m 5s');
+  });
+});
+
+// ============================================================================
+// ReviewDetail — formatDate
+// ============================================================================
+
+describe('formatDate', () => {
+  it('should return a non-empty string for a valid timestamp', () => {
+    const result = formatDate(1705312800000);
+    expect(result.length).toBeGreaterThan(0);
+    expect(typeof result).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace placeholder ReviewDetail page with full annotated review results dashboard
- New components: DiffViewer, IssueCard, SeverityBadge, SeveritySummary, VerdictBanner
- Pure utility functions in `review-helpers.ts` for diff parsing, issue aggregation, severity counting
- 17 new tests covering all utility/parsing functions

## Features
- Annotated diff viewer with line numbers, add/remove/context highlighting, inline issue markers
- Collapsible issue cards with severity badge, confidence %, evidence, reviewer attribution
- Full-width verdict banner (ACCEPT/REJECT/NEEDS_HUMAN) with color coding
- Proportional severity summary bar with legend

## Test Plan
- [x] 17 new tests (39 total) — all pass
- [x] Diff parser, severity counting, issue aggregation, formatting utilities

Sprint 7 Feature 5.2 / 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)