### PR TITLE
feat: Sprint 7.8 — config management UI

### DIFF
--- a/packages/web/src/frontend/components/ConfigField.tsx
+++ b/packages/web/src/frontend/components/ConfigField.tsx
@@ -1,0 +1,217 @@
+/**
+ * ConfigField — Generic form field component.
+ * Renders appropriate input based on field type: text, number, boolean, select, array.
+ * Controlled component pattern with label, description, and validation error display.
+ */
+
+import React, { useState, useCallback } from 'react';
+
+type ConfigFieldType = 'text' | 'number' | 'boolean' | 'select' | 'array';
+
+interface ConfigFieldProps {
+  label: string;
+  description?: string;
+  type: ConfigFieldType;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  error?: string | null;
+  options?: readonly string[];
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function ConfigField({
+  label,
+  description,
+  type,
+  value,
+  onChange,
+  error,
+  options,
+  placeholder,
+  disabled = false,
+}: ConfigFieldProps): React.JSX.Element {
+  return (
+    <div className={`config-field ${error ? 'config-field--error' : ''}`}>
+      <label className="config-field__label">
+        {label}
+        {description && <span className="config-field__description">{description}</span>}
+      </label>
+      <div className="config-field__input-wrapper">
+        {renderInput(type, value, onChange, options, placeholder, disabled)}
+      </div>
+      {error && <span className="config-field__error">{error}</span>}
+    </div>
+  );
+}
+
+function renderInput(
+  type: ConfigFieldType,
+  value: unknown,
+  onChange: (value: unknown) => void,
+  options?: readonly string[],
+  placeholder?: string,
+  disabled?: boolean,
+): React.JSX.Element {
+  switch (type) {
+    case 'boolean':
+      return (
+        <ToggleSwitch
+          checked={Boolean(value)}
+          onChange={(checked) => onChange(checked)}
+          disabled={disabled}
+        />
+      );
+
+    case 'number':
+      return (
+        <input
+          className="config-field__input config-field__input--number"
+          type="number"
+          value={value === undefined || value === null ? '' : String(value)}
+          onChange={(e) => onChange(e.target.value === '' ? '' : Number(e.target.value))}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+      );
+
+    case 'select':
+      return (
+        <select
+          className="config-field__select"
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+        >
+          {(options ?? []).map((opt) => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+      );
+
+    case 'array':
+      return (
+        <ArrayField
+          items={Array.isArray(value) ? (value as string[]) : []}
+          onChange={(items) => onChange(items)}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+      );
+
+    default:
+      return (
+        <input
+          className="config-field__input"
+          type="text"
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+      );
+  }
+}
+
+// ============================================================================
+// Toggle Switch Sub-component
+// ============================================================================
+
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+function ToggleSwitch({ checked, onChange, disabled }: ToggleSwitchProps): React.JSX.Element {
+  return (
+    <button
+      className={`toggle-switch ${checked ? 'toggle-switch--on' : ''} ${disabled ? 'toggle-switch--disabled' : ''}`}
+      onClick={() => !disabled && onChange(!checked)}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+    >
+      <span className="toggle-switch__thumb" />
+    </button>
+  );
+}
+
+// ============================================================================
+// Array Field Sub-component
+// ============================================================================
+
+interface ArrayFieldProps {
+  items: string[];
+  onChange: (items: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+function ArrayField({ items, onChange, placeholder, disabled }: ArrayFieldProps): React.JSX.Element {
+  const [newItem, setNewItem] = useState('');
+
+  const handleAdd = useCallback(() => {
+    const trimmed = newItem.trim();
+    if (trimmed && !items.includes(trimmed)) {
+      onChange([...items, trimmed]);
+      setNewItem('');
+    }
+  }, [newItem, items, onChange]);
+
+  const handleRemove = useCallback((index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  }, [items, onChange]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAdd();
+    }
+  }, [handleAdd]);
+
+  return (
+    <div className="array-field">
+      <div className="array-field__items">
+        {items.map((item, index) => (
+          <span key={`${item}-${index}`} className="array-field__tag">
+            {item}
+            {!disabled && (
+              <button
+                className="array-field__tag-remove"
+                onClick={() => handleRemove(index)}
+                type="button"
+                aria-label={`Remove ${item}`}
+              >
+                \u00D7
+              </button>
+            )}
+          </span>
+        ))}
+      </div>
+      {!disabled && (
+        <div className="array-field__add">
+          <input
+            className="config-field__input array-field__input"
+            type="text"
+            value={newItem}
+            onChange={(e) => setNewItem(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder ?? 'Add item...'}
+          />
+          <button
+            className="array-field__add-button"
+            onClick={handleAdd}
+            type="button"
+            disabled={!newItem.trim()}
+          >
+            Add
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type { ConfigFieldType, ConfigFieldProps };

--- a/packages/web/src/frontend/components/ConfigPreview.tsx
+++ b/packages/web/src/frontend/components/ConfigPreview.tsx
@@ -1,0 +1,133 @@
+/**
+ * ConfigPreview — JSON preview of the current config state.
+ * Syntax-highlighted read-only code block with copy to clipboard.
+ */
+
+import React, { useState, useCallback } from 'react';
+
+interface ConfigPreviewProps {
+  config: Record<string, unknown>;
+}
+
+interface TokenSpan {
+  text: string;
+  className: string;
+}
+
+/**
+ * Tokenize a JSON string into spans with syntax class names.
+ * Uses safe React elements instead of innerHTML.
+ */
+function tokenizeLine(line: string): TokenSpan[] {
+  const tokens: TokenSpan[] = [];
+  let remaining = line;
+
+  while (remaining.length > 0) {
+    // Match leading whitespace
+    const wsMatch = remaining.match(/^(\s+)/);
+    if (wsMatch) {
+      tokens.push({ text: wsMatch[1], className: '' });
+      remaining = remaining.slice(wsMatch[1].length);
+      continue;
+    }
+
+    // Match JSON key (quoted string followed by colon)
+    const keyMatch = remaining.match(/^("(?:[^"\\]|\\.)*")(\s*:)/);
+    if (keyMatch) {
+      tokens.push({ text: keyMatch[1], className: 'json-key' });
+      tokens.push({ text: keyMatch[2], className: '' });
+      remaining = remaining.slice(keyMatch[0].length);
+      continue;
+    }
+
+    // Match string value
+    const strMatch = remaining.match(/^("(?:[^"\\]|\\.)*")/);
+    if (strMatch) {
+      tokens.push({ text: strMatch[1], className: 'json-string' });
+      remaining = remaining.slice(strMatch[1].length);
+      continue;
+    }
+
+    // Match number
+    const numMatch = remaining.match(/^(-?\d+\.?\d*)/);
+    if (numMatch) {
+      tokens.push({ text: numMatch[1], className: 'json-number' });
+      remaining = remaining.slice(numMatch[1].length);
+      continue;
+    }
+
+    // Match boolean
+    const boolMatch = remaining.match(/^(true|false)/);
+    if (boolMatch) {
+      tokens.push({ text: boolMatch[1], className: 'json-boolean' });
+      remaining = remaining.slice(boolMatch[1].length);
+      continue;
+    }
+
+    // Match null
+    const nullMatch = remaining.match(/^(null)/);
+    if (nullMatch) {
+      tokens.push({ text: nullMatch[1], className: 'json-null' });
+      remaining = remaining.slice(nullMatch[1].length);
+      continue;
+    }
+
+    // Match structural characters and other text
+    tokens.push({ text: remaining[0], className: '' });
+    remaining = remaining.slice(1);
+  }
+
+  return tokens;
+}
+
+export function ConfigPreview({ config }: ConfigPreviewProps): React.JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const jsonStr = JSON.stringify(config, null, 2);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(jsonStr);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API may not be available
+    }
+  }, [jsonStr]);
+
+  const lines = jsonStr.split('\n');
+
+  return (
+    <div className="config-preview">
+      <div className="config-preview__header">
+        <span className="config-preview__title">JSON Preview</span>
+        <button
+          className="config-preview__copy"
+          onClick={handleCopy}
+          type="button"
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+      <div className="config-preview__code">
+        {lines.map((line, i) => {
+          const tokens = tokenizeLine(line);
+          return (
+            <div key={i} className="json-line">
+              <span className="json-line-number">{i + 1}</span>
+              <span>
+                {tokens.map((token, j) => (
+                  token.className
+                    ? <span key={j} className={token.className}>{token.text}</span>
+                    : <span key={j}>{token.text}</span>
+                ))}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export type { ConfigPreviewProps };

--- a/packages/web/src/frontend/components/ConfigSection.tsx
+++ b/packages/web/src/frontend/components/ConfigSection.tsx
@@ -1,0 +1,48 @@
+/**
+ * ConfigSection — Collapsible config section with title and description.
+ * Used to organize the config form into logical groups.
+ */
+
+import React, { useState } from 'react';
+
+interface ConfigSectionProps {
+  title: string;
+  description: string;
+  defaultExpanded?: boolean;
+  children: React.ReactNode;
+}
+
+export function ConfigSection({
+  title,
+  description,
+  defaultExpanded = false,
+  children,
+}: ConfigSectionProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className={`config-section ${expanded ? 'config-section--expanded' : ''}`}>
+      <button
+        className="config-section__header"
+        onClick={() => setExpanded(!expanded)}
+        type="button"
+        aria-expanded={expanded}
+      >
+        <div className="config-section__header-left">
+          <span className="config-section__toggle">{expanded ? '\u25BC' : '\u25B6'}</span>
+          <div>
+            <h3 className="config-section__title">{title}</h3>
+            <p className="config-section__description">{description}</p>
+          </div>
+        </div>
+      </button>
+      {expanded && (
+        <div className="config-section__body">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type { ConfigSectionProps };

--- a/packages/web/src/frontend/components/ReviewerEditor.tsx
+++ b/packages/web/src/frontend/components/ReviewerEditor.tsx
@@ -1,0 +1,130 @@
+/**
+ * ReviewerEditor — Reviewer list editor component.
+ * Manages a list of reviewer (AgentConfig) entries with add/remove/edit capabilities.
+ * Compact card layout per reviewer.
+ */
+
+import React, { useCallback } from 'react';
+import type { AgentConfig } from '../utils/config-helpers.js';
+
+const BACKEND_OPTIONS = ['api', 'opencode', 'codex', 'gemini', 'claude', 'copilot'] as const;
+
+interface ReviewerEditorProps {
+  reviewers: AgentConfig[];
+  onChange: (reviewers: AgentConfig[]) => void;
+}
+
+export function ReviewerEditor({ reviewers, onChange }: ReviewerEditorProps): React.JSX.Element {
+  const handleAdd = useCallback(() => {
+    const newReviewer: AgentConfig = {
+      id: `reviewer-${Date.now()}`,
+      model: '',
+      backend: 'api',
+      timeout: 120,
+      enabled: true,
+    };
+    onChange([...reviewers, newReviewer]);
+  }, [reviewers, onChange]);
+
+  const handleRemove = useCallback((index: number) => {
+    onChange(reviewers.filter((_, i) => i !== index));
+  }, [reviewers, onChange]);
+
+  const handleUpdate = useCallback((index: number, field: keyof AgentConfig, value: unknown) => {
+    const updated = reviewers.map((r, i) => {
+      if (i !== index) return r;
+      return { ...r, [field]: value };
+    });
+    onChange(updated);
+  }, [reviewers, onChange]);
+
+  return (
+    <div className="reviewer-editor">
+      <div className="reviewer-editor__list">
+        {reviewers.map((reviewer, index) => (
+          <div key={reviewer.id} className="reviewer-card">
+            <div className="reviewer-card__header">
+              <span className="reviewer-card__id">{reviewer.id}</span>
+              <div className="reviewer-card__actions">
+                <button
+                  className={`reviewer-card__toggle ${reviewer.enabled ? 'reviewer-card__toggle--on' : ''}`}
+                  onClick={() => handleUpdate(index, 'enabled', !reviewer.enabled)}
+                  type="button"
+                  title={reviewer.enabled ? 'Disable' : 'Enable'}
+                >
+                  {reviewer.enabled ? 'ON' : 'OFF'}
+                </button>
+                <button
+                  className="reviewer-card__remove"
+                  onClick={() => handleRemove(index)}
+                  type="button"
+                  aria-label="Remove reviewer"
+                >
+                  \u00D7
+                </button>
+              </div>
+            </div>
+            <div className="reviewer-card__fields">
+              <div className="reviewer-card__field">
+                <label className="reviewer-card__label">ID</label>
+                <input
+                  className="reviewer-card__input"
+                  type="text"
+                  value={reviewer.id}
+                  onChange={(e) => handleUpdate(index, 'id', e.target.value)}
+                />
+              </div>
+              <div className="reviewer-card__field">
+                <label className="reviewer-card__label">Model</label>
+                <input
+                  className="reviewer-card__input"
+                  type="text"
+                  value={reviewer.model}
+                  onChange={(e) => handleUpdate(index, 'model', e.target.value)}
+                  placeholder="e.g. gpt-4"
+                />
+              </div>
+              <div className="reviewer-card__field">
+                <label className="reviewer-card__label">Backend</label>
+                <select
+                  className="reviewer-card__select"
+                  value={reviewer.backend}
+                  onChange={(e) => handleUpdate(index, 'backend', e.target.value)}
+                >
+                  {BACKEND_OPTIONS.map((opt) => (
+                    <option key={opt} value={opt}>{opt}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="reviewer-card__field">
+                <label className="reviewer-card__label">Provider</label>
+                <input
+                  className="reviewer-card__input"
+                  type="text"
+                  value={reviewer.provider ?? ''}
+                  onChange={(e) => handleUpdate(index, 'provider', e.target.value || undefined)}
+                  placeholder="optional"
+                />
+              </div>
+              <div className="reviewer-card__field">
+                <label className="reviewer-card__label">Timeout (s)</label>
+                <input
+                  className="reviewer-card__input reviewer-card__input--number"
+                  type="number"
+                  value={reviewer.timeout}
+                  onChange={(e) => handleUpdate(index, 'timeout', Number(e.target.value))}
+                  min={0}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <button className="reviewer-editor__add" onClick={handleAdd} type="button">
+        + Add Reviewer
+      </button>
+    </div>
+  );
+}
+
+export type { ReviewerEditorProps };

--- a/packages/web/src/frontend/components/Toast.tsx
+++ b/packages/web/src/frontend/components/Toast.tsx
@@ -1,0 +1,33 @@
+/**
+ * Toast — Notification component for success/error messages.
+ * Auto-dismisses after 3 seconds. Fixed position bottom-right with slide-in animation.
+ */
+
+import React, { useEffect } from 'react';
+
+type ToastType = 'success' | 'error';
+
+interface ToastProps {
+  message: string;
+  type: ToastType;
+  onDismiss: () => void;
+}
+
+export function Toast({ message, type, onDismiss }: ToastProps): React.JSX.Element {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 3000);
+    return () => clearTimeout(timer);
+  }, [onDismiss]);
+
+  return (
+    <div className={`toast toast--${type}`} role="alert">
+      <span className="toast__icon">{type === 'success' ? '\u2713' : '\u2717'}</span>
+      <span className="toast__message">{message}</span>
+      <button className="toast__close" onClick={onDismiss} type="button" aria-label="Dismiss">
+        \u00D7
+      </button>
+    </div>
+  );
+}
+
+export type { ToastType, ToastProps };

--- a/packages/web/src/frontend/pages/Config.tsx
+++ b/packages/web/src/frontend/pages/Config.tsx
@@ -1,10 +1,497 @@
-import React from 'react';
+/**
+ * ConfigPage — Config management page.
+ * Form-based editor organized by sections with save, validation, and JSON preview.
+ */
+
+import React, { useState, useCallback, useEffect } from 'react';
+import { useApi } from '../hooks/useApi.js';
+import { ConfigSection } from '../components/ConfigSection.js';
+import { ConfigField } from '../components/ConfigField.js';
+import { ReviewerEditor } from '../components/ReviewerEditor.js';
+import { ConfigPreview } from '../components/ConfigPreview.js';
+import { Toast } from '../components/Toast.js';
+import type { ToastType } from '../components/Toast.js';
+import { validateConfigField, getDefaultConfig } from '../utils/config-helpers.js';
+import type { AgentConfig } from '../utils/config-helpers.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ToastState {
+  message: string;
+  type: ToastType;
+}
+
+interface ConfigData {
+  mode?: string;
+  language?: string;
+  reviewers: AgentConfig[];
+  supporters: {
+    pool: AgentConfig[];
+    pickCount: number;
+    pickStrategy: string;
+    devilsAdvocate: AgentConfig;
+    personaPool: string[];
+    personaAssignment: string;
+  };
+  moderator: { backend: string; model: string; provider?: string };
+  head?: { backend: string; model: string; provider?: string; enabled: boolean };
+  discussion: {
+    maxRounds: number;
+    registrationThreshold: {
+      HARSHLY_CRITICAL: number;
+      CRITICAL: number;
+      WARNING: number;
+      SUGGESTION: null;
+    };
+    codeSnippetRange: number;
+  };
+  errorHandling: { maxRetries: number; forfeitThreshold: number };
+  chunking?: { maxTokens: number };
+  notifications?: {
+    discord?: { webhookUrl: string };
+    slack?: { webhookUrl: string };
+    autoNotify?: boolean;
+  };
+  github?: {
+    humanReviewers: string[];
+    humanTeams: string[];
+    needsHumanLabel: string;
+    postSuggestions: boolean;
+    collapseDiscussions: boolean;
+    sarifOutputPath?: string;
+  };
+  autoApprove?: {
+    enabled: boolean;
+    maxLines: number;
+    allowedFilePatterns: string[];
+  };
+}
+
+// ============================================================================
+// Helper: deep update a nested field
+// ============================================================================
+
+function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): Record<string, unknown> {
+  const parts = path.split('.');
+  const result = { ...obj };
+  let current: Record<string, unknown> = result;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    current[part] = { ...(current[part] as Record<string, unknown> ?? {}) };
+    current = current[part] as Record<string, unknown>;
+  }
+
+  current[parts[parts.length - 1]] = value;
+  return result;
+}
+
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current;
+}
+
+// ============================================================================
+// Page Component
+// ============================================================================
 
 export function ConfigPage(): React.JSX.Element {
+  const { data: serverConfig, loading, error, refetch } = useApi<ConfigData>('/api/config');
+  const [config, setConfig] = useState<Record<string, unknown>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+
+  // Sync server config into local state
+  useEffect(() => {
+    if (serverConfig && !initialized) {
+      setConfig(serverConfig as unknown as Record<string, unknown>);
+      setInitialized(true);
+    }
+  }, [serverConfig, initialized]);
+
+  // When there's no config (404), use defaults
+  useEffect(() => {
+    if (!loading && error && error.includes('404') && !initialized) {
+      setConfig(getDefaultConfig() as unknown as Record<string, unknown>);
+      setInitialized(true);
+    }
+  }, [loading, error, initialized]);
+
+  const updateField = useCallback((path: string, value: unknown) => {
+    setConfig((prev) => setNestedValue(prev, path, value));
+
+    // Validate the field
+    const fieldName = path.split('.').pop() ?? path;
+    const validationError = validateConfigField(fieldName, value);
+    setErrors((prev) => {
+      const next = { ...prev };
+      if (validationError) {
+        next[path] = validationError;
+      } else {
+        delete next[path];
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const response = await fetch('/api/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({})) as Record<string, unknown>;
+        const details = body.details;
+        let message = 'Failed to save configuration';
+        if (details && Array.isArray(details) && details.length > 0) {
+          const firstIssue = details[0] as Record<string, unknown>;
+          message = `Validation error: ${String(firstIssue.message ?? '')}`;
+        }
+        setToast({ message, type: 'error' });
+      } else {
+        setToast({ message: 'Configuration saved successfully', type: 'success' });
+        refetch();
+      }
+    } catch (err: unknown) {
+      setToast({
+        message: err instanceof Error ? err.message : 'Failed to save configuration',
+        type: 'error',
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [config, refetch]);
+
+  if (loading && !initialized) {
+    return (
+      <div className="page">
+        <h2>Configuration</h2>
+        <p>Loading configuration...</p>
+      </div>
+    );
+  }
+
+  if (error && !error.includes('404') && !initialized) {
+    return (
+      <div className="page">
+        <h2>Configuration</h2>
+        <p className="error-text">Error: {error}</p>
+        <button onClick={refetch} type="button" className="retry-button">Retry</button>
+      </div>
+    );
+  }
+
+  const hasErrors = Object.keys(errors).length > 0;
+  const reviewers = (getNestedValue(config, 'reviewers') as AgentConfig[] | undefined) ?? [];
+
   return (
     <div className="page">
-      <h2>Config</h2>
-      <p>Coming soon</p>
+      <div className="page-header">
+        <h2>Configuration</h2>
+        <div className="config-actions">
+          <button
+            className={`config-preview-toggle ${showPreview ? 'config-preview-toggle--active' : ''}`}
+            onClick={() => setShowPreview(!showPreview)}
+            type="button"
+          >
+            {showPreview ? 'Hide JSON' : 'Show JSON'}
+          </button>
+          <button
+            className="config-save-button"
+            onClick={handleSave}
+            type="button"
+            disabled={saving || hasErrors}
+          >
+            {saving ? 'Saving...' : 'Save Configuration'}
+          </button>
+        </div>
+      </div>
+
+      {showPreview && <ConfigPreview config={config} />}
+
+      {/* General Section */}
+      <ConfigSection title="General" description="Mode and language settings" defaultExpanded>
+        <div className="config-fields-grid">
+          <ConfigField
+            label="Mode"
+            description="Review strictness level"
+            type="select"
+            value={getNestedValue(config, 'mode') ?? 'pragmatic'}
+            onChange={(v) => updateField('mode', v)}
+            options={['strict', 'pragmatic']}
+            error={errors['mode']}
+          />
+          <ConfigField
+            label="Language"
+            description="Output language"
+            type="select"
+            value={getNestedValue(config, 'language') ?? 'en'}
+            onChange={(v) => updateField('language', v)}
+            options={['en', 'ko']}
+            error={errors['language']}
+          />
+        </div>
+      </ConfigSection>
+
+      {/* Reviewers Section */}
+      <ConfigSection title="Reviewers" description="Configure reviewer models and backends">
+        <ReviewerEditor
+          reviewers={reviewers}
+          onChange={(r) => updateField('reviewers', r)}
+        />
+      </ConfigSection>
+
+      {/* Supporters Section */}
+      <ConfigSection title="Supporters" description="Discussion supporter pool configuration">
+        <div className="config-fields-grid">
+          <ConfigField
+            label="Pick Count"
+            description="Number of supporters to select per discussion"
+            type="number"
+            value={getNestedValue(config, 'supporters.pickCount') ?? 2}
+            onChange={(v) => updateField('supporters.pickCount', v)}
+            error={errors['supporters.pickCount']}
+          />
+          <ConfigField
+            label="Pick Strategy"
+            description="How to select supporters"
+            type="select"
+            value={getNestedValue(config, 'supporters.pickStrategy') ?? 'random'}
+            onChange={(v) => updateField('supporters.pickStrategy', v)}
+            options={['random', 'round-robin']}
+            error={errors['supporters.pickStrategy']}
+          />
+          <ConfigField
+            label="Persona Assignment"
+            description="How personas are assigned to supporters"
+            type="select"
+            value={getNestedValue(config, 'supporters.personaAssignment') ?? 'random'}
+            onChange={(v) => updateField('supporters.personaAssignment', v)}
+            options={['random', 'fixed']}
+            error={errors['supporters.personaAssignment']}
+          />
+          <ConfigField
+            label="Persona Pool"
+            description="Available personas for supporters"
+            type="array"
+            value={getNestedValue(config, 'supporters.personaPool') ?? []}
+            onChange={(v) => updateField('supporters.personaPool', v)}
+            placeholder="Add persona..."
+          />
+        </div>
+      </ConfigSection>
+
+      {/* Discussion Section */}
+      <ConfigSection title="Discussion" description="Discussion rounds and thresholds">
+        <div className="config-fields-grid">
+          <ConfigField
+            label="Max Rounds"
+            description="Maximum discussion rounds"
+            type="number"
+            value={getNestedValue(config, 'discussion.maxRounds') ?? 3}
+            onChange={(v) => updateField('discussion.maxRounds', v)}
+            error={errors['discussion.maxRounds']}
+          />
+          <ConfigField
+            label="Code Snippet Range"
+            description="Lines of context around code snippets"
+            type="number"
+            value={getNestedValue(config, 'discussion.codeSnippetRange') ?? 5}
+            onChange={(v) => updateField('discussion.codeSnippetRange', v)}
+            error={errors['discussion.codeSnippetRange']}
+          />
+          <ConfigField
+            label="Harshly Critical Threshold"
+            description="Registration threshold (0-1)"
+            type="number"
+            value={getNestedValue(config, 'discussion.registrationThreshold.HARSHLY_CRITICAL') ?? 0.3}
+            onChange={(v) => updateField('discussion.registrationThreshold.HARSHLY_CRITICAL', v)}
+            error={errors['discussion.registrationThreshold.HARSHLY_CRITICAL']}
+          />
+          <ConfigField
+            label="Critical Threshold"
+            description="Registration threshold (0-1)"
+            type="number"
+            value={getNestedValue(config, 'discussion.registrationThreshold.CRITICAL') ?? 0.5}
+            onChange={(v) => updateField('discussion.registrationThreshold.CRITICAL', v)}
+            error={errors['discussion.registrationThreshold.CRITICAL']}
+          />
+          <ConfigField
+            label="Warning Threshold"
+            description="Registration threshold (0-1)"
+            type="number"
+            value={getNestedValue(config, 'discussion.registrationThreshold.WARNING') ?? 0.7}
+            onChange={(v) => updateField('discussion.registrationThreshold.WARNING', v)}
+            error={errors['discussion.registrationThreshold.WARNING']}
+          />
+        </div>
+      </ConfigSection>
+
+      {/* Error Handling Section */}
+      <ConfigSection title="Error Handling" description="Retry and failure thresholds">
+        <div className="config-fields-grid">
+          <ConfigField
+            label="Max Retries"
+            description="Maximum retry attempts"
+            type="number"
+            value={getNestedValue(config, 'errorHandling.maxRetries') ?? 3}
+            onChange={(v) => updateField('errorHandling.maxRetries', v)}
+            error={errors['errorHandling.maxRetries']}
+          />
+          <ConfigField
+            label="Forfeit Threshold"
+            description="Failures before forfeiting"
+            type="number"
+            value={getNestedValue(config, 'errorHandling.forfeitThreshold') ?? 2}
+            onChange={(v) => updateField('errorHandling.forfeitThreshold', v)}
+            error={errors['errorHandling.forfeitThreshold']}
+          />
+          <ConfigField
+            label="Max Tokens (Chunking)"
+            description="Maximum tokens per chunk"
+            type="number"
+            value={getNestedValue(config, 'chunking.maxTokens') ?? 8000}
+            onChange={(v) => updateField('chunking.maxTokens', v)}
+            error={errors['chunking.maxTokens']}
+          />
+        </div>
+      </ConfigSection>
+
+      {/* Notifications Section */}
+      <ConfigSection title="Notifications" description="Discord and Slack webhook settings">
+        <div className="config-fields-grid">
+          <ConfigField
+            label="Auto Notify"
+            description="Automatically send notifications after review"
+            type="boolean"
+            value={getNestedValue(config, 'notifications.autoNotify') ?? false}
+            onChange={(v) => updateField('notifications.autoNotify', v)}
+          />
+          <ConfigField
+            label="Discord Webhook URL"
+            description="Discord notification webhook"
+            type="text"
+            value={getNestedValue(config, 'notifications.discord.webhookUrl') ?? ''}
+            onChange={(v) => updateField('notifications.discord.webhookUrl', v)}
+            placeholder="https://discord.com/api/webhooks/..."
+            error={errors['notifications.discord.webhookUrl']}
+          />
+          <ConfigField
+            label="Slack Webhook URL"
+            description="Slack notification webhook"
+            type="text"
+            value={getNestedValue(config, 'notifications.slack.webhookUrl') ?? ''}
+            onChange={(v) => updateField('notifications.slack.webhookUrl', v)}
+            placeholder="https://hooks.slack.com/services/..."
+            error={errors['notifications.slack.webhookUrl']}
+          />
+        </div>
+      </ConfigSection>
+
+      {/* GitHub Section */}
+      <ConfigSection title="GitHub" description="GitHub integration settings">
+        <div className="config-fields-grid">
+          <ConfigField
+            label="Post Suggestions"
+            description="Post review suggestions as GitHub comments"
+            type="boolean"
+            value={getNestedValue(config, 'github.postSuggestions') ?? true}
+            onChange={(v) => updateField('github.postSuggestions', v)}
+          />
+          <ConfigField
+            label="Collapse Discussions"
+            description="Collapse discussion details in PR comments"
+            type="boolean"
+            value={getNestedValue(config, 'github.collapseDiscussions') ?? true}
+            onChange={(v) => updateField('github.collapseDiscussions', v)}
+          />
+          <ConfigField
+            label="Needs Human Label"
+            description="Label for PRs requiring human review"
+            type="text"
+            value={getNestedValue(config, 'github.needsHumanLabel') ?? 'needs-human-review'}
+            onChange={(v) => updateField('github.needsHumanLabel', v)}
+            error={errors['github.needsHumanLabel']}
+          />
+          <ConfigField
+            label="Human Reviewers"
+            description="GitHub usernames for human review assignment"
+            type="array"
+            value={getNestedValue(config, 'github.humanReviewers') ?? []}
+            onChange={(v) => updateField('github.humanReviewers', v)}
+            placeholder="Add GitHub username..."
+          />
+          <ConfigField
+            label="Human Teams"
+            description="GitHub teams for human review assignment"
+            type="array"
+            value={getNestedValue(config, 'github.humanTeams') ?? []}
+            onChange={(v) => updateField('github.humanTeams', v)}
+            placeholder="Add GitHub team..."
+          />
+          <ConfigField
+            label="SARIF Output Path"
+            description="Path for SARIF report output"
+            type="text"
+            value={getNestedValue(config, 'github.sarifOutputPath') ?? ''}
+            onChange={(v) => updateField('github.sarifOutputPath', v)}
+            placeholder="e.g. results.sarif"
+          />
+        </div>
+      </ConfigSection>
+
+      {/* Auto-Approve Section */}
+      <ConfigSection title="Auto-Approve" description="Automatic approval for low-risk changes">
+        <div className="config-fields-grid">
+          <ConfigField
+            label="Enabled"
+            description="Enable auto-approval"
+            type="boolean"
+            value={getNestedValue(config, 'autoApprove.enabled') ?? false}
+            onChange={(v) => updateField('autoApprove.enabled', v)}
+          />
+          <ConfigField
+            label="Max Lines"
+            description="Maximum changed lines for auto-approval"
+            type="number"
+            value={getNestedValue(config, 'autoApprove.maxLines') ?? 50}
+            onChange={(v) => updateField('autoApprove.maxLines', v)}
+            error={errors['autoApprove.maxLines']}
+          />
+          <ConfigField
+            label="Allowed File Patterns"
+            description="Glob patterns eligible for auto-approval"
+            type="array"
+            value={getNestedValue(config, 'autoApprove.allowedFilePatterns') ?? []}
+            onChange={(v) => updateField('autoApprove.allowedFilePatterns', v)}
+            placeholder="e.g. *.md, *.txt"
+          />
+        </div>
+      </ConfigSection>
+
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onDismiss={() => setToast(null)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web/src/frontend/styles/globals.css
+++ b/packages/web/src/frontend/styles/globals.css
@@ -2478,3 +2478,638 @@ a:hover {
 .consensus-progress__result {
   margin-top: 10px;
 }
+
+/* ============================================================================
+   Config Management UI
+   ============================================================================ */
+
+/* Config Actions Bar */
+
+.config-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-left: auto;
+}
+
+.config-save-button {
+  padding: 6px 20px;
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.config-save-button:hover {
+  background-color: var(--color-accent-hover);
+}
+
+.config-save-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.config-preview-toggle {
+  padding: 6px 14px;
+  background: none;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.config-preview-toggle:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-secondary);
+}
+
+.config-preview-toggle--active {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+/* ============================================================================
+   Config Section (Collapsible)
+   ============================================================================ */
+
+.config-section {
+  margin-bottom: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: var(--color-bg-secondary);
+}
+
+.config-section__header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 14px 16px;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  text-align: left;
+  transition: background-color 0.15s;
+}
+
+.config-section__header:hover {
+  background-color: var(--color-bg-tertiary);
+}
+
+.config-section__header-left {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.config-section__toggle {
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+
+.config-section__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 2px;
+}
+
+.config-section__description {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.config-section__body {
+  padding: 16px;
+  border-top: 1px solid var(--color-border);
+}
+
+/* ============================================================================
+   Config Fields Grid
+   ============================================================================ */
+
+.config-fields-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 700px) {
+  .config-fields-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============================================================================
+   Config Field
+   ============================================================================ */
+
+.config-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.config-field__label {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.config-field__description {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+}
+
+.config-field__input-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.config-field__input {
+  padding: 6px 10px;
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.config-field__input:focus {
+  border-color: var(--color-accent);
+}
+
+.config-field__input::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.config-field__input--number {
+  width: 120px;
+  font-family: var(--font-mono);
+}
+
+.config-field__select {
+  padding: 6px 10px;
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.config-field__select:focus {
+  border-color: var(--color-accent);
+}
+
+.config-field__error {
+  font-size: 11px;
+  color: var(--color-error);
+  margin-top: 2px;
+}
+
+.config-field--error .config-field__input,
+.config-field--error .config-field__select {
+  border-color: var(--color-error);
+}
+
+/* ============================================================================
+   Toggle Switch
+   ============================================================================ */
+
+.toggle-switch {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: 11px;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+  padding: 0;
+}
+
+.toggle-switch--on {
+  background-color: rgba(63, 185, 80, 0.3);
+  border-color: var(--color-success);
+}
+
+.toggle-switch__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background-color: var(--color-text-secondary);
+  border-radius: 50%;
+  transition: transform 0.2s, background-color 0.2s;
+}
+
+.toggle-switch--on .toggle-switch__thumb {
+  transform: translateX(18px);
+  background-color: var(--color-success);
+}
+
+.toggle-switch--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ============================================================================
+   Array Field
+   ============================================================================ */
+
+.array-field__items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.array-field__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--color-text);
+}
+
+.array-field__tag-remove {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.array-field__tag-remove:hover {
+  color: var(--color-error);
+}
+
+.array-field__add {
+  display: flex;
+  gap: 6px;
+}
+
+.array-field__input {
+  flex: 1;
+}
+
+.array-field__add-button {
+  padding: 6px 12px;
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.array-field__add-button:hover {
+  background-color: var(--color-border);
+}
+
+.array-field__add-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ============================================================================
+   Reviewer Editor
+   ============================================================================ */
+
+.reviewer-editor__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.reviewer-editor__add {
+  padding: 8px 16px;
+  background: none;
+  color: var(--color-accent);
+  border: 1px dashed var(--color-accent);
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  width: 100%;
+}
+
+.reviewer-editor__add:hover {
+  background-color: rgba(88, 166, 255, 0.08);
+}
+
+.reviewer-card {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 12px;
+  background-color: var(--color-bg-tertiary);
+}
+
+.reviewer-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.reviewer-card__id {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.reviewer-card__actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.reviewer-card__toggle {
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  border: none;
+  cursor: pointer;
+  background-color: rgba(248, 81, 73, 0.15);
+  color: var(--color-error);
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.reviewer-card__toggle--on {
+  background-color: rgba(63, 185, 80, 0.15);
+  color: var(--color-success);
+}
+
+.reviewer-card__remove {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  border-radius: 4px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 14px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.reviewer-card__remove:hover {
+  color: var(--color-error);
+  border-color: var(--color-error);
+}
+
+.reviewer-card__fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+
+@media (max-width: 700px) {
+  .reviewer-card__fields {
+    grid-template-columns: 1fr;
+  }
+}
+
+.reviewer-card__field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.reviewer-card__label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.reviewer-card__input {
+  padding: 4px 8px;
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.reviewer-card__input:focus {
+  border-color: var(--color-accent);
+}
+
+.reviewer-card__input::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.reviewer-card__input--number {
+  width: 80px;
+}
+
+.reviewer-card__select {
+  padding: 4px 8px;
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  outline: none;
+  cursor: pointer;
+}
+
+.reviewer-card__select:focus {
+  border-color: var(--color-accent);
+}
+
+/* ============================================================================
+   Config JSON Preview
+   ============================================================================ */
+
+.config-preview {
+  margin-bottom: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: var(--color-bg-secondary);
+}
+
+.config-preview__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background-color: var(--color-bg-tertiary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.config-preview__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.config-preview__copy {
+  padding: 3px 10px;
+  background: none;
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  border-radius: 4px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.config-preview__copy:hover {
+  background-color: rgba(88, 166, 255, 0.1);
+}
+
+.config-preview__code {
+  padding: 12px;
+  max-height: 400px;
+  overflow-y: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.json-line {
+  display: flex;
+  gap: 12px;
+}
+
+.json-line-number {
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+  user-select: none;
+  min-width: 28px;
+  text-align: right;
+}
+
+.json-key {
+  color: var(--color-accent);
+}
+
+.json-string {
+  color: var(--color-success);
+}
+
+.json-number {
+  color: var(--color-warning);
+}
+
+.json-boolean {
+  color: #bc6bff;
+}
+
+.json-null {
+  color: var(--color-text-secondary);
+}
+
+/* ============================================================================
+   Toast Notification
+   ============================================================================ */
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  animation: toast-slide-in 0.3s ease-out;
+}
+
+.toast--success {
+  background-color: rgba(63, 185, 80, 0.15);
+  border: 1px solid rgba(63, 185, 80, 0.4);
+  color: var(--color-success);
+}
+
+.toast--error {
+  background-color: rgba(248, 81, 73, 0.15);
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  color: var(--color-error);
+}
+
+.toast__icon {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.toast__message {
+  flex: 1;
+}
+
+.toast__close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+
+.toast__close:hover {
+  opacity: 1;
+}
+
+@keyframes toast-slide-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}

--- a/packages/web/src/frontend/utils/config-helpers.ts
+++ b/packages/web/src/frontend/utils/config-helpers.ts
@@ -1,0 +1,343 @@
+/**
+ * Pure utility functions for the config management UI.
+ * Separated from React components so they can be unit-tested in Node environment.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type FieldType = 'text' | 'number' | 'boolean' | 'select' | 'array' | 'object';
+
+interface FieldValidationError {
+  field: string;
+  message: string;
+}
+
+interface ConfigDiff {
+  path: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+interface AgentConfig {
+  id: string;
+  label?: string;
+  model: string;
+  backend: 'opencode' | 'codex' | 'gemini' | 'claude' | 'copilot' | 'api';
+  provider?: string;
+  persona?: string;
+  timeout: number;
+  enabled: boolean;
+}
+
+interface DefaultConfig {
+  mode: 'pragmatic';
+  language: 'en';
+  reviewers: AgentConfig[];
+  supporters: {
+    pool: AgentConfig[];
+    pickCount: number;
+    pickStrategy: 'random';
+    devilsAdvocate: AgentConfig;
+    personaPool: string[];
+    personaAssignment: 'random';
+  };
+  moderator: { backend: string; model: string };
+  head: { backend: string; model: string; enabled: boolean };
+  discussion: {
+    maxRounds: number;
+    registrationThreshold: {
+      HARSHLY_CRITICAL: number;
+      CRITICAL: number;
+      WARNING: number;
+      SUGGESTION: null;
+    };
+    codeSnippetRange: number;
+  };
+  errorHandling: { maxRetries: number; forfeitThreshold: number };
+  chunking: { maxTokens: number };
+  notifications: { autoNotify: boolean };
+  github: {
+    humanReviewers: string[];
+    humanTeams: string[];
+    needsHumanLabel: string;
+    postSuggestions: boolean;
+    collapseDiscussions: boolean;
+  };
+  autoApprove: { enabled: boolean; maxLines: number; allowedFilePatterns: string[] };
+}
+
+// ============================================================================
+// Field type inference
+// ============================================================================
+
+/**
+ * Infer the field type from a runtime value.
+ */
+function getFieldType(value: unknown): FieldType {
+  if (value === null || value === undefined) return 'text';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'number') return 'number';
+  if (Array.isArray(value)) return 'array';
+  if (typeof value === 'object') return 'object';
+  return 'text';
+}
+
+// ============================================================================
+// Field validation
+// ============================================================================
+
+/**
+ * Validate a single config field value.
+ * Returns an error message string, or null if valid.
+ */
+function validateConfigField(field: string, value: unknown): string | null {
+  // Required field check — empty strings are invalid for most fields
+  if (value === '' || value === undefined || value === null) {
+    // Some fields are optional
+    const optionalFields = ['provider', 'label', 'persona', 'sarifOutputPath'];
+    if (optionalFields.includes(field)) return null;
+    return `${field} is required`;
+  }
+
+  // Number fields must be positive
+  const numberFields = [
+    'timeout', 'maxRounds', 'maxRetries', 'forfeitThreshold',
+    'codeSnippetRange', 'pickCount', 'maxTokens', 'maxLines',
+  ];
+  if (numberFields.includes(field)) {
+    const num = typeof value === 'number' ? value : Number(value);
+    if (isNaN(num)) return `${field} must be a number`;
+    if (num < 0) return `${field} must be non-negative`;
+    // Integer check for certain fields
+    const integerFields = ['maxRounds', 'maxRetries', 'pickCount', 'maxLines', 'codeSnippetRange'];
+    if (integerFields.includes(field) && !Number.isInteger(num)) {
+      return `${field} must be an integer`;
+    }
+  }
+
+  // Threshold fields allow specific number values or null
+  const thresholdFields = ['HARSHLY_CRITICAL', 'CRITICAL', 'WARNING'];
+  if (thresholdFields.includes(field)) {
+    if (typeof value === 'number') {
+      if (value < 0 || value > 1) return `${field} must be between 0 and 1`;
+    }
+  }
+
+  // Backend must be one of the allowed values
+  if (field === 'backend') {
+    const allowed = ['opencode', 'codex', 'gemini', 'claude', 'copilot', 'api'];
+    if (typeof value === 'string' && !allowed.includes(value)) {
+      return `${field} must be one of: ${allowed.join(', ')}`;
+    }
+  }
+
+  // Mode must be strict or pragmatic
+  if (field === 'mode') {
+    if (typeof value === 'string' && !['strict', 'pragmatic'].includes(value)) {
+      return `${field} must be "strict" or "pragmatic"`;
+    }
+  }
+
+  // Language must be en or ko
+  if (field === 'language') {
+    if (typeof value === 'string' && !['en', 'ko'].includes(value)) {
+      return `${field} must be "en" or "ko"`;
+    }
+  }
+
+  // Pick strategy
+  if (field === 'pickStrategy') {
+    if (typeof value === 'string' && !['random', 'round-robin'].includes(value)) {
+      return `${field} must be "random" or "round-robin"`;
+    }
+  }
+
+  // Persona assignment
+  if (field === 'personaAssignment') {
+    if (typeof value === 'string' && !['random', 'fixed'].includes(value)) {
+      return `${field} must be "random" or "fixed"`;
+    }
+  }
+
+  // URL validation for webhook URLs
+  if (field === 'webhookUrl') {
+    if (typeof value === 'string' && value.length > 0) {
+      if (!value.startsWith('https://')) {
+        return `${field} must start with https://`;
+      }
+    }
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Config flatten / unflatten
+// ============================================================================
+
+/**
+ * Flatten a nested config object into dot-path keys.
+ * Arrays are preserved as-is (not expanded into indexed keys).
+ */
+function flattenConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  function recurse(obj: Record<string, unknown>, prefix: string): void {
+    for (const [key, value] of Object.entries(obj)) {
+      const fullKey = prefix ? `${prefix}.${key}` : key;
+
+      if (Array.isArray(value)) {
+        // Preserve arrays as-is
+        result[fullKey] = value;
+      } else if (value !== null && typeof value === 'object') {
+        recurse(value as Record<string, unknown>, fullKey);
+      } else {
+        result[fullKey] = value;
+      }
+    }
+  }
+
+  recurse(config, '');
+  return result;
+}
+
+/**
+ * Reconstruct a nested config object from dot-path keys.
+ */
+function unflattenConfig(flat: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(flat)) {
+    const parts = key.split('.');
+    let current: Record<string, unknown> = result;
+
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (!(part in current) || typeof current[part] !== 'object' || current[part] === null) {
+        current[part] = {};
+      }
+      current = current[part] as Record<string, unknown>;
+    }
+
+    current[parts[parts.length - 1]] = value;
+  }
+
+  return result;
+}
+
+// ============================================================================
+// Default config
+// ============================================================================
+
+/**
+ * Return sensible defaults for a new config.
+ */
+function getDefaultConfig(): DefaultConfig {
+  return {
+    mode: 'pragmatic',
+    language: 'en',
+    reviewers: [
+      {
+        id: 'reviewer-1',
+        model: 'gpt-4',
+        backend: 'api',
+        timeout: 120,
+        enabled: true,
+      },
+    ],
+    supporters: {
+      pool: [],
+      pickCount: 2,
+      pickStrategy: 'random',
+      devilsAdvocate: {
+        id: 'devils-advocate',
+        model: 'gpt-4',
+        backend: 'api',
+        timeout: 120,
+        enabled: true,
+      },
+      personaPool: [],
+      personaAssignment: 'random',
+    },
+    moderator: { backend: 'api', model: 'gpt-4' },
+    head: { backend: 'api', model: 'gpt-4', enabled: true },
+    discussion: {
+      maxRounds: 3,
+      registrationThreshold: {
+        HARSHLY_CRITICAL: 0.3,
+        CRITICAL: 0.5,
+        WARNING: 0.7,
+        SUGGESTION: null,
+      },
+      codeSnippetRange: 5,
+    },
+    errorHandling: { maxRetries: 3, forfeitThreshold: 2 },
+    chunking: { maxTokens: 8000 },
+    notifications: { autoNotify: false },
+    github: {
+      humanReviewers: [],
+      humanTeams: [],
+      needsHumanLabel: 'needs-human-review',
+      postSuggestions: true,
+      collapseDiscussions: true,
+    },
+    autoApprove: { enabled: false, maxLines: 50, allowedFilePatterns: [] },
+  };
+}
+
+// ============================================================================
+// Config diff
+// ============================================================================
+
+/**
+ * Find which fields changed between two config objects.
+ * Compares flattened representations for simple scalar diffs.
+ */
+function diffConfigs(
+  original: Record<string, unknown>,
+  modified: Record<string, unknown>,
+): ConfigDiff[] {
+  const flatOriginal = flattenConfig(original);
+  const flatModified = flattenConfig(modified);
+
+  const diffs: ConfigDiff[] = [];
+  const allKeys = new Set([...Object.keys(flatOriginal), ...Object.keys(flatModified)]);
+
+  for (const key of allKeys) {
+    const oldVal = flatOriginal[key];
+    const newVal = flatModified[key];
+
+    // Deep compare for arrays and objects
+    const oldStr = JSON.stringify(oldVal);
+    const newStr = JSON.stringify(newVal);
+
+    if (oldStr !== newStr) {
+      diffs.push({ path: key, oldValue: oldVal, newValue: newVal });
+    }
+  }
+
+  return diffs.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  getFieldType,
+  validateConfigField,
+  flattenConfig,
+  unflattenConfig,
+  getDefaultConfig,
+  diffConfigs,
+};
+
+export type {
+  FieldType,
+  FieldValidationError,
+  ConfigDiff,
+  AgentConfig,
+  DefaultConfig,
+};

--- a/packages/web/tests/frontend/config.test.ts
+++ b/packages/web/tests/frontend/config.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Config Management — Utility Function Tests
+ * Tests validateConfigField, getFieldType, flattenConfig, unflattenConfig,
+ * getDefaultConfig, diffConfigs, and edge cases.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateConfigField,
+  getFieldType,
+  flattenConfig,
+  unflattenConfig,
+  getDefaultConfig,
+  diffConfigs,
+} from '../../src/frontend/utils/config-helpers.js';
+
+// ============================================================================
+// getFieldType Tests
+// ============================================================================
+
+describe('getFieldType', () => {
+  it('should return "boolean" for boolean values', () => {
+    expect(getFieldType(true)).toBe('boolean');
+    expect(getFieldType(false)).toBe('boolean');
+  });
+
+  it('should return "number" for numeric values', () => {
+    expect(getFieldType(42)).toBe('number');
+    expect(getFieldType(0)).toBe('number');
+    expect(getFieldType(3.14)).toBe('number');
+  });
+
+  it('should return "text" for string values', () => {
+    expect(getFieldType('hello')).toBe('text');
+    expect(getFieldType('')).toBe('text');
+  });
+
+  it('should return "array" for array values', () => {
+    expect(getFieldType([])).toBe('array');
+    expect(getFieldType([1, 2, 3])).toBe('array');
+  });
+
+  it('should return "object" for plain objects', () => {
+    expect(getFieldType({ key: 'value' })).toBe('object');
+    expect(getFieldType({})).toBe('object');
+  });
+
+  it('should return "text" for null and undefined', () => {
+    expect(getFieldType(null)).toBe('text');
+    expect(getFieldType(undefined)).toBe('text');
+  });
+});
+
+// ============================================================================
+// validateConfigField Tests
+// ============================================================================
+
+describe('validateConfigField', () => {
+  it('should return null for valid text fields', () => {
+    expect(validateConfigField('model', 'gpt-4')).toBeNull();
+  });
+
+  it('should return error for empty required fields', () => {
+    expect(validateConfigField('model', '')).not.toBeNull();
+    expect(validateConfigField('id', undefined)).not.toBeNull();
+  });
+
+  it('should allow empty optional fields', () => {
+    expect(validateConfigField('provider', '')).toBeNull();
+    expect(validateConfigField('label', null)).toBeNull();
+    expect(validateConfigField('persona', undefined)).toBeNull();
+  });
+
+  it('should validate number fields are non-negative', () => {
+    expect(validateConfigField('timeout', 120)).toBeNull();
+    expect(validateConfigField('timeout', -1)).not.toBeNull();
+    expect(validateConfigField('maxRounds', 'abc')).not.toBeNull();
+  });
+
+  it('should validate integer fields', () => {
+    expect(validateConfigField('maxRounds', 3)).toBeNull();
+    expect(validateConfigField('maxRounds', 3.5)).not.toBeNull();
+    expect(validateConfigField('pickCount', 2.1)).not.toBeNull();
+  });
+
+  it('should validate backend field against allowed values', () => {
+    expect(validateConfigField('backend', 'api')).toBeNull();
+    expect(validateConfigField('backend', 'claude')).toBeNull();
+    expect(validateConfigField('backend', 'invalid')).not.toBeNull();
+  });
+
+  it('should validate mode field', () => {
+    expect(validateConfigField('mode', 'strict')).toBeNull();
+    expect(validateConfigField('mode', 'pragmatic')).toBeNull();
+    expect(validateConfigField('mode', 'other')).not.toBeNull();
+  });
+
+  it('should validate language field', () => {
+    expect(validateConfigField('language', 'en')).toBeNull();
+    expect(validateConfigField('language', 'ko')).toBeNull();
+    expect(validateConfigField('language', 'fr')).not.toBeNull();
+  });
+
+  it('should validate webhook URLs must use https', () => {
+    expect(validateConfigField('webhookUrl', 'https://example.com/webhook')).toBeNull();
+    expect(validateConfigField('webhookUrl', 'http://example.com/webhook')).not.toBeNull();
+  });
+
+  it('should validate pickStrategy field', () => {
+    expect(validateConfigField('pickStrategy', 'random')).toBeNull();
+    expect(validateConfigField('pickStrategy', 'round-robin')).toBeNull();
+    expect(validateConfigField('pickStrategy', 'invalid')).not.toBeNull();
+  });
+
+  it('should validate threshold fields are between 0 and 1', () => {
+    expect(validateConfigField('CRITICAL', 0.5)).toBeNull();
+    expect(validateConfigField('CRITICAL', 1.5)).not.toBeNull();
+    expect(validateConfigField('WARNING', -0.1)).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// flattenConfig Tests
+// ============================================================================
+
+describe('flattenConfig', () => {
+  it('should flatten nested objects to dot-path keys', () => {
+    const config = {
+      discussion: {
+        maxRounds: 3,
+        codeSnippetRange: 5,
+      },
+    };
+    const flat = flattenConfig(config);
+    expect(flat['discussion.maxRounds']).toBe(3);
+    expect(flat['discussion.codeSnippetRange']).toBe(5);
+  });
+
+  it('should preserve arrays as-is', () => {
+    const config = {
+      reviewers: [{ id: 'r1', model: 'gpt-4' }],
+    };
+    const flat = flattenConfig(config);
+    expect(Array.isArray(flat['reviewers'])).toBe(true);
+  });
+
+  it('should handle deeply nested objects', () => {
+    const config = {
+      discussion: {
+        registrationThreshold: {
+          CRITICAL: 0.5,
+        },
+      },
+    };
+    const flat = flattenConfig(config);
+    expect(flat['discussion.registrationThreshold.CRITICAL']).toBe(0.5);
+  });
+
+  it('should handle empty objects', () => {
+    expect(flattenConfig({})).toEqual({});
+  });
+
+  it('should handle top-level scalar values', () => {
+    const config = { mode: 'strict', language: 'en' };
+    const flat = flattenConfig(config);
+    expect(flat['mode']).toBe('strict');
+    expect(flat['language']).toBe('en');
+  });
+});
+
+// ============================================================================
+// unflattenConfig Tests
+// ============================================================================
+
+describe('unflattenConfig', () => {
+  it('should reconstruct nested objects from dot-path keys', () => {
+    const flat = {
+      'discussion.maxRounds': 3,
+      'discussion.codeSnippetRange': 5,
+    };
+    const config = unflattenConfig(flat);
+    expect((config['discussion'] as Record<string, unknown>)['maxRounds']).toBe(3);
+    expect((config['discussion'] as Record<string, unknown>)['codeSnippetRange']).toBe(5);
+  });
+
+  it('should handle top-level keys', () => {
+    const flat = { mode: 'strict' };
+    const config = unflattenConfig(flat);
+    expect(config['mode']).toBe('strict');
+  });
+
+  it('should handle empty input', () => {
+    expect(unflattenConfig({})).toEqual({});
+  });
+});
+
+// ============================================================================
+// flattenConfig / unflattenConfig roundtrip
+// ============================================================================
+
+describe('flattenConfig / unflattenConfig roundtrip', () => {
+  it('should roundtrip a config without arrays', () => {
+    const original: Record<string, unknown> = {
+      mode: 'pragmatic',
+      discussion: {
+        maxRounds: 3,
+        registrationThreshold: {
+          CRITICAL: 0.5,
+          WARNING: 0.7,
+        },
+      },
+      errorHandling: {
+        maxRetries: 3,
+      },
+    };
+    const roundtripped = unflattenConfig(flattenConfig(original));
+    expect(roundtripped).toEqual(original);
+  });
+
+  it('should preserve array values through roundtrip', () => {
+    const original: Record<string, unknown> = {
+      github: {
+        humanReviewers: ['user1', 'user2'],
+      },
+    };
+    const roundtripped = unflattenConfig(flattenConfig(original));
+    expect(roundtripped).toEqual(original);
+  });
+});
+
+// ============================================================================
+// getDefaultConfig Tests
+// ============================================================================
+
+describe('getDefaultConfig', () => {
+  it('should return a valid config structure', () => {
+    const config = getDefaultConfig();
+    expect(config).toBeDefined();
+    expect(config.mode).toBe('pragmatic');
+    expect(config.language).toBe('en');
+  });
+
+  it('should include required top-level sections', () => {
+    const config = getDefaultConfig();
+    expect(config.reviewers).toBeDefined();
+    expect(Array.isArray(config.reviewers)).toBe(true);
+    expect(config.reviewers.length).toBeGreaterThan(0);
+    expect(config.supporters).toBeDefined();
+    expect(config.moderator).toBeDefined();
+    expect(config.discussion).toBeDefined();
+    expect(config.errorHandling).toBeDefined();
+  });
+
+  it('should have valid default reviewer', () => {
+    const config = getDefaultConfig();
+    const reviewer = config.reviewers[0];
+    expect(reviewer.id).toBeTruthy();
+    expect(reviewer.model).toBeTruthy();
+    expect(reviewer.backend).toBeTruthy();
+    expect(reviewer.timeout).toBeGreaterThan(0);
+    expect(reviewer.enabled).toBe(true);
+  });
+
+  it('should have valid discussion defaults', () => {
+    const config = getDefaultConfig();
+    expect(config.discussion.maxRounds).toBeGreaterThan(0);
+    expect(config.discussion.codeSnippetRange).toBeGreaterThan(0);
+    expect(config.discussion.registrationThreshold.SUGGESTION).toBeNull();
+  });
+
+  it('should return a fresh object each call', () => {
+    const a = getDefaultConfig();
+    const b = getDefaultConfig();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});
+
+// ============================================================================
+// diffConfigs Tests
+// ============================================================================
+
+describe('diffConfigs', () => {
+  it('should detect changed scalar values', () => {
+    const original = { mode: 'strict', language: 'en' };
+    const modified = { mode: 'pragmatic', language: 'en' };
+    const diffs = diffConfigs(original, modified);
+    expect(diffs.length).toBe(1);
+    expect(diffs[0].path).toBe('mode');
+    expect(diffs[0].oldValue).toBe('strict');
+    expect(diffs[0].newValue).toBe('pragmatic');
+  });
+
+  it('should detect added fields', () => {
+    const original: Record<string, unknown> = { mode: 'strict' };
+    const modified: Record<string, unknown> = { mode: 'strict', language: 'ko' };
+    const diffs = diffConfigs(original, modified);
+    expect(diffs.length).toBe(1);
+    expect(diffs[0].path).toBe('language');
+    expect(diffs[0].oldValue).toBeUndefined();
+    expect(diffs[0].newValue).toBe('ko');
+  });
+
+  it('should detect removed fields', () => {
+    const original: Record<string, unknown> = { mode: 'strict', language: 'en' };
+    const modified: Record<string, unknown> = { mode: 'strict' };
+    const diffs = diffConfigs(original, modified);
+    expect(diffs.length).toBe(1);
+    expect(diffs[0].path).toBe('language');
+  });
+
+  it('should detect nested changes', () => {
+    const original = { discussion: { maxRounds: 3 } };
+    const modified = { discussion: { maxRounds: 5 } };
+    const diffs = diffConfigs(original, modified);
+    expect(diffs.length).toBe(1);
+    expect(diffs[0].path).toBe('discussion.maxRounds');
+  });
+
+  it('should return empty array for identical configs', () => {
+    const config = { mode: 'strict', language: 'en' };
+    expect(diffConfigs(config, config)).toEqual([]);
+  });
+
+  it('should sort diffs by path', () => {
+    const original: Record<string, unknown> = { b: 1, a: 1 };
+    const modified: Record<string, unknown> = { b: 2, a: 2 };
+    const diffs = diffConfigs(original, modified);
+    expect(diffs[0].path).toBe('a');
+    expect(diffs[1].path).toBe('b');
+  });
+});


### PR DESCRIPTION
## Summary
- Form-based config editor with real-time validation, JSON preview, and toast notifications
- New components: ConfigSection, ConfigField, ReviewerEditor, ConfigPreview, Toast
- Pure utility functions in `config-helpers.ts`
- 38 new tests (207 total across web package)

## Features
- Collapsible sections: General, Reviewers, Supporters, Discussion, Error Handling, Notifications, GitHub, Auto-Approve
- Generic form fields: text, number, boolean (toggle switch), select, array with add/remove
- Reviewer list editor with add/remove/edit per reviewer
- Syntax-highlighted JSON preview with copy to clipboard
- Success/error toast with 3s auto-dismiss and slide-in animation
- Save validates via Zod ConfigSchema, shows inline errors

## Test Plan
- [x] 38 new tests — all pass
- [x] validateConfigField, getFieldType, flattenConfig/unflattenConfig roundtrip, diffConfigs

Sprint 7 Feature 5.8 / 8 — **Sprint 7 Complete!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)