### PR TITLE
feat: Sprint 7.7 — discussion/debate viewer

### DIFF
--- a/packages/web/src/frontend/components/ConsensusProgress.tsx
+++ b/packages/web/src/frontend/components/ConsensusProgress.tsx
@@ -1,0 +1,137 @@
+/**
+ * ConsensusProgress — Bar chart showing consensus percentage per round.
+ * Displays a threshold line and whether consensus was ultimately reached.
+ */
+
+import React from 'react';
+import type { DiscussionRound } from '../utils/discussion-helpers.js';
+import { getConsensusPercentage } from '../utils/discussion-helpers.js';
+
+interface ConsensusProgressProps {
+  rounds: readonly DiscussionRound[];
+  consensusReached: boolean;
+  threshold?: number;
+}
+
+const BAR_HEIGHT = 20;
+const BAR_GAP = 6;
+const LABEL_WIDTH = 60;
+const CHART_WIDTH = 300;
+const THRESHOLD_DEFAULT = 75;
+
+export function ConsensusProgress({
+  rounds,
+  consensusReached,
+  threshold = THRESHOLD_DEFAULT,
+}: ConsensusProgressProps): React.JSX.Element {
+  const sorted = [...rounds].sort((a, b) => a.round - b.round);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="consensus-progress">
+        <p className="consensus-progress__empty">No round data available.</p>
+      </div>
+    );
+  }
+
+  const percentages = sorted.map((r) => getConsensusPercentage(r));
+  const svgHeight = sorted.length * (BAR_HEIGHT + BAR_GAP) + 24;
+  const svgWidth = LABEL_WIDTH + CHART_WIDTH + 40;
+  const thresholdX = LABEL_WIDTH + (threshold / 100) * CHART_WIDTH;
+
+  return (
+    <div className="consensus-progress">
+      <h4 className="consensus-progress__title">Consensus Progress</h4>
+
+      <svg
+        className="consensus-progress__svg"
+        width={svgWidth}
+        height={svgHeight}
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+      >
+        {/* Threshold line */}
+        <line
+          x1={thresholdX}
+          y1={0}
+          x2={thresholdX}
+          y2={svgHeight - 20}
+          stroke="rgba(210, 153, 34, 0.5)"
+          strokeWidth={1}
+          strokeDasharray="4,3"
+        />
+        <text
+          x={thresholdX}
+          y={svgHeight - 6}
+          textAnchor="middle"
+          className="consensus-progress__threshold-label"
+        >
+          {threshold}%
+        </text>
+
+        {/* Bars */}
+        {sorted.map((round, idx) => {
+          const pct = percentages[idx];
+          const y = idx * (BAR_HEIGHT + BAR_GAP) + 4;
+          const barWidth = (pct / 100) * CHART_WIDTH;
+          const meetsThreshold = pct >= threshold;
+
+          return (
+            <g key={round.round}>
+              <text
+                x={LABEL_WIDTH - 8}
+                y={y + BAR_HEIGHT / 2 + 4}
+                textAnchor="end"
+                className="consensus-progress__bar-label"
+              >
+                Round {round.round}
+              </text>
+
+              {/* Background track */}
+              <rect
+                x={LABEL_WIDTH}
+                y={y}
+                width={CHART_WIDTH}
+                height={BAR_HEIGHT}
+                rx={3}
+                fill="rgba(48, 54, 61, 0.5)"
+              />
+
+              {/* Fill bar */}
+              <rect
+                x={LABEL_WIDTH}
+                y={y}
+                width={Math.max(barWidth, 0)}
+                height={BAR_HEIGHT}
+                rx={3}
+                fill={
+                  meetsThreshold
+                    ? 'rgba(63, 185, 80, 0.7)'
+                    : 'rgba(88, 166, 255, 0.7)'
+                }
+              />
+
+              {/* Percentage label */}
+              <text
+                x={LABEL_WIDTH + CHART_WIDTH + 6}
+                y={y + BAR_HEIGHT / 2 + 4}
+                className="consensus-progress__pct-label"
+              >
+                {pct}%
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      <div className="consensus-progress__result">
+        <span
+          className={`consensus-badge ${
+            consensusReached ? 'consensus--reached' : 'consensus--not-reached'
+          }`}
+        >
+          {consensusReached ? 'Consensus Reached' : 'No Consensus'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/frontend/components/DebateTimeline.tsx
+++ b/packages/web/src/frontend/components/DebateTimeline.tsx
@@ -1,0 +1,130 @@
+/**
+ * DebateTimeline — Round-by-round threaded timeline view for a single discussion.
+ * Shows moderator prompts, supporter responses with stance badges, and verdict.
+ */
+
+import React from 'react';
+import type {
+  DiscussionVerdict,
+  DiscussionRound,
+} from '../utils/discussion-helpers.js';
+import {
+  getConsensusPercentage,
+  isDevilsAdvocate,
+  discussionSeverityClassMap,
+  discussionSeverityLabelMap,
+} from '../utils/discussion-helpers.js';
+
+interface DebateTimelineProps {
+  verdict: DiscussionVerdict;
+  rounds: readonly DiscussionRound[];
+}
+
+function stanceClass(stance: string): string {
+  switch (stance) {
+    case 'agree':
+      return 'stance--agree';
+    case 'disagree':
+      return 'stance--disagree';
+    default:
+      return 'stance--neutral';
+  }
+}
+
+export function DebateTimeline({
+  verdict,
+  rounds,
+}: DebateTimelineProps): React.JSX.Element {
+  const sorted = [...rounds].sort((a, b) => a.round - b.round);
+
+  return (
+    <div className="debate-timeline">
+      <div className="debate-timeline__header">
+        <h3 className="debate-timeline__title">
+          Debate: {verdict.filePath} (L{verdict.lineRange[0]}-{verdict.lineRange[1]})
+        </h3>
+        <span
+          className={`disc-severity ${discussionSeverityClassMap[verdict.finalSeverity]}`}
+        >
+          {discussionSeverityLabelMap[verdict.finalSeverity]}
+        </span>
+      </div>
+
+      <div className="debate-timeline__rounds">
+        {sorted.map((round) => {
+          const consensusPct = getConsensusPercentage(round);
+
+          return (
+            <div key={round.round} className="debate-round">
+              <div className="debate-round__header">
+                <span className="debate-round__label">Round {round.round}</span>
+                <span className="debate-round__consensus">
+                  {consensusPct}% agree
+                </span>
+              </div>
+
+              <div className="debate-round__moderator">
+                <span className="debate-round__moderator-label">Moderator</span>
+                <p className="debate-round__moderator-prompt">
+                  {round.moderatorPrompt}
+                </p>
+              </div>
+
+              <div className="debate-round__responses">
+                {round.supporterResponses.map((resp) => {
+                  const isDA = isDevilsAdvocate(resp.supporterId);
+                  const respClass = [
+                    'debate-response',
+                    isDA ? 'debate-response--devil' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ');
+
+                  return (
+                    <div key={resp.supporterId} className={respClass}>
+                      <div className="debate-response__header">
+                        <span className="debate-response__supporter">
+                          {resp.supporterId}
+                          {isDA && (
+                            <span className="debate-response__da-tag">DA</span>
+                          )}
+                        </span>
+                        <span
+                          className={`stance-badge ${stanceClass(resp.stance)}`}
+                        >
+                          {resp.stance}
+                        </span>
+                      </div>
+                      <p className="debate-response__text">{resp.response}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="debate-timeline__verdict">
+        <div className="debate-timeline__verdict-header">
+          <span className="debate-timeline__verdict-label">Final Verdict</span>
+          <span
+            className={`disc-severity ${discussionSeverityClassMap[verdict.finalSeverity]}`}
+          >
+            {discussionSeverityLabelMap[verdict.finalSeverity]}
+          </span>
+          <span
+            className={`consensus-badge ${
+              verdict.consensusReached
+                ? 'consensus--reached'
+                : 'consensus--not-reached'
+            }`}
+          >
+            {verdict.consensusReached ? 'Consensus Reached' : 'No Consensus'}
+          </span>
+        </div>
+        <p className="debate-timeline__verdict-reasoning">{verdict.reasoning}</p>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/frontend/components/DiscussionList.tsx
+++ b/packages/web/src/frontend/components/DiscussionList.tsx
@@ -1,0 +1,136 @@
+/**
+ * DiscussionList — Summary list of all discussions in a session.
+ * Shows verdict info with filtering by severity and consensus status.
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import type { DiscussionVerdict, DiscussionSeverity } from '../utils/discussion-helpers.js';
+import {
+  discussionSeverityClassMap,
+  discussionSeverityLabelMap,
+} from '../utils/discussion-helpers.js';
+
+interface DiscussionListProps {
+  discussions: readonly DiscussionVerdict[];
+  selectedId: string | null;
+  onSelect: (discussionId: string) => void;
+}
+
+type SeverityFilter = DiscussionSeverity | 'all';
+type ConsensusFilter = 'all' | 'reached' | 'not-reached';
+
+export function DiscussionList({
+  discussions,
+  selectedId,
+  onSelect,
+}: DiscussionListProps): React.JSX.Element {
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('all');
+  const [consensusFilter, setConsensusFilter] = useState<ConsensusFilter>('all');
+
+  const filtered = useMemo(() => {
+    let result = [...discussions];
+
+    if (severityFilter !== 'all') {
+      result = result.filter((d) => d.finalSeverity === severityFilter);
+    }
+
+    if (consensusFilter === 'reached') {
+      result = result.filter((d) => d.consensusReached);
+    } else if (consensusFilter === 'not-reached') {
+      result = result.filter((d) => !d.consensusReached);
+    }
+
+    return result;
+  }, [discussions, severityFilter, consensusFilter]);
+
+  const handleSeverityChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSeverityFilter(e.target.value as SeverityFilter);
+    },
+    [],
+  );
+
+  const handleConsensusChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setConsensusFilter(e.target.value as ConsensusFilter);
+    },
+    [],
+  );
+
+  return (
+    <div className="disc-list">
+      <div className="disc-list__filters">
+        <select
+          className="filter-select"
+          value={severityFilter}
+          onChange={handleSeverityChange}
+          aria-label="Filter by severity"
+        >
+          <option value="all">All Severities</option>
+          <option value="HARSHLY_CRITICAL">Harshly Critical</option>
+          <option value="CRITICAL">Critical</option>
+          <option value="WARNING">Warning</option>
+          <option value="SUGGESTION">Suggestion</option>
+          <option value="DISMISSED">Dismissed</option>
+        </select>
+
+        <select
+          className="filter-select"
+          value={consensusFilter}
+          onChange={handleConsensusChange}
+          aria-label="Filter by consensus"
+        >
+          <option value="all">All Consensus</option>
+          <option value="reached">Consensus Reached</option>
+          <option value="not-reached">No Consensus</option>
+        </select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="disc-list__empty">No discussions match the current filters.</p>
+      ) : (
+        <div className="disc-list__items">
+          {filtered.map((d) => {
+            const isSelected = d.discussionId === selectedId;
+            const rowClass = [
+              'disc-list__row',
+              isSelected ? 'disc-list__row--selected' : '',
+            ]
+              .filter(Boolean)
+              .join(' ');
+
+            return (
+              <button
+                key={d.discussionId}
+                className={rowClass}
+                onClick={() => onSelect(d.discussionId)}
+                type="button"
+              >
+                <span className="disc-list__id">{d.discussionId}</span>
+                <span className="disc-list__file">{d.filePath}</span>
+                <span className="disc-list__line">
+                  L{d.lineRange[0]}-{d.lineRange[1]}
+                </span>
+                <span
+                  className={`disc-severity ${discussionSeverityClassMap[d.finalSeverity]}`}
+                >
+                  {discussionSeverityLabelMap[d.finalSeverity]}
+                </span>
+                <span className="disc-list__rounds">{d.rounds} round{d.rounds !== 1 ? 's' : ''}</span>
+                <span
+                  className={`disc-list__consensus ${
+                    d.consensusReached
+                      ? 'disc-list__consensus--reached'
+                      : 'disc-list__consensus--not-reached'
+                  }`}
+                >
+                  {d.consensusReached ? 'Consensus' : 'No Consensus'}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/frontend/components/StanceVisualization.tsx
+++ b/packages/web/src/frontend/components/StanceVisualization.tsx
@@ -1,0 +1,136 @@
+/**
+ * StanceVisualization — SVG grid showing how each supporter's stance
+ * changed across rounds. Rows = supporters, columns = rounds.
+ */
+
+import React from 'react';
+import type { DiscussionRound, Stance } from '../utils/discussion-helpers.js';
+import { getStanceProgression, isDevilsAdvocate } from '../utils/discussion-helpers.js';
+
+interface StanceVisualizationProps {
+  rounds: readonly DiscussionRound[];
+}
+
+const CELL_SIZE = 32;
+const CELL_GAP = 4;
+const LABEL_WIDTH = 140;
+const HEADER_HEIGHT = 28;
+
+const stanceColorMap: Record<Stance, string> = {
+  agree: 'rgba(63, 185, 80, 0.7)',
+  disagree: 'rgba(248, 81, 73, 0.7)',
+  neutral: 'rgba(139, 148, 158, 0.4)',
+};
+
+export function StanceVisualization({
+  rounds,
+}: StanceVisualizationProps): React.JSX.Element {
+  const progression = getStanceProgression(rounds);
+  const sorted = [...rounds].sort((a, b) => a.round - b.round);
+
+  if (progression.length === 0 || sorted.length === 0) {
+    return (
+      <div className="stance-viz">
+        <p className="stance-viz__empty">No stance data available.</p>
+      </div>
+    );
+  }
+
+  const numRounds = sorted.length;
+  const numSupporters = progression.length;
+  const svgWidth = LABEL_WIDTH + numRounds * (CELL_SIZE + CELL_GAP);
+  const svgHeight = HEADER_HEIGHT + numSupporters * (CELL_SIZE + CELL_GAP);
+
+  return (
+    <div className="stance-viz">
+      <h4 className="stance-viz__title">Stance Progression</h4>
+      <div className="stance-viz__scroll">
+        <svg
+          className="stance-viz__svg"
+          width={svgWidth}
+          height={svgHeight}
+          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        >
+          {/* Column headers (round numbers) */}
+          {sorted.map((round, colIdx) => (
+            <text
+              key={`header-${round.round}`}
+              x={LABEL_WIDTH + colIdx * (CELL_SIZE + CELL_GAP) + CELL_SIZE / 2}
+              y={HEADER_HEIGHT - 8}
+              textAnchor="middle"
+              className="stance-viz__header-text"
+            >
+              R{round.round}
+            </text>
+          ))}
+
+          {/* Rows */}
+          {progression.map((entry, rowIdx) => {
+            const y = HEADER_HEIGHT + rowIdx * (CELL_SIZE + CELL_GAP);
+            const isDA = isDevilsAdvocate(entry.supporterId);
+            const labelText =
+              entry.supporterId.length > 16
+                ? entry.supporterId.slice(0, 14) + '...'
+                : entry.supporterId;
+
+            return (
+              <g key={entry.supporterId}>
+                {/* Row label */}
+                <text
+                  x={LABEL_WIDTH - 8}
+                  y={y + CELL_SIZE / 2 + 4}
+                  textAnchor="end"
+                  className={`stance-viz__row-label ${isDA ? 'stance-viz__row-label--da' : ''}`}
+                >
+                  {labelText}
+                  {isDA ? ' (DA)' : ''}
+                </text>
+
+                {/* Stance cells */}
+                {entry.stances.map((stance, colIdx) => (
+                  <rect
+                    key={`${entry.supporterId}-${colIdx}`}
+                    x={LABEL_WIDTH + colIdx * (CELL_SIZE + CELL_GAP)}
+                    y={y}
+                    width={CELL_SIZE}
+                    height={CELL_SIZE}
+                    rx={4}
+                    fill={stanceColorMap[stance]}
+                  >
+                    <title>
+                      {entry.supporterId} - Round {sorted[colIdx].round}: {stance}
+                    </title>
+                  </rect>
+                ))}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <div className="stance-viz__legend">
+        <span className="stance-viz__legend-item">
+          <span
+            className="stance-viz__legend-dot"
+            style={{ backgroundColor: stanceColorMap.agree }}
+          />
+          Agree
+        </span>
+        <span className="stance-viz__legend-item">
+          <span
+            className="stance-viz__legend-dot"
+            style={{ backgroundColor: stanceColorMap.disagree }}
+          />
+          Disagree
+        </span>
+        <span className="stance-viz__legend-item">
+          <span
+            className="stance-viz__legend-dot"
+            style={{ backgroundColor: stanceColorMap.neutral }}
+          />
+          Neutral
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/frontend/pages/Discussions.tsx
+++ b/packages/web/src/frontend/pages/Discussions.tsx
@@ -1,10 +1,234 @@
-import React from 'react';
+/**
+ * Discussions — Discussion/debate viewer page.
+ * Session selector, discussion list with filters, and detailed debate view.
+ */
+
+import React, { useState, useCallback, useMemo } from 'react';
+import { useApi } from '../hooks/useApi.js';
+import { DiscussionList } from '../components/DiscussionList.js';
+import { DebateTimeline } from '../components/DebateTimeline.js';
+import { StanceVisualization } from '../components/StanceVisualization.js';
+import { ConsensusProgress } from '../components/ConsensusProgress.js';
+import { summarizeDiscussion } from '../utils/discussion-helpers.js';
+import type {
+  DiscussionVerdict,
+  DiscussionRound,
+} from '../utils/discussion-helpers.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SessionData {
+  metadata: {
+    sessionId: string;
+    date: string;
+  };
+  discussions: DiscussionVerdict[];
+  rounds: Record<string, DiscussionRound[]>;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
 
 export function Discussions(): React.JSX.Element {
+  const [dateInput, setDateInput] = useState('');
+  const [idInput, setIdInput] = useState('');
+  const [sessionPath, setSessionPath] = useState<string | null>(null);
+  const [selectedDiscussionId, setSelectedDiscussionId] = useState<string | null>(null);
+
+  const { data: session, loading, error, refetch } = useApi<SessionData>(
+    sessionPath ?? '',
+  );
+
+  const handleLoad = useCallback(() => {
+    if (dateInput.trim() && idInput.trim()) {
+      setSessionPath(`/api/sessions/${dateInput.trim()}/${idInput.trim()}`);
+      setSelectedDiscussionId(null);
+    }
+  }, [dateInput, idInput]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        handleLoad();
+      }
+    },
+    [handleLoad],
+  );
+
+  const handleSelectDiscussion = useCallback((discussionId: string) => {
+    setSelectedDiscussionId((prev) =>
+      prev === discussionId ? null : discussionId,
+    );
+  }, []);
+
+  const selectedVerdict = useMemo(() => {
+    if (!session || !selectedDiscussionId) return null;
+    return (
+      session.discussions.find(
+        (d) => d.discussionId === selectedDiscussionId,
+      ) ?? null
+    );
+  }, [session, selectedDiscussionId]);
+
+  const selectedRounds = useMemo(() => {
+    if (!session || !selectedDiscussionId) return [];
+    return session.rounds[selectedDiscussionId] ?? [];
+  }, [session, selectedDiscussionId]);
+
+  const summary = useMemo(() => {
+    if (!selectedVerdict) return null;
+    return summarizeDiscussion(selectedVerdict, selectedRounds);
+  }, [selectedVerdict, selectedRounds]);
+
+  // No session path set yet — show the selector
+  if (!sessionPath) {
+    return (
+      <div className="page">
+        <h2>Discussions</h2>
+        <p>Enter a session date and ID to view discussions and debates.</p>
+
+        <div className="disc-selector">
+          <input
+            className="filter-input"
+            type="text"
+            placeholder="Date (e.g. 2024-01-15)"
+            value={dateInput}
+            onChange={(e) => setDateInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Session date"
+          />
+          <input
+            className="filter-input"
+            type="text"
+            placeholder="Session ID"
+            value={idInput}
+            onChange={(e) => setIdInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Session ID"
+          />
+          <button
+            className="disc-selector__load"
+            onClick={handleLoad}
+            type="button"
+            disabled={!dateInput.trim() || !idInput.trim()}
+          >
+            Load Session
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="page">
+        <h2>Discussions</h2>
+        <p>Loading session...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page">
+        <h2>Discussions</h2>
+        <p className="error-text">Error: {error}</p>
+        <div className="disc-selector">
+          <button
+            onClick={() => setSessionPath(null)}
+            type="button"
+            className="retry-button"
+          >
+            Change Session
+          </button>
+          <button onClick={refetch} type="button" className="retry-button">
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="page">
+        <h2>Discussions</h2>
+        <p>Session not found.</p>
+      </div>
+    );
+  }
+
+  const discussions = session.discussions ?? [];
+
   return (
     <div className="page">
-      <h2>Discussions</h2>
-      <p>Coming soon</p>
+      <div className="page-header">
+        <h2>Discussions</h2>
+        <span className="page-header__count">
+          {discussions.length} discussion{discussions.length !== 1 ? 's' : ''}
+        </span>
+        <button
+          onClick={() => setSessionPath(null)}
+          type="button"
+          className="disc-change-session"
+        >
+          Change Session
+        </button>
+      </div>
+
+      <p className="disc-session-info">
+        Session: {session.metadata.sessionId} ({session.metadata.date})
+      </p>
+
+      {discussions.length === 0 ? (
+        <p className="disc-empty">No discussions found in this session.</p>
+      ) : (
+        <div className="disc-layout">
+          <div className="disc-layout__list">
+            <DiscussionList
+              discussions={discussions}
+              selectedId={selectedDiscussionId}
+              onSelect={handleSelectDiscussion}
+            />
+          </div>
+
+          {selectedVerdict && (
+            <div className="disc-layout__detail">
+              {summary && (
+                <div className="disc-summary">
+                  <span className="disc-summary__item">
+                    {summary.totalRounds} round{summary.totalRounds !== 1 ? 's' : ''}
+                  </span>
+                  <span className="disc-summary__item">
+                    {summary.totalSupporters} supporter{summary.totalSupporters !== 1 ? 's' : ''}
+                  </span>
+                  <span className="disc-summary__item">
+                    {summary.finalConsensusPercentage}% final agreement
+                  </span>
+                  {summary.hasDevilsAdvocate && (
+                    <span className="disc-summary__item disc-summary__item--da">
+                      Devil&apos;s Advocate present
+                    </span>
+                  )}
+                </div>
+              )}
+
+              <StanceVisualization rounds={selectedRounds} />
+              <ConsensusProgress
+                rounds={selectedRounds}
+                consensusReached={selectedVerdict.consensusReached}
+              />
+              <DebateTimeline
+                verdict={selectedVerdict}
+                rounds={selectedRounds}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/frontend/styles/globals.css
+++ b/packages/web/src/frontend/styles/globals.css
@@ -1525,6 +1525,72 @@ a:hover {
    ============================================================================ */
 
 .model-dashboard {
+   Discussion/Debate Viewer — Session Selector
+   ============================================================================ */
+
+.disc-selector {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.disc-selector__load {
+  padding: 6px 20px;
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.disc-selector__load:hover {
+  background-color: var(--color-accent-hover);
+}
+
+.disc-selector__load:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.disc-change-session {
+  margin-left: auto;
+  padding: 4px 12px;
+  background: none;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.disc-change-session:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-secondary);
+}
+
+.disc-session-info {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin-bottom: 16px;
+}
+
+.disc-empty {
+  color: var(--color-text-secondary);
+  font-style: italic;
+  padding: 24px 0;
+}
+
+/* ============================================================================
+   Discussion/Debate Viewer — Layout
+   ============================================================================ */
+
+.disc-layout {
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -1772,6 +1838,106 @@ a:hover {
   font-size: 13px;
   color: var(--color-text);
   font-family: var(--font-mono);
+.disc-layout__list {
+  width: 100%;
+}
+
+.disc-layout__detail {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ============================================================================
+   Discussion/Debate Viewer — Summary Stats
+   ============================================================================ */
+
+.disc-summary {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 10px 14px;
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+}
+
+.disc-summary__item {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.disc-summary__item--da {
+  color: var(--color-warning);
+  font-weight: 600;
+}
+
+/* ============================================================================
+   Discussion/Debate Viewer — Discussion List
+   ============================================================================ */
+
+.disc-list__filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.disc-list__empty {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-style: italic;
+  padding: 16px 0;
+}
+
+.disc-list__items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.disc-list__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 14px;
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  text-align: left;
+  color: var(--color-text);
+  transition: background-color 0.12s, border-color 0.12s;
+}
+
+.disc-list__row:hover {
+  background-color: var(--color-bg-tertiary);
+}
+
+.disc-list__row--selected {
+  border-color: var(--color-accent);
+  background-color: rgba(88, 166, 255, 0.06);
+}
+
+.disc-list__id {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-accent);
+  min-width: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 120px;
+}
+
+.disc-list__file {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1811,6 +1977,208 @@ a:hover {
 
 .provider-card {
   padding: 14px;
+.disc-list__line {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.disc-list__rounds {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.disc-list__consensus {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.disc-list__consensus--reached {
+  color: var(--color-success);
+  background-color: rgba(63, 185, 80, 0.15);
+}
+
+.disc-list__consensus--not-reached {
+  color: var(--color-warning);
+  background-color: rgba(210, 153, 34, 0.15);
+}
+
+/* ============================================================================
+   Discussion/Debate Viewer — Severity Badges
+   ============================================================================ */
+
+.disc-severity {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.disc-severity--harshly-critical {
+  background-color: rgba(188, 107, 255, 0.15);
+  color: #bc6bff;
+}
+
+.disc-severity--critical {
+  background-color: rgba(248, 81, 73, 0.15);
+  color: var(--color-error);
+}
+
+.disc-severity--warning {
+  background-color: rgba(210, 153, 34, 0.15);
+  color: var(--color-warning);
+}
+
+.disc-severity--suggestion {
+  background-color: rgba(63, 185, 80, 0.15);
+  color: var(--color-success);
+}
+
+.disc-severity--dismissed {
+  background-color: rgba(139, 148, 158, 0.15);
+  color: var(--color-text-secondary);
+}
+
+/* ============================================================================
+   Discussion/Debate Viewer — Debate Timeline
+   ============================================================================ */
+
+.debate-timeline {
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.debate-timeline__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.debate-timeline__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.debate-timeline__rounds {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.debate-round {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.debate-round__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background-color: var(--color-bg-tertiary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.debate-round__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.debate-round__consensus {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.debate-round__moderator {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+  background-color: rgba(88, 166, 255, 0.04);
+}
+
+.debate-round__moderator-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.debate-round__moderator-prompt {
+  font-size: 13px;
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.debate-round__responses {
+  display: flex;
+  flex-direction: column;
+}
+
+.debate-response {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.debate-response:last-child {
+  border-bottom: none;
+}
+
+.debate-response--devil {
+  background-color: rgba(210, 153, 34, 0.04);
+}
+
+.debate-response__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.debate-response__supporter {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
+.debate-response__da-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 0 4px;
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--color-warning);
+  background-color: rgba(210, 153, 34, 0.15);
+  border-radius: 3px;
+  font-family: var(--font-sans);
+  text-transform: uppercase;
+}
+
+.debate-response__text {
+  font-size: 13px;
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.debate-timeline__verdict {
+  margin-top: 16px;
+  padding: 14px 16px;
   background-color: var(--color-bg-tertiary);
   border-radius: 6px;
   border: 1px solid var(--color-border);
@@ -1917,6 +2285,39 @@ a:hover {
 }
 
 .cost-breakdown__title {
+.debate-timeline__verdict-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.debate-timeline__verdict-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.debate-timeline__verdict-reasoning {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+/* ============================================================================
+   Discussion/Debate Viewer — Stance Visualization
+   ============================================================================ */
+
+.stance-viz {
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.stance-viz__title {
   font-size: 12px;
   font-weight: 600;
   color: var(--color-text-secondary);
@@ -1956,6 +2357,43 @@ a:hover {
 }
 
 .cost-breakdown__legend-item {
+.stance-viz__empty {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.stance-viz__scroll {
+  overflow-x: auto;
+}
+
+.stance-viz__svg {
+  display: block;
+}
+
+.stance-viz__header-text {
+  font-size: 11px;
+  fill: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
+.stance-viz__row-label {
+  font-size: 11px;
+  fill: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
+.stance-viz__row-label--da {
+  fill: var(--color-warning);
+}
+
+.stance-viz__legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.stance-viz__legend-item {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -1979,4 +2417,64 @@ a:hover {
   color: var(--color-text-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.stance-viz__legend-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+/* ============================================================================
+   Discussion/Debate Viewer — Consensus Progress
+   ============================================================================ */
+
+.consensus-progress {
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.consensus-progress__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 12px;
+}
+
+.consensus-progress__empty {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.consensus-progress__svg {
+  display: block;
+}
+
+.consensus-progress__bar-label {
+  font-size: 11px;
+  fill: var(--color-text-secondary);
+  font-family: var(--font-sans);
+}
+
+.consensus-progress__pct-label {
+  font-size: 11px;
+  fill: var(--color-text);
+  font-family: var(--font-mono);
+}
+
+.consensus-progress__threshold-label {
+  font-size: 10px;
+  fill: var(--color-warning);
+  font-family: var(--font-mono);
+}
+
+.consensus-progress__result {
+  margin-top: 10px;
 }

--- a/packages/web/src/frontend/utils/discussion-helpers.ts
+++ b/packages/web/src/frontend/utils/discussion-helpers.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure utility functions for the discussion/debate viewer.
+ * Separated from React components so they can be unit-tested in Node environment.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type DiscussionSeverity =
+  | 'HARSHLY_CRITICAL'
+  | 'CRITICAL'
+  | 'WARNING'
+  | 'SUGGESTION'
+  | 'DISMISSED';
+
+type Stance = 'agree' | 'disagree' | 'neutral';
+
+interface DiscussionVerdict {
+  discussionId: string;
+  filePath: string;
+  lineRange: [number, number];
+  finalSeverity: DiscussionSeverity;
+  reasoning: string;
+  consensusReached: boolean;
+  rounds: number;
+}
+
+interface SupporterResponse {
+  supporterId: string;
+  response: string;
+  stance: Stance;
+}
+
+interface DiscussionRound {
+  round: number;
+  moderatorPrompt: string;
+  supporterResponses: SupporterResponse[];
+}
+
+interface StanceCounts {
+  agree: number;
+  disagree: number;
+  neutral: number;
+}
+
+interface StanceProgressionEntry {
+  supporterId: string;
+  stances: Stance[];
+}
+
+interface DiscussionSummary {
+  totalRounds: number;
+  totalSupporters: number;
+  consensusReached: boolean;
+  finalSeverity: DiscussionSeverity;
+  finalConsensusPercentage: number;
+  hasDevilsAdvocate: boolean;
+}
+
+// ============================================================================
+// Severity display maps
+// ============================================================================
+
+const discussionSeverityClassMap: Record<DiscussionSeverity, string> = {
+  HARSHLY_CRITICAL: 'disc-severity--harshly-critical',
+  CRITICAL: 'disc-severity--critical',
+  WARNING: 'disc-severity--warning',
+  SUGGESTION: 'disc-severity--suggestion',
+  DISMISSED: 'disc-severity--dismissed',
+};
+
+const discussionSeverityLabelMap: Record<DiscussionSeverity, string> = {
+  HARSHLY_CRITICAL: 'Harshly Critical',
+  CRITICAL: 'Critical',
+  WARNING: 'Warning',
+  SUGGESTION: 'Suggestion',
+  DISMISSED: 'Dismissed',
+};
+
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+/**
+ * Count agree/disagree/neutral stances in a single round.
+ */
+function getStanceCounts(round: DiscussionRound): StanceCounts {
+  const counts: StanceCounts = { agree: 0, disagree: 0, neutral: 0 };
+
+  for (const response of round.supporterResponses) {
+    counts[response.stance]++;
+  }
+
+  return counts;
+}
+
+/**
+ * Calculate the percentage of agree stances in a round.
+ * Returns 0 for rounds with no supporters.
+ */
+function getConsensusPercentage(round: DiscussionRound): number {
+  const total = round.supporterResponses.length;
+  if (total === 0) return 0;
+
+  const agreeCount = round.supporterResponses.filter(
+    (r) => r.stance === 'agree',
+  ).length;
+
+  return Math.round((agreeCount / total) * 100);
+}
+
+/**
+ * Check if a supporter is a devil's advocate.
+ * Identified by "devil" appearing in the supporter ID (case-insensitive).
+ */
+function isDevilsAdvocate(supporterId: string): boolean {
+  return supporterId.toLowerCase().includes('devil');
+}
+
+/**
+ * Build per-supporter stance progression across all rounds.
+ * Each entry tracks how one supporter's stance changed over rounds.
+ */
+function getStanceProgression(
+  rounds: readonly DiscussionRound[],
+): StanceProgressionEntry[] {
+  if (rounds.length === 0) return [];
+
+  // Collect all unique supporter IDs across all rounds
+  const supporterIds = new Set<string>();
+  for (const round of rounds) {
+    for (const response of round.supporterResponses) {
+      supporterIds.add(response.supporterId);
+    }
+  }
+
+  // Sort rounds by round number
+  const sorted = [...rounds].sort((a, b) => a.round - b.round);
+
+  // Build progression for each supporter
+  const progression: StanceProgressionEntry[] = [];
+
+  for (const supporterId of supporterIds) {
+    const stances: Stance[] = [];
+
+    for (const round of sorted) {
+      const response = round.supporterResponses.find(
+        (r) => r.supporterId === supporterId,
+      );
+      // If supporter didn't participate in a round, default to neutral
+      stances.push(response ? response.stance : 'neutral');
+    }
+
+    progression.push({ supporterId, stances });
+  }
+
+  return progression;
+}
+
+/**
+ * Generate summary statistics for a discussion.
+ */
+function summarizeDiscussion(
+  verdict: DiscussionVerdict,
+  rounds: readonly DiscussionRound[],
+): DiscussionSummary {
+  const sorted = [...rounds].sort((a, b) => a.round - b.round);
+  const lastRound = sorted.length > 0 ? sorted[sorted.length - 1] : null;
+
+  // Collect unique supporter IDs
+  const supporterIds = new Set<string>();
+  for (const round of rounds) {
+    for (const response of round.supporterResponses) {
+      supporterIds.add(response.supporterId);
+    }
+  }
+
+  const hasDevilsAdvocate = [...supporterIds].some((id) =>
+    isDevilsAdvocate(id),
+  );
+
+  const finalConsensusPercentage = lastRound
+    ? getConsensusPercentage(lastRound)
+    : 0;
+
+  return {
+    totalRounds: verdict.rounds,
+    totalSupporters: supporterIds.size,
+    consensusReached: verdict.consensusReached,
+    finalSeverity: verdict.finalSeverity,
+    finalConsensusPercentage,
+    hasDevilsAdvocate,
+  };
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  getStanceCounts,
+  getConsensusPercentage,
+  isDevilsAdvocate,
+  getStanceProgression,
+  summarizeDiscussion,
+  discussionSeverityClassMap,
+  discussionSeverityLabelMap,
+};
+
+export type {
+  DiscussionSeverity,
+  Stance,
+  DiscussionVerdict,
+  SupporterResponse,
+  DiscussionRound,
+  StanceCounts,
+  StanceProgressionEntry,
+  DiscussionSummary,
+};

--- a/packages/web/tests/frontend/discussions.test.ts
+++ b/packages/web/tests/frontend/discussions.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Discussion/Debate Viewer Frontend Tests
+ * Tests utility functions used by the discussion viewer components.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getStanceCounts,
+  getConsensusPercentage,
+  isDevilsAdvocate,
+  getStanceProgression,
+  summarizeDiscussion,
+  discussionSeverityClassMap,
+  discussionSeverityLabelMap,
+} from '../../src/frontend/utils/discussion-helpers.js';
+import type {
+  DiscussionRound,
+  DiscussionVerdict,
+  Stance,
+} from '../../src/frontend/utils/discussion-helpers.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeRound(
+  roundNum: number,
+  stances: Array<{ id: string; stance: Stance }>,
+): DiscussionRound {
+  return {
+    round: roundNum,
+    moderatorPrompt: `Moderator prompt for round ${roundNum}`,
+    supporterResponses: stances.map((s) => ({
+      supporterId: s.id,
+      response: `Response from ${s.id}`,
+      stance: s.stance,
+    })),
+  };
+}
+
+function makeVerdict(overrides: Partial<DiscussionVerdict> = {}): DiscussionVerdict {
+  return {
+    discussionId: 'disc-001',
+    filePath: 'src/main.ts',
+    lineRange: [10, 20],
+    finalSeverity: 'WARNING',
+    reasoning: 'Test reasoning',
+    consensusReached: true,
+    rounds: 3,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// getStanceCounts
+// ============================================================================
+
+describe('getStanceCounts', () => {
+  it('should count agree, disagree, and neutral stances', () => {
+    const round = makeRound(1, [
+      { id: 'r1', stance: 'agree' },
+      { id: 'r2', stance: 'disagree' },
+      { id: 'r3', stance: 'agree' },
+      { id: 'r4', stance: 'neutral' },
+    ]);
+
+    const counts = getStanceCounts(round);
+
+    expect(counts.agree).toBe(2);
+    expect(counts.disagree).toBe(1);
+    expect(counts.neutral).toBe(1);
+  });
+
+  it('should return all zeros for a round with no supporters', () => {
+    const round = makeRound(1, []);
+
+    const counts = getStanceCounts(round);
+
+    expect(counts.agree).toBe(0);
+    expect(counts.disagree).toBe(0);
+    expect(counts.neutral).toBe(0);
+  });
+
+  it('should handle all same stance', () => {
+    const round = makeRound(1, [
+      { id: 'r1', stance: 'agree' },
+      { id: 'r2', stance: 'agree' },
+      { id: 'r3', stance: 'agree' },
+    ]);
+
+    const counts = getStanceCounts(round);
+
+    expect(counts.agree).toBe(3);
+    expect(counts.disagree).toBe(0);
+    expect(counts.neutral).toBe(0);
+  });
+});
+
+// ============================================================================
+// getConsensusPercentage
+// ============================================================================
+
+describe('getConsensusPercentage', () => {
+  it('should calculate percentage of agree stances', () => {
+    const round = makeRound(1, [
+      { id: 'r1', stance: 'agree' },
+      { id: 'r2', stance: 'disagree' },
+      { id: 'r3', stance: 'agree' },
+      { id: 'r4', stance: 'agree' },
+    ]);
+
+    const pct = getConsensusPercentage(round);
+
+    expect(pct).toBe(75);
+  });
+
+  it('should return 0 for an empty round', () => {
+    const round = makeRound(1, []);
+
+    expect(getConsensusPercentage(round)).toBe(0);
+  });
+
+  it('should return 100 when all agree', () => {
+    const round = makeRound(1, [
+      { id: 'r1', stance: 'agree' },
+      { id: 'r2', stance: 'agree' },
+    ]);
+
+    expect(getConsensusPercentage(round)).toBe(100);
+  });
+
+  it('should return 0 when all disagree', () => {
+    const round = makeRound(1, [
+      { id: 'r1', stance: 'disagree' },
+      { id: 'r2', stance: 'disagree' },
+    ]);
+
+    expect(getConsensusPercentage(round)).toBe(0);
+  });
+});
+
+// ============================================================================
+// isDevilsAdvocate
+// ============================================================================
+
+describe('isDevilsAdvocate', () => {
+  it('should detect devil in supporter ID (case-insensitive)', () => {
+    expect(isDevilsAdvocate('devil-advocate-1')).toBe(true);
+    expect(isDevilsAdvocate('DevilsAdvocate')).toBe(true);
+    expect(isDevilsAdvocate('DEVIL_AGENT')).toBe(true);
+  });
+
+  it('should return false for non-devil supporter IDs', () => {
+    expect(isDevilsAdvocate('supporter-1')).toBe(false);
+    expect(isDevilsAdvocate('reviewer-alpha')).toBe(false);
+    expect(isDevilsAdvocate('')).toBe(false);
+  });
+});
+
+// ============================================================================
+// getStanceProgression
+// ============================================================================
+
+describe('getStanceProgression', () => {
+  it('should track stance changes across multiple rounds', () => {
+    const rounds: DiscussionRound[] = [
+      makeRound(1, [
+        { id: 'r1', stance: 'disagree' },
+        { id: 'r2', stance: 'disagree' },
+      ]),
+      makeRound(2, [
+        { id: 'r1', stance: 'neutral' },
+        { id: 'r2', stance: 'agree' },
+      ]),
+      makeRound(3, [
+        { id: 'r1', stance: 'agree' },
+        { id: 'r2', stance: 'agree' },
+      ]),
+    ];
+
+    const progression = getStanceProgression(rounds);
+
+    expect(progression).toHaveLength(2);
+
+    const r1 = progression.find((p) => p.supporterId === 'r1');
+    const r2 = progression.find((p) => p.supporterId === 'r2');
+
+    expect(r1).toBeDefined();
+    expect(r1!.stances).toEqual(['disagree', 'neutral', 'agree']);
+
+    expect(r2).toBeDefined();
+    expect(r2!.stances).toEqual(['disagree', 'agree', 'agree']);
+  });
+
+  it('should return empty array for empty rounds', () => {
+    const progression = getStanceProgression([]);
+
+    expect(progression).toEqual([]);
+  });
+
+  it('should handle single round', () => {
+    const rounds: DiscussionRound[] = [
+      makeRound(1, [
+        { id: 'r1', stance: 'agree' },
+      ]),
+    ];
+
+    const progression = getStanceProgression(rounds);
+
+    expect(progression).toHaveLength(1);
+    expect(progression[0].stances).toEqual(['agree']);
+  });
+
+  it('should default to neutral when supporter missing from a round', () => {
+    const rounds: DiscussionRound[] = [
+      makeRound(1, [
+        { id: 'r1', stance: 'agree' },
+        { id: 'r2', stance: 'disagree' },
+      ]),
+      makeRound(2, [
+        { id: 'r1', stance: 'agree' },
+        // r2 missing from round 2
+      ]),
+    ];
+
+    const progression = getStanceProgression(rounds);
+    const r2 = progression.find((p) => p.supporterId === 'r2');
+
+    expect(r2).toBeDefined();
+    expect(r2!.stances).toEqual(['disagree', 'neutral']);
+  });
+
+  it('should sort rounds by round number', () => {
+    // Provide rounds out of order
+    const rounds: DiscussionRound[] = [
+      makeRound(3, [{ id: 'r1', stance: 'agree' }]),
+      makeRound(1, [{ id: 'r1', stance: 'disagree' }]),
+      makeRound(2, [{ id: 'r1', stance: 'neutral' }]),
+    ];
+
+    const progression = getStanceProgression(rounds);
+
+    expect(progression[0].stances).toEqual(['disagree', 'neutral', 'agree']);
+  });
+});
+
+// ============================================================================
+// summarizeDiscussion
+// ============================================================================
+
+describe('summarizeDiscussion', () => {
+  it('should generate complete summary stats', () => {
+    const verdict = makeVerdict({
+      rounds: 3,
+      consensusReached: true,
+      finalSeverity: 'CRITICAL',
+    });
+
+    const rounds: DiscussionRound[] = [
+      makeRound(1, [
+        { id: 'r1', stance: 'disagree' },
+        { id: 'r2', stance: 'disagree' },
+      ]),
+      makeRound(2, [
+        { id: 'r1', stance: 'agree' },
+        { id: 'r2', stance: 'neutral' },
+      ]),
+      makeRound(3, [
+        { id: 'r1', stance: 'agree' },
+        { id: 'r2', stance: 'agree' },
+      ]),
+    ];
+
+    const summary = summarizeDiscussion(verdict, rounds);
+
+    expect(summary.totalRounds).toBe(3);
+    expect(summary.totalSupporters).toBe(2);
+    expect(summary.consensusReached).toBe(true);
+    expect(summary.finalSeverity).toBe('CRITICAL');
+    expect(summary.finalConsensusPercentage).toBe(100);
+    expect(summary.hasDevilsAdvocate).toBe(false);
+  });
+
+  it('should detect devil advocate supporter', () => {
+    const verdict = makeVerdict();
+    const rounds: DiscussionRound[] = [
+      makeRound(1, [
+        { id: 'devil-advocate-1', stance: 'disagree' },
+        { id: 'reviewer-2', stance: 'agree' },
+      ]),
+    ];
+
+    const summary = summarizeDiscussion(verdict, rounds);
+
+    expect(summary.hasDevilsAdvocate).toBe(true);
+  });
+
+  it('should handle empty rounds', () => {
+    const verdict = makeVerdict({ rounds: 0 });
+    const rounds: DiscussionRound[] = [];
+
+    const summary = summarizeDiscussion(verdict, rounds);
+
+    expect(summary.totalRounds).toBe(0);
+    expect(summary.totalSupporters).toBe(0);
+    expect(summary.finalConsensusPercentage).toBe(0);
+    expect(summary.hasDevilsAdvocate).toBe(false);
+  });
+
+  it('should use last round for final consensus percentage', () => {
+    const verdict = makeVerdict({ rounds: 2 });
+    const rounds: DiscussionRound[] = [
+      makeRound(1, [
+        { id: 'r1', stance: 'disagree' },
+        { id: 'r2', stance: 'disagree' },
+        { id: 'r3', stance: 'agree' },
+      ]),
+      makeRound(2, [
+        { id: 'r1', stance: 'agree' },
+        { id: 'r2', stance: 'agree' },
+        { id: 'r3', stance: 'disagree' },
+      ]),
+    ];
+
+    const summary = summarizeDiscussion(verdict, rounds);
+
+    // Last round: 2 agree out of 3 = 67%
+    expect(summary.finalConsensusPercentage).toBe(67);
+  });
+});
+
+// ============================================================================
+// Severity maps
+// ============================================================================
+
+describe('discussionSeverityMaps', () => {
+  it('should map all severity levels to CSS classes', () => {
+    const severities = [
+      'HARSHLY_CRITICAL',
+      'CRITICAL',
+      'WARNING',
+      'SUGGESTION',
+      'DISMISSED',
+    ] as const;
+
+    for (const severity of severities) {
+      expect(discussionSeverityClassMap[severity]).toBeDefined();
+      expect(discussionSeverityClassMap[severity]).toContain('disc-severity--');
+    }
+  });
+
+  it('should provide human-readable labels for all severities', () => {
+    expect(discussionSeverityLabelMap.HARSHLY_CRITICAL).toBe('Harshly Critical');
+    expect(discussionSeverityLabelMap.CRITICAL).toBe('Critical');
+    expect(discussionSeverityLabelMap.WARNING).toBe('Warning');
+    expect(discussionSeverityLabelMap.SUGGESTION).toBe('Suggestion');
+    expect(discussionSeverityLabelMap.DISMISSED).toBe('Dismissed');
+  });
+});


### PR DESCRIPTION
## Summary
- Round-by-round debate viewer with stance visualization and consensus tracking
- New components: DiscussionList, DebateTimeline, StanceVisualization, ConsensusProgress
- Pure utility functions in `discussion-helpers.ts`
- 20 new tests

## Features
- Session selector with discussion list (filterable by severity/consensus)
- Threaded timeline showing moderator prompts + supporter responses with stance badges
- SVG stance progression grid (rows=supporters, columns=rounds) with DA highlighting
- Consensus percentage bar chart per round with threshold line

## Test Plan
- [x] 20 new tests — all pass

Sprint 7 Feature 5.7 / 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)