### PR TITLE
test: Sprint 7 component rendering tests (130 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ reviews/
 .ca/sessions/
 .ca/logs/
 .ca/model-quality.json
+.claude/worktrees/

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,21 +15,25 @@
   "dependencies": {
     "@codeagora/core": "workspace:*",
     "@codeagora/shared": "workspace:*",
-    "hono": "^4.7.0",
     "@hono/node-server": "^1.14.0",
-    "@hono/node-ws": "^1.1.0"
+    "@hono/node-ws": "^1.1.0",
+    "hono": "^4.7.0"
   },
   "devDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^7.6.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.5.2",
-    "vite": "^6.3.0",
-    "vitest": "^1.2.0",
+    "jsdom": "^29.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.6.0",
     "tsup": "^8.0.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vite": "^6.3.0",
+    "vitest": "^1.2.0"
   }
 }

--- a/packages/web/tests/frontend/render/config-field.test.tsx
+++ b/packages/web/tests/frontend/render/config-field.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConfigField } from '../../../src/frontend/components/ConfigField.js';
+
+describe('ConfigField', () => {
+  it('renders text input for string fields', () => {
+    render(
+      <ConfigField label="API Key" type="text" value="abc123" onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText('API Key')).toBeInTheDocument();
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveValue('abc123');
+  });
+
+  it('renders number input for number fields', () => {
+    render(
+      <ConfigField label="Timeout" type="number" value={30} onChange={vi.fn()} />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveAttribute('type', 'number');
+    expect(input).toHaveValue(30);
+  });
+
+  it('renders toggle switch for boolean fields', () => {
+    render(
+      <ConfigField label="Enabled" type="boolean" value={true} onChange={vi.fn()} />,
+    );
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders select for enum fields', () => {
+    const options = ['option-a', 'option-b', 'option-c'];
+    render(
+      <ConfigField
+        label="Mode"
+        type="select"
+        value="option-b"
+        onChange={vi.fn()}
+        options={options}
+      />,
+    );
+
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveValue('option-b');
+    expect(screen.getByRole('option', { name: 'option-a' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'option-b' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'option-c' })).toBeInTheDocument();
+  });
+
+  it('shows validation error message', () => {
+    render(
+      <ConfigField
+        label="URL"
+        type="text"
+        value=""
+        onChange={vi.fn()}
+        error="This field is required."
+      />,
+    );
+
+    expect(screen.getByText('This field is required.')).toBeInTheDocument();
+  });
+
+  it('calls onChange with new value on text input change', () => {
+    const onChange = vi.fn();
+    render(
+      <ConfigField label="Name" type="text" value="old" onChange={onChange} />,
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'new-value' } });
+    expect(onChange).toHaveBeenCalledWith('new-value');
+  });
+});

--- a/packages/web/tests/frontend/render/config-preview.test.tsx
+++ b/packages/web/tests/frontend/render/config-preview.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConfigPreview } from '../../../src/frontend/components/ConfigPreview.js';
+
+describe('ConfigPreview', () => {
+  it('renders JSON preview title', () => {
+    render(<ConfigPreview config={{ key: 'value' }} />);
+
+    expect(screen.getByText('JSON Preview')).toBeInTheDocument();
+  });
+
+  it('shows copy button', () => {
+    render(<ConfigPreview config={{ key: 'value' }} />);
+
+    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
+  });
+
+  it('displays config object keys and values', () => {
+    render(<ConfigPreview config={{ apiKey: 'abc', timeout: 30 }} />);
+
+    expect(screen.getByText('"apiKey"')).toBeInTheDocument();
+    expect(screen.getByText('"abc"')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('renders line numbers', () => {
+    const { container } = render(<ConfigPreview config={{ a: 1 }} />);
+
+    // JSON.stringify({ a: 1 }, null, 2) produces 3 lines so there should be 3 line-number spans
+    const lineNumbers = container.querySelectorAll('.json-line-number');
+    expect(lineNumbers.length).toBe(3);
+    expect(lineNumbers[0].textContent).toBe('1');
+    expect(lineNumbers[1].textContent).toBe('2');
+    expect(lineNumbers[2].textContent).toBe('3');
+  });
+
+  it('shows Copied! after clicking copy (with clipboard mock)', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    render(<ConfigPreview config={{ x: 1 }} />);
+
+    const copyBtn = screen.getByRole('button', { name: /copy/i });
+    fireEvent.click(copyBtn);
+
+    await screen.findByText('Copied!');
+    expect(screen.getByText('Copied!')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/config-section.test.tsx
+++ b/packages/web/tests/frontend/render/config-section.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ConfigSection } from '../../../src/frontend/components/ConfigSection.js';
+
+describe('ConfigSection', () => {
+  it('renders title and description', () => {
+    render(
+      <ConfigSection title="General Settings" description="Basic configuration options.">
+        <span>Child content</span>
+      </ConfigSection>,
+    );
+
+    expect(screen.getByText('General Settings')).toBeInTheDocument();
+    expect(screen.getByText('Basic configuration options.')).toBeInTheDocument();
+  });
+
+  it('is collapsed by default (children hidden)', () => {
+    render(
+      <ConfigSection title="Section" description="Desc">
+        <span>Hidden child</span>
+      </ConfigSection>,
+    );
+
+    expect(screen.queryByText('Hidden child')).not.toBeInTheDocument();
+  });
+
+  it('expands when header is clicked', () => {
+    render(
+      <ConfigSection title="Section" description="Desc">
+        <span>Visible child</span>
+      </ConfigSection>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('Visible child')).toBeInTheDocument();
+  });
+
+  it('collapses again when header is clicked a second time', () => {
+    render(
+      <ConfigSection title="Section" description="Desc">
+        <span>Toggle child</span>
+      </ConfigSection>,
+    );
+
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn);
+    expect(screen.getByText('Toggle child')).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(screen.queryByText('Toggle child')).not.toBeInTheDocument();
+  });
+
+  it('renders expanded when defaultExpanded is true', () => {
+    render(
+      <ConfigSection title="Section" description="Desc" defaultExpanded>
+        <span>Default visible</span>
+      </ConfigSection>,
+    );
+
+    expect(screen.getByText('Default visible')).toBeInTheDocument();
+  });
+
+  it('sets aria-expanded correctly', () => {
+    render(
+      <ConfigSection title="Section" description="Desc">
+        <span>Child</span>
+      </ConfigSection>,
+    );
+
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/packages/web/tests/frontend/render/consensus-progress.test.tsx
+++ b/packages/web/tests/frontend/render/consensus-progress.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ConsensusProgress } from '../../../src/frontend/components/ConsensusProgress.js';
+import type { DiscussionRound } from '../../../src/frontend/utils/discussion-helpers.js';
+
+const makeRound = (round: number, agreeCount: number, total: number): DiscussionRound => ({
+  round,
+  moderatorPrompt: `Round ${round} prompt`,
+  supporterResponses: [
+    ...Array.from({ length: agreeCount }, (_, i) => ({
+      supporterId: `agree-${i}`,
+      response: 'I agree.',
+      stance: 'agree' as const,
+    })),
+    ...Array.from({ length: total - agreeCount }, (_, i) => ({
+      supporterId: `disagree-${i}`,
+      response: 'I disagree.',
+      stance: 'disagree' as const,
+    })),
+  ],
+});
+
+describe('ConsensusProgress', () => {
+  it('renders SVG bars for each round', () => {
+    const rounds = [makeRound(1, 2, 4), makeRound(2, 3, 4)];
+
+    const { container } = render(
+      <ConsensusProgress rounds={rounds} consensusReached={false} />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    // Each round renders a <g> element
+    const groups = container.querySelectorAll('svg g');
+    expect(groups.length).toBe(2);
+  });
+
+  it('shows round labels in the SVG', () => {
+    const rounds = [makeRound(1, 3, 4), makeRound(2, 4, 4)];
+
+    render(<ConsensusProgress rounds={rounds} consensusReached={true} />);
+
+    expect(screen.getByText('Round 1')).toBeInTheDocument();
+    expect(screen.getByText('Round 2')).toBeInTheDocument();
+  });
+
+  it('shows consensus percentage labels', () => {
+    // 2 agree out of 4 = 50%
+    const rounds = [makeRound(1, 2, 4)];
+
+    render(<ConsensusProgress rounds={rounds} consensusReached={false} />);
+
+    expect(screen.getByText('50%')).toBeInTheDocument();
+  });
+
+  it('shows consensus reached badge', () => {
+    const rounds = [makeRound(1, 4, 4)];
+
+    render(<ConsensusProgress rounds={rounds} consensusReached={true} />);
+
+    expect(screen.getByText('Consensus Reached')).toBeInTheDocument();
+  });
+
+  it('shows no consensus badge when not reached', () => {
+    const rounds = [makeRound(1, 1, 4)];
+
+    render(<ConsensusProgress rounds={rounds} consensusReached={false} />);
+
+    expect(screen.getByText('No Consensus')).toBeInTheDocument();
+  });
+
+  it('handles empty rounds', () => {
+    render(<ConsensusProgress rounds={[]} consensusReached={false} />);
+
+    expect(screen.getByText('No round data available.')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/cost-summary.test.tsx
+++ b/packages/web/tests/frontend/render/cost-summary.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CostSummary } from '../../../src/frontend/components/CostSummary.js';
+import type { SessionCost } from '../../../src/frontend/utils/cost-helpers.js';
+
+const SAMPLE_SESSIONS: SessionCost[] = [
+  {
+    date: '2024-01-15',
+    sessionId: 'abc-001',
+    totalCost: 0.02,
+    reviewerCosts: { 'openai/gpt-4o': 0.015, 'anthropic/claude-3': 0.005 },
+    layerCosts: { l1: 0.01, l2: 0.005, l3: 0.005 },
+  },
+  {
+    date: '2024-01-16',
+    sessionId: 'abc-002',
+    totalCost: 0.04,
+    reviewerCosts: { 'openai/gpt-4o': 0.03, 'anthropic/claude-3': 0.01 },
+    layerCosts: { l1: 0.02, l2: 0.01, l3: 0.01 },
+  },
+];
+
+describe('CostSummary', () => {
+  it('renders 4 metric cards', () => {
+    render(<CostSummary sessions={SAMPLE_SESSIONS} />);
+    expect(screen.getByText('Total Spend')).toBeInTheDocument();
+    expect(screen.getByText('Avg per Session')).toBeInTheDocument();
+    expect(screen.getByText('Most Expensive Session')).toBeInTheDocument();
+    expect(screen.getByText('Top Reviewer')).toBeInTheDocument();
+  });
+
+  it('shows total spend formatted as dollar amount', () => {
+    render(<CostSummary sessions={SAMPLE_SESSIONS} />);
+    // Total = 0.02 + 0.04 = 0.06 -> $0.0600
+    expect(screen.getByText('$0.0600')).toBeInTheDocument();
+  });
+
+  it('shows average cost per session', () => {
+    render(<CostSummary sessions={SAMPLE_SESSIONS} />);
+    // Average = 0.06 / 2 = 0.03 -> $0.0300
+    expect(screen.getByText('$0.0300')).toBeInTheDocument();
+  });
+
+  it('shows session count detail', () => {
+    render(<CostSummary sessions={SAMPLE_SESSIONS} />);
+    expect(screen.getByText('2 sessions')).toBeInTheDocument();
+  });
+
+  it('handles empty data with zero costs', () => {
+    render(<CostSummary sessions={[]} />);
+    expect(screen.getByText('Total Spend')).toBeInTheDocument();
+    // Both Total and Avg show $0.0000 when empty
+    expect(screen.getAllByText('$0.0000')).toHaveLength(2);
+    expect(screen.getByText('0 sessions')).toBeInTheDocument();
+    // Most expensive session and top reviewer show '--' when empty
+    expect(screen.getAllByText('--')).toHaveLength(2);
+  });
+
+  it('shows most expensive session identifier', () => {
+    render(<CostSummary sessions={SAMPLE_SESSIONS} />);
+    // abc-002 has higher cost (0.04)
+    expect(screen.getByText('2024-01-16 / abc-002')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/debate-timeline.test.tsx
+++ b/packages/web/tests/frontend/render/debate-timeline.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { DebateTimeline } from '../../../src/frontend/components/DebateTimeline.js';
+import type {
+  DiscussionVerdict,
+  DiscussionRound,
+} from '../../../src/frontend/utils/discussion-helpers.js';
+
+const verdict: DiscussionVerdict = {
+  discussionId: 'disc-1',
+  filePath: 'src/auth.ts',
+  lineRange: [5, 15],
+  finalSeverity: 'CRITICAL',
+  reasoning: 'Security vulnerability identified by consensus.',
+  consensusReached: true,
+  rounds: 2,
+};
+
+const rounds: DiscussionRound[] = [
+  {
+    round: 1,
+    moderatorPrompt: 'Is this a genuine security issue?',
+    supporterResponses: [
+      { supporterId: 'reviewer-a', response: 'Yes, definitely.', stance: 'agree' },
+      { supporterId: 'reviewer-b', response: 'I disagree.', stance: 'disagree' },
+      { supporterId: 'reviewer-devil', response: 'Neutral on this.', stance: 'neutral' },
+    ],
+  },
+  {
+    round: 2,
+    moderatorPrompt: 'Do you maintain your position?',
+    supporterResponses: [
+      { supporterId: 'reviewer-a', response: 'Still agree.', stance: 'agree' },
+      { supporterId: 'reviewer-b', response: 'Now I agree too.', stance: 'agree' },
+      { supporterId: 'reviewer-devil', response: 'Fine, agree.', stance: 'agree' },
+    ],
+  },
+];
+
+describe('DebateTimeline', () => {
+  it('renders moderator prompt for each round', () => {
+    render(<DebateTimeline verdict={verdict} rounds={rounds} />);
+
+    expect(screen.getByText('Is this a genuine security issue?')).toBeInTheDocument();
+    expect(screen.getByText('Do you maintain your position?')).toBeInTheDocument();
+  });
+
+  it('shows supporter responses with stance badges', () => {
+    render(<DebateTimeline verdict={verdict} rounds={rounds} />);
+
+    // reviewer-a appears in both rounds so use getAllByText
+    expect(screen.getAllByText('reviewer-a').length).toBeGreaterThan(0);
+    expect(screen.getByText('Yes, definitely.')).toBeInTheDocument();
+    // stance badges are text content
+    const agreeBadges = screen.getAllByText('agree');
+    expect(agreeBadges.length).toBeGreaterThan(0);
+    expect(screen.getByText('disagree')).toBeInTheDocument();
+    expect(screen.getByText('neutral')).toBeInTheDocument();
+  });
+
+  it('stance badges have correct classes for agree, disagree, neutral', () => {
+    render(<DebateTimeline verdict={verdict} rounds={rounds} />);
+
+    const agreeBadge = screen.getAllByText('agree')[0].closest('.stance-badge');
+    expect(agreeBadge).toHaveClass('stance--agree');
+
+    const disagreeBadge = screen.getByText('disagree').closest('.stance-badge');
+    expect(disagreeBadge).toHaveClass('stance--disagree');
+
+    const neutralBadge = screen.getByText('neutral').closest('.stance-badge');
+    expect(neutralBadge).toHaveClass('stance--neutral');
+  });
+
+  it('shows final verdict and reasoning', () => {
+    render(<DebateTimeline verdict={verdict} rounds={rounds} />);
+
+    expect(screen.getByText('Final Verdict')).toBeInTheDocument();
+    expect(screen.getByText('Security vulnerability identified by consensus.')).toBeInTheDocument();
+    expect(screen.getByText('Consensus Reached')).toBeInTheDocument();
+  });
+
+  it('highlights devil\'s advocate supporters with DA tag', () => {
+    render(<DebateTimeline verdict={verdict} rounds={rounds} />);
+
+    // reviewer-devil contains "devil" so isDevilsAdvocate returns true
+    const daTags = screen.getAllByText('DA');
+    expect(daTags.length).toBeGreaterThan(0);
+  });
+
+  it('handles single round', () => {
+    const singleRound: DiscussionRound[] = [
+      {
+        round: 1,
+        moderatorPrompt: 'Only prompt.',
+        supporterResponses: [
+          { supporterId: 'reviewer-x', response: 'Agreed.', stance: 'agree' },
+        ],
+      },
+    ];
+
+    render(<DebateTimeline verdict={verdict} rounds={singleRound} />);
+
+    expect(screen.getByText('Round 1')).toBeInTheDocument();
+    expect(screen.getByText('Only prompt.')).toBeInTheDocument();
+    expect(screen.queryByText('Round 2')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/discussion-list.test.tsx
+++ b/packages/web/tests/frontend/render/discussion-list.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DiscussionList } from '../../../src/frontend/components/DiscussionList.js';
+import type { DiscussionVerdict } from '../../../src/frontend/utils/discussion-helpers.js';
+
+const makeDiscussion = (overrides: Partial<DiscussionVerdict> = {}): DiscussionVerdict => ({
+  discussionId: 'disc-1',
+  filePath: 'src/index.ts',
+  lineRange: [10, 20],
+  finalSeverity: 'WARNING',
+  reasoning: 'Some reasoning',
+  consensusReached: true,
+  rounds: 2,
+  ...overrides,
+});
+
+describe('DiscussionList', () => {
+  it('renders list of discussions with ID, file path, and severity', () => {
+    const discussions = [
+      makeDiscussion({ discussionId: 'disc-1', filePath: 'src/index.ts', finalSeverity: 'WARNING' }),
+      makeDiscussion({ discussionId: 'disc-2', filePath: 'src/utils.ts', finalSeverity: 'CRITICAL' }),
+    ];
+
+    render(<DiscussionList discussions={discussions} selectedId={null} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('disc-1')).toBeInTheDocument();
+    expect(screen.getByText('src/index.ts')).toBeInTheDocument();
+    // 'Warning' also appears in the filter <option>, so check for the severity span specifically
+    const warningSeverity = document.querySelector('.disc-severity--warning');
+    expect(warningSeverity).toBeInTheDocument();
+    expect(warningSeverity?.textContent).toBe('Warning');
+    expect(screen.getByText('disc-2')).toBeInTheDocument();
+    expect(screen.getByText('src/utils.ts')).toBeInTheDocument();
+    const criticalSeverity = document.querySelector('.disc-severity--critical');
+    expect(criticalSeverity).toBeInTheDocument();
+    expect(criticalSeverity?.textContent).toBe('Critical');
+  });
+
+  it('shows consensus status reached and not reached', () => {
+    const discussions = [
+      makeDiscussion({ discussionId: 'disc-1', consensusReached: true }),
+      makeDiscussion({ discussionId: 'disc-2', consensusReached: false }),
+    ];
+
+    render(<DiscussionList discussions={discussions} selectedId={null} onSelect={vi.fn()} />);
+
+    // 'Consensus' badge in the row (not the filter option which says 'Consensus Reached')
+    expect(document.querySelector('.disc-list__consensus--reached')).toBeInTheDocument();
+    // 'No Consensus' also appears in the filter <option>, use the class-scoped element
+    expect(document.querySelector('.disc-list__consensus--not-reached')).toBeInTheDocument();
+  });
+
+  it('shows round count', () => {
+    const discussions = [
+      makeDiscussion({ discussionId: 'disc-1', rounds: 3 }),
+    ];
+
+    render(<DiscussionList discussions={discussions} selectedId={null} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('3 rounds')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when a discussion is clicked', () => {
+    const onSelect = vi.fn();
+    const discussions = [makeDiscussion({ discussionId: 'disc-abc' })];
+
+    render(<DiscussionList discussions={discussions} selectedId={null} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByText('disc-abc'));
+    expect(onSelect).toHaveBeenCalledWith('disc-abc');
+  });
+
+  it('filters by severity', () => {
+    const discussions = [
+      makeDiscussion({ discussionId: 'disc-1', finalSeverity: 'CRITICAL' }),
+      makeDiscussion({ discussionId: 'disc-2', finalSeverity: 'WARNING' }),
+    ];
+
+    render(<DiscussionList discussions={discussions} selectedId={null} onSelect={vi.fn()} />);
+
+    fireEvent.change(screen.getByRole('combobox', { name: /filter by severity/i }), {
+      target: { value: 'CRITICAL' },
+    });
+
+    expect(screen.getByText('disc-1')).toBeInTheDocument();
+    expect(screen.queryByText('disc-2')).not.toBeInTheDocument();
+  });
+
+  it('shows empty message when no discussions match filters', () => {
+    render(<DiscussionList discussions={[]} selectedId={null} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('No discussions match the current filters.')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/event-log.test.tsx
+++ b/packages/web/tests/frontend/render/event-log.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { EventLog } from '../../../src/frontend/components/EventLog.js';
+import type { PipelineEventEntry, ProgressEvent, DiscussionEvent } from '../../../src/frontend/hooks/usePipelineEvents.js';
+
+function makeProgressEntry(
+  id: number,
+  eventType: ProgressEvent['event'],
+  stage: ProgressEvent['stage'],
+  message: string,
+  timestamp = Date.now()
+): PipelineEventEntry {
+  return {
+    id,
+    source: 'progress',
+    event: {
+      stage,
+      event: eventType,
+      progress: 50,
+      message,
+      timestamp,
+    } satisfies ProgressEvent,
+    timestamp,
+  };
+}
+
+function makeDiscussionEntry(
+  id: number,
+  event: DiscussionEvent,
+  timestamp = Date.now()
+): PipelineEventEntry {
+  return { id, source: 'discussion', event, timestamp };
+}
+
+describe('EventLog', () => {
+  it('renders empty state message when no events', () => {
+    render(<EventLog events={[]} />);
+    expect(screen.getByText('No events yet')).toBeInTheDocument();
+  });
+
+  it('renders "Event Log" heading always', () => {
+    render(<EventLog events={[]} />);
+    expect(screen.getByText('Event Log')).toBeInTheDocument();
+  });
+
+  it('renders event messages for progress events', () => {
+    const events = [
+      makeProgressEntry(1, 'stage-start', 'review', 'Review started'),
+      makeProgressEntry(2, 'stage-complete', 'review', 'Review complete'),
+    ];
+    render(<EventLog events={events} />);
+    expect(screen.getByText(/\[review\] Review started/)).toBeInTheDocument();
+    expect(screen.getByText(/\[review\] Review complete/)).toBeInTheDocument();
+  });
+
+  it('renders event messages for discussion events', () => {
+    const discEvent: DiscussionEvent = {
+      type: 'discussion-start',
+      discussionId: 'd1',
+      issueTitle: 'Memory leak',
+      filePath: 'src/app.ts',
+      severity: 'CRITICAL',
+    };
+    const events = [makeDiscussionEntry(1, discEvent)];
+    render(<EventLog events={events} />);
+    expect(screen.getByText(/Discussion started: Memory leak \(src\/app\.ts\)/)).toBeInTheDocument();
+  });
+
+  it('applies color class based on event type', () => {
+    const events = [
+      makeProgressEntry(1, 'stage-start', 'init', 'Init started'),
+      makeProgressEntry(2, 'stage-error', 'review', 'Error occurred'),
+      makeProgressEntry(3, 'stage-complete', 'verdict', 'Done'),
+    ];
+    const { container } = render(<EventLog events={events} />);
+    const items = container.querySelectorAll('.event-item');
+    expect(items[0]).toHaveClass('event-item--complete'); // reversed: complete is first
+    expect(items[1]).toHaveClass('event-item--error');
+    expect(items[2]).toHaveClass('event-item--start');
+  });
+
+  it('shows at most 200 events', () => {
+    const events: PipelineEventEntry[] = Array.from({ length: 250 }, (_, i) =>
+      makeProgressEntry(i, 'stage-update', 'review', `Update ${i}`)
+    );
+    // EventLog receives pre-sliced events from the hook, but renders all passed in
+    // Pass exactly 200 to verify all are rendered
+    const sliced = events.slice(50); // 200 entries
+    const { container } = render(<EventLog events={sliced} />);
+    const items = container.querySelectorAll('.event-item');
+    expect(items).toHaveLength(200);
+  });
+
+  it('renders timestamps for each event', () => {
+    const ts = new Date('2024-01-15T10:30:45Z').getTime();
+    const events = [makeProgressEntry(1, 'stage-update', 'review', 'Processing', ts)];
+    const { container } = render(<EventLog events={events} />);
+    const timeEl = container.querySelector('.event-time');
+    expect(timeEl).toBeInTheDocument();
+    expect(timeEl?.textContent).toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+});

--- a/packages/web/tests/frontend/render/issue-card.test.tsx
+++ b/packages/web/tests/frontend/render/issue-card.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IssueCard } from '../../../src/frontend/components/IssueCard.js';
+
+const baseProps = {
+  issueTitle: 'Unhandled promise rejection',
+  problem: 'The async function lacks error handling.',
+  evidence: ['Line 42: await fetchData()', 'No try/catch block present'],
+  severity: 'CRITICAL' as const,
+  suggestion: 'Wrap the call in a try/catch block.',
+  filePath: 'src/api/client.ts',
+  lineRange: [40, 50] as [number, number],
+  reviewers: ['gpt-4o', 'claude-3'],
+};
+
+describe('IssueCard', () => {
+  it('renders issue title and severity badge', () => {
+    render(<IssueCard {...baseProps} />);
+    expect(screen.getByText('Unhandled promise rejection')).toBeInTheDocument();
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+  });
+
+  it('does not show body content when collapsed', () => {
+    render(<IssueCard {...baseProps} />);
+    expect(screen.queryByText('The async function lacks error handling.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Wrap the call in a try/catch block.')).not.toBeInTheDocument();
+  });
+
+  it('expands to show problem, evidence, and suggestion on click', () => {
+    render(<IssueCard {...baseProps} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('The async function lacks error handling.')).toBeInTheDocument();
+    expect(screen.getByText('Line 42: await fetchData()')).toBeInTheDocument();
+    expect(screen.getByText('Wrap the call in a try/catch block.')).toBeInTheDocument();
+  });
+
+  it('collapses again on second click', () => {
+    render(<IssueCard {...baseProps} />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(screen.queryByText('The async function lacks error handling.')).not.toBeInTheDocument();
+  });
+
+  it('shows reviewer tags when expanded', () => {
+    render(<IssueCard {...baseProps} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('gpt-4o')).toBeInTheDocument();
+    expect(screen.getByText('claude-3')).toBeInTheDocument();
+  });
+
+  it('shows confidence percentage when provided', () => {
+    render(<IssueCard {...baseProps} confidence={0.85} />);
+    expect(screen.getByText('85%')).toBeInTheDocument();
+  });
+
+  it('does not show confidence when not provided', () => {
+    render(<IssueCard {...baseProps} />);
+    expect(screen.queryByText(/%$/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/model-leaderboard.test.tsx
+++ b/packages/web/tests/frontend/render/model-leaderboard.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ModelLeaderboard } from '../../../src/frontend/components/ModelLeaderboard.js';
+import type { ArmWithStats } from '../../../src/frontend/utils/model-helpers.js';
+
+function makeArm(modelId: string, alpha: number, beta: number, reviewCount: number, lastUsed = 0): ArmWithStats {
+  const winRate = alpha + beta > 0 ? alpha / (alpha + beta) : 0;
+  return { modelId, alpha, beta, reviewCount, lastUsed, winRate };
+}
+
+const SAMPLE_ARMS: ArmWithStats[] = [
+  makeArm('openai/gpt-4o', 80, 20, 100, 1700000000000),
+  makeArm('anthropic/claude-3', 55, 45, 80, 1700000001000),
+  makeArm('mistral/mistral-7b', 15, 35, 50, 1700000002000),
+];
+
+describe('ModelLeaderboard', () => {
+  it('renders table with model rows', () => {
+    render(<ModelLeaderboard arms={SAMPLE_ARMS} />);
+    // modelId is rendered in a <code> element with the full id
+    expect(screen.getByText('openai/gpt-4o')).toBeInTheDocument();
+    expect(screen.getByText('anthropic/claude-3')).toBeInTheDocument();
+    expect(screen.getByText('mistral/mistral-7b')).toBeInTheDocument();
+  });
+
+  it('shows win rate, review count, alpha and beta values', () => {
+    render(<ModelLeaderboard arms={SAMPLE_ARMS} />);
+    // Win rate for gpt-4o: 80/(80+20) = 80.0%
+    expect(screen.getByText('80.0%')).toBeInTheDocument();
+    // Review counts
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('80')).toBeInTheDocument();
+    // Alpha/beta values (toFixed(1))
+    expect(screen.getByText('80.0')).toBeInTheDocument();
+    expect(screen.getByText('20.0')).toBeInTheDocument();
+  });
+
+  it('top model row has accent highlight class', () => {
+    render(<ModelLeaderboard arms={SAMPLE_ARMS} />);
+    // openai/gpt-4o has highest win rate (80%), so it should have model-row--top
+    const topCode = screen.getByText('openai/gpt-4o');
+    const topRow = topCode.closest('tr');
+    expect(topRow).toHaveClass('model-row--top');
+  });
+
+  it('handles empty arms gracefully', () => {
+    render(<ModelLeaderboard arms={[]} />);
+    expect(screen.getByText('No model data available')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('color-codes win rate: green >70%, yellow 40-70%, red <40%', () => {
+    render(<ModelLeaderboard arms={SAMPLE_ARMS} />);
+    // gpt-4o = 80% -> high (green)
+    expect(screen.getByText('80.0%')).toHaveClass('model-winrate--high');
+    // claude-3 = 55% -> medium (yellow)
+    expect(screen.getByText('55.0%')).toHaveClass('model-winrate--medium');
+    // mistral-7b = 30% -> low (red)
+    expect(screen.getByText('30.0%')).toHaveClass('model-winrate--low');
+  });
+
+  it('sorts by column when header is clicked', () => {
+    render(<ModelLeaderboard arms={SAMPLE_ARMS} />);
+    const reviewsHeader = screen.getByText(/Reviews/);
+    fireEvent.click(reviewsHeader);
+    const rows = screen.getAllByRole('row');
+    // After clicking Reviews (desc), highest review count should be first data row
+    const firstDataRow = rows[1];
+    expect(firstDataRow).toHaveClass('model-row--top');
+  });
+});

--- a/packages/web/tests/frontend/render/progress-bar.test.tsx
+++ b/packages/web/tests/frontend/render/progress-bar.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ProgressBar } from '../../../src/frontend/components/ProgressBar.js';
+
+describe('ProgressBar', () => {
+  it('renders the percentage label by default', () => {
+    render(<ProgressBar progress={60} />);
+    expect(screen.getByText('60%')).toBeInTheDocument();
+  });
+
+  it('sets fill width to match progress percentage', () => {
+    const { container } = render(<ProgressBar progress={75} />);
+    const fill = container.querySelector('.progress-bar-fill');
+    expect(fill).toHaveStyle({ width: '75%' });
+  });
+
+  it('applies active variant class by default', () => {
+    const { container } = render(<ProgressBar progress={40} />);
+    expect(container.querySelector('.progress-bar-fill')).toHaveClass('progress-bar-fill--active');
+  });
+
+  it('applies complete variant class', () => {
+    const { container } = render(<ProgressBar progress={100} variant="complete" />);
+    expect(container.querySelector('.progress-bar-fill')).toHaveClass('progress-bar-fill--complete');
+  });
+
+  it('applies error variant class', () => {
+    const { container } = render(<ProgressBar progress={30} variant="error" />);
+    expect(container.querySelector('.progress-bar-fill')).toHaveClass('progress-bar-fill--error');
+  });
+
+  it('hides the label when showLabel is false', () => {
+    render(<ProgressBar progress={50} showLabel={false} />);
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
+  });
+
+  it('clamps progress above 100 to 100', () => {
+    render(<ProgressBar progress={150} />);
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+
+  it('clamps progress below 0 to 0', () => {
+    render(<ProgressBar progress={-10} />);
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/provider-reliability.test.tsx
+++ b/packages/web/tests/frontend/render/provider-reliability.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ProviderReliability } from '../../../src/frontend/components/ProviderReliability.js';
+import type { ArmWithStats } from '../../../src/frontend/utils/model-helpers.js';
+
+function makeArm(modelId: string, alpha: number, beta: number, reviewCount: number): ArmWithStats {
+  const winRate = alpha + beta > 0 ? alpha / (alpha + beta) : 0;
+  return { modelId, alpha, beta, reviewCount, lastUsed: 0, winRate };
+}
+
+describe('ProviderReliability', () => {
+  it('renders provider cards with names', () => {
+    const arms: ArmWithStats[] = [
+      makeArm('openai/gpt-4o', 80, 20, 100),
+      makeArm('anthropic/claude-3', 55, 45, 80),
+    ];
+    render(<ProviderReliability arms={arms} />);
+    expect(screen.getByText('openai')).toBeInTheDocument();
+    expect(screen.getByText('anthropic')).toBeInTheDocument();
+  });
+
+  it('shows health status badge for healthy provider', () => {
+    // win rate > 0.6 -> healthy
+    const arms: ArmWithStats[] = [makeArm('openai/gpt-4o', 80, 20, 100)];
+    render(<ProviderReliability arms={arms} />);
+    expect(screen.getByText('Healthy')).toBeInTheDocument();
+    expect(screen.getByText('Healthy')).toHaveClass('provider-card__status--healthy');
+  });
+
+  it('shows degraded status badge when win rate is 40-60%', () => {
+    // win rate 0.4-0.6 -> degraded
+    const arms: ArmWithStats[] = [makeArm('anthropic/claude', 50, 50, 60)];
+    render(<ProviderReliability arms={arms} />);
+    expect(screen.getByText('Degraded')).toBeInTheDocument();
+    expect(screen.getByText('Degraded')).toHaveClass('provider-card__status--degraded');
+  });
+
+  it('shows unhealthy status badge when win rate is below 40%', () => {
+    // win rate < 0.4 -> unhealthy
+    const arms: ArmWithStats[] = [makeArm('mistral/mistral-7b', 20, 80, 50)];
+    render(<ProviderReliability arms={arms} />);
+    expect(screen.getByText('Unhealthy')).toBeInTheDocument();
+    expect(screen.getByText('Unhealthy')).toHaveClass('provider-card__status--unhealthy');
+  });
+
+  it('shows total reviews and average win rate', () => {
+    const arms: ArmWithStats[] = [
+      makeArm('openai/gpt-4o', 80, 20, 100),
+      makeArm('openai/gpt-3.5', 70, 30, 50),
+    ];
+    render(<ProviderReliability arms={arms} />);
+    // Total reviews for openai = 100 + 50 = 150
+    expect(screen.getByText('150')).toBeInTheDocument();
+    // Average win rate = (0.8 + 0.7) / 2 = 0.75 -> 75.0%
+    expect(screen.getByText('75.0%')).toBeInTheDocument();
+  });
+
+  it('handles empty data gracefully', () => {
+    render(<ProviderReliability arms={[]} />);
+    expect(screen.getByText('No provider data available')).toBeInTheDocument();
+    expect(screen.queryByText('Reviews')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/reviewer-costs.test.tsx
+++ b/packages/web/tests/frontend/render/reviewer-costs.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ReviewerCosts } from '../../../src/frontend/components/ReviewerCosts.js';
+import type { ReviewerAggregate } from '../../../src/frontend/utils/cost-helpers.js';
+
+// Component expects reviewers already sorted descending by cost
+const SAMPLE_REVIEWERS: ReviewerAggregate[] = [
+  { reviewer: 'openai/gpt-4o', totalCost: 0.05 },
+  { reviewer: 'anthropic/claude-3', totalCost: 0.03 },
+  { reviewer: 'mistral/mistral-7b', totalCost: 0.01 },
+];
+
+describe('ReviewerCosts', () => {
+  it('renders a bar row for each reviewer', () => {
+    render(<ReviewerCosts reviewers={SAMPLE_REVIEWERS} />);
+    // Model names extracted from "provider/model"
+    expect(screen.getByText('gpt-4o')).toBeInTheDocument();
+    expect(screen.getByText('claude-3')).toBeInTheDocument();
+    expect(screen.getByText('mistral-7b')).toBeInTheDocument();
+  });
+
+  it('shows cost amount for each reviewer', () => {
+    render(<ReviewerCosts reviewers={SAMPLE_REVIEWERS} />);
+    expect(screen.getByText('$0.0500')).toBeInTheDocument();
+    expect(screen.getByText('$0.0300')).toBeInTheDocument();
+    expect(screen.getByText('$0.0100')).toBeInTheDocument();
+  });
+
+  it('shows provider name alongside model name', () => {
+    render(<ReviewerCosts reviewers={SAMPLE_REVIEWERS} />);
+    expect(screen.getByText('openai')).toBeInTheDocument();
+    expect(screen.getByText('anthropic')).toBeInTheDocument();
+    expect(screen.getByText('mistral')).toBeInTheDocument();
+  });
+
+  it('handles empty data gracefully', () => {
+    render(<ReviewerCosts reviewers={[]} />);
+    expect(screen.getByText('No reviewer cost data')).toBeInTheDocument();
+    expect(screen.queryByText('$')).not.toBeInTheDocument();
+  });
+
+  it('renders bars with non-zero width for reviewers with cost', () => {
+    render(<ReviewerCosts reviewers={SAMPLE_REVIEWERS} />);
+    const bars = document.querySelectorAll('.reviewer-costs__bar');
+    expect(bars).toHaveLength(3);
+    // Top reviewer bar should be 100% width
+    const topBar = bars[0] as HTMLElement;
+    expect(topBar.style.width).toBe('100%');
+  });
+
+  it('renders with a single reviewer at full bar width', () => {
+    const single: ReviewerAggregate[] = [{ reviewer: 'openai/gpt-4o', totalCost: 0.08 }];
+    render(<ReviewerCosts reviewers={single} />);
+    expect(screen.getByText('gpt-4o')).toBeInTheDocument();
+    expect(screen.getByText('$0.0800')).toBeInTheDocument();
+    const bar = document.querySelector('.reviewer-costs__bar') as HTMLElement;
+    expect(bar.style.width).toBe('100%');
+  });
+});

--- a/packages/web/tests/frontend/render/session-filters.test.tsx
+++ b/packages/web/tests/frontend/render/session-filters.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionFilters } from '../../../src/frontend/components/SessionFilters.js';
+import type { SessionFilters as SessionFiltersType } from '../../../src/frontend/utils/session-filters.js';
+
+const DEFAULT_FILTERS: SessionFiltersType = {
+  search: '',
+  status: 'all',
+  dateFrom: '',
+  dateTo: '',
+};
+
+describe('SessionFilters', () => {
+  it('renders search input, status dropdown, and date inputs', () => {
+    render(<SessionFilters filters={DEFAULT_FILTERS} onFilterChange={vi.fn()} />);
+    expect(screen.getByPlaceholderText('Search by ID, path, or date...')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    // Two date inputs
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    expect(dateInputs).toHaveLength(2);
+  });
+
+  it('calls onFilterChange with updated search when text is typed', () => {
+    const onFilterChange = vi.fn();
+    render(<SessionFilters filters={DEFAULT_FILTERS} onFilterChange={onFilterChange} />);
+    const searchInput = screen.getByPlaceholderText('Search by ID, path, or date...');
+    fireEvent.change(searchInput, { target: { value: 'abc' } });
+    expect(onFilterChange).toHaveBeenCalledWith({ ...DEFAULT_FILTERS, search: 'abc' });
+  });
+
+  it('calls onFilterChange with updated status when dropdown changes', () => {
+    const onFilterChange = vi.fn();
+    render(<SessionFilters filters={DEFAULT_FILTERS} onFilterChange={onFilterChange} />);
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'completed' } });
+    expect(onFilterChange).toHaveBeenCalledWith({ ...DEFAULT_FILTERS, status: 'completed' });
+  });
+
+  it('shows active filter count and clear button when filters are set', () => {
+    const activeFilters: SessionFiltersType = {
+      search: 'abc',
+      status: 'completed',
+      dateFrom: '2024-01-01',
+      dateTo: '2024-01-31',
+    };
+    render(<SessionFilters filters={activeFilters} onFilterChange={vi.fn()} />);
+    // 4 active filters
+    expect(screen.getByText('Clear (4)')).toBeInTheDocument();
+  });
+
+  it('clear button resets all filters to defaults', () => {
+    const onFilterChange = vi.fn();
+    const activeFilters: SessionFiltersType = {
+      search: 'test',
+      status: 'failed',
+      dateFrom: '2024-01-01',
+      dateTo: '',
+    };
+    render(<SessionFilters filters={activeFilters} onFilterChange={onFilterChange} />);
+    // Button text "Clear (3)" may be split across elements — use role query
+    const clearButton = screen.getByRole('button');
+    fireEvent.click(clearButton);
+    expect(onFilterChange).toHaveBeenCalledWith({
+      search: '',
+      status: 'all',
+      dateFrom: '',
+      dateTo: '',
+    });
+  });
+
+  it('does not render clear button when no filters are active', () => {
+    render(<SessionFilters filters={DEFAULT_FILTERS} onFilterChange={vi.fn()} />);
+    expect(screen.queryByText(/Clear/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/session-list.test.tsx
+++ b/packages/web/tests/frontend/render/session-list.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SessionList } from '../../../src/frontend/components/SessionList.js';
+import type { SessionMetadata, SortColumn, SortDirection } from '../../../src/frontend/utils/session-filters.js';
+
+const SAMPLE_SESSIONS: SessionMetadata[] = [
+  {
+    sessionId: 'abc-001',
+    date: '2024-01-15',
+    timestamp: 1705276800000,
+    diffPath: 'diffs/abc-001.diff',
+    status: 'completed',
+    startedAt: 1705276800000,
+    completedAt: 1705276860000,
+  },
+  {
+    sessionId: 'abc-002',
+    date: '2024-01-16',
+    timestamp: 1705363200000,
+    diffPath: 'diffs/abc-002.diff',
+    status: 'failed',
+    startedAt: 1705363200000,
+    completedAt: 1705363230000,
+  },
+  {
+    sessionId: 'abc-003',
+    date: '2024-01-17',
+    timestamp: 1705449600000,
+    diffPath: 'diffs/abc-003.diff',
+    status: 'in_progress',
+    startedAt: 1705449600000,
+  },
+];
+
+function renderList(
+  sessions: SessionMetadata[] = SAMPLE_SESSIONS,
+  sortColumn: SortColumn = 'date',
+  sortDirection: SortDirection = 'desc',
+  selectedIds: Set<string> = new Set(),
+  onSortChange = vi.fn(),
+  onSelectionChange = vi.fn(),
+  focusedIndex = -1,
+) {
+  return render(
+    <MemoryRouter>
+      <SessionList
+        sessions={sessions}
+        sortColumn={sortColumn}
+        sortDirection={sortDirection}
+        onSortChange={onSortChange}
+        selectedIds={selectedIds}
+        onSelectionChange={onSelectionChange}
+        focusedIndex={focusedIndex}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('SessionList', () => {
+  it('renders table rows with session data', () => {
+    renderList();
+    expect(screen.getByText('abc-001')).toBeInTheDocument();
+    expect(screen.getByText('abc-002')).toBeInTheDocument();
+    expect(screen.getByText('abc-003')).toBeInTheDocument();
+    expect(screen.getByText('2024-01-15')).toBeInTheDocument();
+    expect(screen.getByText('diffs/abc-001.diff')).toBeInTheDocument();
+  });
+
+  it('shows status badges with correct classes', () => {
+    renderList();
+    const completedBadge = screen.getByText('Completed');
+    expect(completedBadge).toHaveClass('status-badge--completed');
+
+    const failedBadge = screen.getByText('Failed');
+    expect(failedBadge).toHaveClass('status-badge--failed');
+
+    const inProgressBadge = screen.getByText('In Progress');
+    expect(inProgressBadge).toHaveClass('status-badge--in-progress');
+  });
+
+  it('calls onSortChange when column header is clicked', () => {
+    const onSortChange = vi.fn();
+    renderList(SAMPLE_SESSIONS, 'date', 'desc', new Set(), onSortChange);
+    fireEvent.click(screen.getByText('Status'));
+    expect(onSortChange).toHaveBeenCalledWith('status');
+  });
+
+  it('shows "No sessions found" when empty', () => {
+    renderList([]);
+    expect(screen.getByText('No sessions found')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders sortable column headers for date, sessionId, status, duration, diffPath', () => {
+    renderList();
+    const table = screen.getByRole('table');
+    expect(table).toBeInTheDocument();
+    // All sortable columns are clickable th elements
+    expect(screen.getByText('Date')).toBeInTheDocument();
+    expect(screen.getByText('Session ID')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(screen.getByText('Diff Path')).toBeInTheDocument();
+  });
+
+  it('applies focused class to the focused row', () => {
+    renderList(SAMPLE_SESSIONS, 'date', 'desc', new Set(), vi.fn(), vi.fn(), 1);
+    const rows = screen.getAllByRole('row');
+    // rows[0] is thead tr, rows[1] is first data row (index 0), rows[2] is second (index 1)
+    expect(rows[2]).toHaveClass('session-row--focused');
+    expect(rows[1]).not.toHaveClass('session-row--focused');
+  });
+});

--- a/packages/web/tests/frontend/render/setup.ts
+++ b/packages/web/tests/frontend/render/setup.ts
@@ -1,0 +1,5 @@
+/**
+ * Setup file for jsdom rendering tests.
+ * Extends vitest matchers with @testing-library/jest-dom.
+ */
+import '@testing-library/jest-dom/vitest';

--- a/packages/web/tests/frontend/render/severity-badge.test.tsx
+++ b/packages/web/tests/frontend/render/severity-badge.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SeverityBadge } from '../../../src/frontend/components/SeverityBadge.js';
+
+describe('SeverityBadge', () => {
+  it('renders correct label for HARSHLY_CRITICAL', () => {
+    render(<SeverityBadge severity="HARSHLY_CRITICAL" />);
+    expect(screen.getByText('Harshly Critical')).toBeInTheDocument();
+  });
+
+  it('renders correct label for CRITICAL', () => {
+    render(<SeverityBadge severity="CRITICAL" />);
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+  });
+
+  it('renders correct label for WARNING', () => {
+    render(<SeverityBadge severity="WARNING" />);
+    expect(screen.getByText('Warning')).toBeInTheDocument();
+  });
+
+  it('renders correct label for SUGGESTION', () => {
+    render(<SeverityBadge severity="SUGGESTION" />);
+    expect(screen.getByText('Suggestion')).toBeInTheDocument();
+  });
+
+  it('applies the correct CSS class per severity', () => {
+    const { rerender } = render(<SeverityBadge severity="CRITICAL" />);
+    expect(screen.getByText('Critical')).toHaveClass('severity-badge--critical');
+
+    rerender(<SeverityBadge severity="WARNING" />);
+    expect(screen.getByText('Warning')).toHaveClass('severity-badge--warning');
+
+    rerender(<SeverityBadge severity="SUGGESTION" />);
+    expect(screen.getByText('Suggestion')).toHaveClass('severity-badge--suggestion');
+
+    rerender(<SeverityBadge severity="HARSHLY_CRITICAL" />);
+    expect(screen.getByText('Harshly Critical')).toHaveClass('severity-badge--harshly-critical');
+  });
+
+  it('applies large variant class when variant is large', () => {
+    render(<SeverityBadge severity="CRITICAL" variant="large" />);
+    expect(screen.getByText('Critical')).toHaveClass('severity-badge--large');
+  });
+
+  it('does not apply large variant class by default', () => {
+    render(<SeverityBadge severity="WARNING" />);
+    expect(screen.getByText('Warning')).not.toHaveClass('severity-badge--large');
+  });
+});

--- a/packages/web/tests/frontend/render/severity-summary.test.tsx
+++ b/packages/web/tests/frontend/render/severity-summary.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SeveritySummary } from '../../../src/frontend/components/SeveritySummary.js';
+
+const fullCounts = {
+  HARSHLY_CRITICAL: 2,
+  CRITICAL: 5,
+  WARNING: 8,
+  SUGGESTION: 3,
+};
+
+const zeroCounts = {
+  HARSHLY_CRITICAL: 0,
+  CRITICAL: 0,
+  WARNING: 0,
+  SUGGESTION: 0,
+};
+
+describe('SeveritySummary', () => {
+  it('renders legend items for all severities', () => {
+    render(<SeveritySummary counts={fullCounts} />);
+    expect(screen.getByText(/Harshly Critical: 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Critical: 5/)).toBeInTheDocument();
+    expect(screen.getByText(/Warning: 8/)).toBeInTheDocument();
+    expect(screen.getByText(/Suggestion: 3/)).toBeInTheDocument();
+  });
+
+  it('renders bar segments only for non-zero severities', () => {
+    const counts = { HARSHLY_CRITICAL: 0, CRITICAL: 3, WARNING: 0, SUGGESTION: 1 };
+    const { container } = render(<SeveritySummary counts={counts} />);
+    const segments = container.querySelectorAll('.severity-summary__segment');
+    expect(segments).toHaveLength(2);
+  });
+
+  it('renders no bar segments when all counts are zero', () => {
+    const { container } = render(<SeveritySummary counts={zeroCounts} />);
+    const segments = container.querySelectorAll('.severity-summary__segment');
+    expect(segments).toHaveLength(0);
+  });
+
+  it('still renders legend items when all counts are zero', () => {
+    render(<SeveritySummary counts={zeroCounts} />);
+    expect(screen.getByText(/Harshly Critical: 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Suggestion: 0/)).toBeInTheDocument();
+  });
+
+  it('applies correct segment classes for each severity', () => {
+    const { container } = render(<SeveritySummary counts={fullCounts} />);
+    expect(container.querySelector('.severity-summary__segment--harshly-critical')).toBeInTheDocument();
+    expect(container.querySelector('.severity-summary__segment--critical')).toBeInTheDocument();
+    expect(container.querySelector('.severity-summary__segment--warning')).toBeInTheDocument();
+    expect(container.querySelector('.severity-summary__segment--suggestion')).toBeInTheDocument();
+  });
+
+  it('shows count inside each bar segment', () => {
+    render(<SeveritySummary counts={fullCounts} />);
+    // Segment text content shows raw counts
+    expect(screen.getByTitle('Harshly Critical: 2')).toHaveTextContent('2');
+    expect(screen.getByTitle('Critical: 5')).toHaveTextContent('5');
+  });
+});

--- a/packages/web/tests/frontend/render/sidebar.test.tsx
+++ b/packages/web/tests/frontend/render/sidebar.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Sidebar } from '../../../src/frontend/components/Sidebar.js';
+
+function renderSidebar(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Sidebar />
+    </MemoryRouter>
+  );
+}
+
+describe('Sidebar', () => {
+  it('shows the CodeAgora title', () => {
+    renderSidebar();
+    expect(screen.getByText('CodeAgora')).toBeInTheDocument();
+  });
+
+  it('renders all navigation link labels', () => {
+    renderSidebar();
+    const labels = ['Dashboard', 'Sessions', 'Models', 'Costs', 'Discussions', 'Config', 'Pipeline'];
+    for (const label of labels) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('renders links with correct hrefs', () => {
+    renderSidebar();
+    const expectedLinks: [string, string][] = [
+      ['Dashboard', '/'],
+      ['Sessions', '/sessions'],
+      ['Models', '/models'],
+      ['Costs', '/costs'],
+      ['Discussions', '/discussions'],
+      ['Config', '/config'],
+      ['Pipeline', '/pipeline'],
+    ];
+    for (const [label, href] of expectedLinks) {
+      const link = screen.getByText(label).closest('a');
+      expect(link).toHaveAttribute('href', href);
+    }
+  });
+
+  it('applies active class to the current route link', () => {
+    renderSidebar('/sessions');
+    const sessionsLink = screen.getByText('Sessions').closest('a');
+    expect(sessionsLink).toHaveClass('sidebar-link--active');
+  });
+
+  it('renders inside a nav element', () => {
+    renderSidebar();
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/toast.test.tsx
+++ b/packages/web/tests/frontend/render/toast.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Toast } from '../../../src/frontend/components/Toast.js';
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders success toast with correct class', () => {
+    const { container } = render(
+      <Toast message="Saved!" type="success" onDismiss={vi.fn()} />,
+    );
+
+    const toast = container.querySelector('.toast');
+    expect(toast).toHaveClass('toast--success');
+  });
+
+  it('renders error toast with correct class', () => {
+    const { container } = render(
+      <Toast message="Something went wrong." type="error" onDismiss={vi.fn()} />,
+    );
+
+    const toast = container.querySelector('.toast');
+    expect(toast).toHaveClass('toast--error');
+  });
+
+  it('shows message text', () => {
+    render(<Toast message="Operation successful!" type="success" onDismiss={vi.fn()} />);
+
+    expect(screen.getByText('Operation successful!')).toBeInTheDocument();
+  });
+
+  it('has alert role for accessibility', () => {
+    render(<Toast message="Alert!" type="error" onDismiss={vi.fn()} />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('calls onDismiss after 3 seconds', () => {
+    const onDismiss = vi.fn();
+    render(<Toast message="Auto dismiss" type="success" onDismiss={onDismiss} />);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(3000);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDismiss when close button is clicked', () => {
+    const onDismiss = vi.fn();
+    render(<Toast message="Click to dismiss" type="error" onDismiss={onDismiss} />);
+
+    screen.getByRole('button', { name: /dismiss/i }).click();
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/packages/web/tests/frontend/render/trend-chart.test.tsx
+++ b/packages/web/tests/frontend/render/trend-chart.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TrendChart } from '../../../src/frontend/components/TrendChart.js';
+import type { TrendDataPoint } from '../../../src/frontend/components/TrendChart.js';
+
+const SAMPLE_DATA: TrendDataPoint[] = [
+  { label: 'Jan', value: 10 },
+  { label: 'Feb', value: 25 },
+  { label: 'Mar', value: 15 },
+];
+
+describe('TrendChart', () => {
+  it('renders SVG element when data is provided', () => {
+    render(<TrendChart data={SAMPLE_DATA} title="Reviews per Month" />);
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders bars for each data point', () => {
+    render(<TrendChart data={SAMPLE_DATA} title="Reviews per Month" />);
+    const bars = document.querySelectorAll('rect');
+    // 3 bars for 3 data points (may include tooltip rect, but at least 3)
+    expect(bars.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('handles empty data gracefully', () => {
+    render(<TrendChart data={[]} title="Reviews per Month" />);
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+    expect(document.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('renders the chart title', () => {
+    render(<TrendChart data={SAMPLE_DATA} title="Reviews per Month" />);
+    expect(screen.getByText('Reviews per Month')).toBeInTheDocument();
+  });
+
+  it('renders axis labels for first and last data points', () => {
+    render(<TrendChart data={SAMPLE_DATA} title="Reviews per Month" />);
+    expect(screen.getByText('Jan')).toBeInTheDocument();
+    expect(screen.getByText('Mar')).toBeInTheDocument();
+  });
+
+  it('renders y-axis max value label', () => {
+    render(<TrendChart data={SAMPLE_DATA} title="Reviews per Month" />);
+    // maxValue is 25
+    expect(screen.getByText('25')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/frontend/render/verdict-banner.test.tsx
+++ b/packages/web/tests/frontend/render/verdict-banner.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { VerdictBanner } from '../../../src/frontend/components/VerdictBanner.js';
+
+describe('VerdictBanner', () => {
+  it('renders ACCEPT decision with correct label and class', () => {
+    const { container } = render(
+      <VerdictBanner decision="ACCEPT" reasoning="The code looks good." />
+    );
+    expect(screen.getByText('Accepted')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('verdict-banner--accept');
+  });
+
+  it('renders REJECT decision with reasoning', () => {
+    const { container } = render(
+      <VerdictBanner decision="REJECT" reasoning="There are critical issues." />
+    );
+    expect(screen.getByText('Rejected')).toBeInTheDocument();
+    expect(screen.getByText('There are critical issues.')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('verdict-banner--reject');
+  });
+
+  it('renders NEEDS_HUMAN with questions list', () => {
+    const questions = ['Is this intentional?', 'Have you tested edge cases?'];
+    render(
+      <VerdictBanner
+        decision="NEEDS_HUMAN"
+        reasoning="Manual review required."
+        questionsForHuman={questions}
+      />
+    );
+    expect(screen.getByText('Needs Human Review')).toBeInTheDocument();
+    expect(screen.getByText('Is this intentional?')).toBeInTheDocument();
+    expect(screen.getByText('Have you tested edge cases?')).toBeInTheDocument();
+    expect(screen.getByText('Questions for Human')).toBeInTheDocument();
+  });
+
+  it('does not render questions section when questionsForHuman is empty', () => {
+    render(
+      <VerdictBanner decision="NEEDS_HUMAN" reasoning="Review needed." questionsForHuman={[]} />
+    );
+    expect(screen.queryByText('Questions for Human')).not.toBeInTheDocument();
+  });
+
+  it('does not render questions section when questionsForHuman is omitted', () => {
+    render(<VerdictBanner decision="ACCEPT" reasoning="Looks good." />);
+    expect(screen.queryByText('Questions for Human')).not.toBeInTheDocument();
+  });
+
+  it('always renders reasoning text', () => {
+    render(<VerdictBanner decision="REJECT" reasoning="Needs more work." />);
+    expect(screen.getByText('Needs more work.')).toBeInTheDocument();
+  });
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    environmentMatchGlobs: [
+      ['tests/frontend/render/**', 'jsdom'],
+    ],
+    setupFiles: ['tests/frontend/render/setup.ts'],
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 8.57.0(eslint@10.0.3)(typescript@5.9.3)
       vitest:
         specifier: ^1.2.0
-        version: 1.6.1(@types/node@20.19.37)
+        version: 1.6.1(@types/node@20.19.37)(jsdom@29.0.0)
 
   packages/cli:
     dependencies:
@@ -245,6 +245,15 @@ importers:
         specifier: ^4.7.0
         version: 4.12.8
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -254,6 +263,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.1(@types/node@20.19.37)(tsx@4.21.0)(yaml@2.8.2))
+      jsdom:
+        specifier: ^29.0.0
+        version: 29.0.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -277,9 +289,12 @@ importers:
         version: 6.4.1(@types/node@20.19.37)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^1.2.0
-        version: 1.6.1(@types/node@20.19.37)
+        version: 1.6.1(@types/node@20.19.37)(jsdom@29.0.0)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@ai-sdk/anthropic@3.0.58':
     resolution: {integrity: sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q==}
@@ -330,6 +345,17 @@ packages:
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
     engines: {node: '>=18'}
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.3':
+    resolution: {integrity: sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -402,6 +428,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -414,11 +444,51 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@clack/core@1.1.0':
     resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
 
   '@clack/prompts@1.1.0':
     resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1':
+    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -909,6 +979,15 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
@@ -1178,6 +1257,38 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1336,6 +1447,10 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -1350,6 +1465,13 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -1369,6 +1491,9 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -1497,8 +1622,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1508,6 +1644,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
@@ -1520,9 +1659,19 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1540,6 +1689,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1785,6 +1938,10 @@ packages:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -1808,6 +1965,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -1874,6 +2035,9 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -1900,6 +2064,15 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@29.0.0:
+    resolution: {integrity: sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1965,8 +2138,16 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1974,6 +2155,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2005,6 +2189,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -2085,6 +2273,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2161,6 +2352,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2189,6 +2384,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -2228,6 +2426,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -2258,6 +2460,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2368,6 +2574,10 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
@@ -2375,6 +2585,9 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -2409,6 +2622,13 @@ packages:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.26:
+    resolution: {integrity: sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==}
+
+  tldts@7.0.26:
+    resolution: {integrity: sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==}
+    hasBin: true
+
   to-rotated@1.0.0:
     resolution: {integrity: sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==}
     engines: {node: '>=18'}
@@ -2416,6 +2636,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2487,6 +2715,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.24.4:
+    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+    engines: {node: '>=20.18.1'}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -2609,6 +2841,22 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2645,6 +2893,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2684,6 +2939,8 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@ai-sdk/anthropic@3.0.58(zod@3.25.76)':
     dependencies:
@@ -2737,6 +2994,24 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.3':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2827,6 +3102,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2850,6 +3127,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@clack/core@1.1.0':
     dependencies:
       sisteransi: 1.0.5
@@ -2858,6 +3139,30 @@ snapshots:
     dependencies:
       '@clack/core': 1.1.0
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3118,6 +3423,8 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
+  '@exodus/bytes@1.15.0': {}
+
   '@hono/node-server@1.19.11(hono@4.12.8)':
     dependencies:
       hono: 4.12.8
@@ -3338,6 +3645,42 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -3556,6 +3899,8 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@5.2.0: {}
@@ -3563,6 +3908,12 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   assertion-error@1.1.0: {}
 
@@ -3573,6 +3924,10 @@ snapshots:
   baseline-browser-mapping@2.10.8: {}
 
   before-after-hook@4.0.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   body-parser@2.2.2:
     dependencies:
@@ -3695,11 +4050,27 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-eql@4.1.4:
     dependencies:
@@ -3709,7 +4080,13 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   diff-sequences@29.6.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3724,6 +4101,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   encodeurl@2.0.0: {}
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -4076,6 +4455,12 @@ snapshots:
 
   hono@4.12.8: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -4095,6 +4480,8 @@ snapshots:
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
 
@@ -4163,6 +4550,8 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-stream@3.0.0: {}
@@ -4178,6 +4567,32 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  jsdom@29.0.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@asamuzakjp/dom-selector': 7.0.3
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4230,15 +4645,21 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -4257,6 +4678,8 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -4345,6 +4768,10 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   patch-console@2.0.0: {}
@@ -4393,6 +4820,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -4424,6 +4857,8 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
 
   react-reconciler@0.33.0(react@19.2.4):
@@ -4450,6 +4885,11 @@ snapshots:
   react@19.2.4: {}
 
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   require-from-string@2.0.2: {}
 
@@ -4509,6 +4949,10 @@ snapshots:
       - supports-color
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -4625,6 +5069,10 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
@@ -4638,6 +5086,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
 
@@ -4664,9 +5114,23 @@ snapshots:
 
   tinyspy@2.2.1: {}
 
+  tldts-core@7.0.26: {}
+
+  tldts@7.0.26:
+    dependencies:
+      tldts-core: 7.0.26
+
   to-rotated@1.0.0: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.26
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -4744,6 +5208,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.24.4: {}
+
   universal-user-agent@7.0.3: {}
 
   unpipe@1.0.0: {}
@@ -4801,7 +5267,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@1.6.1(@types/node@20.19.37):
+  vitest@1.6.1(@types/node@20.19.37)(jsdom@29.0.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -4825,6 +5291,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
+      jsdom: 29.0.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -4834,6 +5301,22 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -4859,6 +5342,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- Add 130 React component rendering tests using @testing-library/react + jsdom
- 21 test files covering all 21 Sprint 7 components
- Setup: vitest environmentMatchGlobs for jsdom on `tests/frontend/render/**`

## Test Coverage by Component

| Component | Tests | Verifies |
|-----------|-------|----------|
| Sidebar | 5 | Nav links, hrefs, title, active class |
| SeverityBadge | 7 | All 4 severity labels, CSS classes, large variant |
| VerdictBanner | 6 | ACCEPT/REJECT/NEEDS_HUMAN, reasoning, questions |
| IssueCard | 7 | Expand/collapse, problem/evidence/suggestion, reviewers |
| SeveritySummary | 6 | Segments, legend, zero count handling |
| ProgressBar | 8 | Width, label, variant classes, clamping |
| EventLog | 7 | Empty state, events, type CSS, 200 limit |
| ModelLeaderboard | 6 | Table rows, win rate colors, top highlight, sort |
| ProviderReliability | 6 | Cards, health status badges, stats |
| SessionList | 6 | Rows, status badges, sort, empty state |
| SessionFilters | 6 | Inputs, onChange, filter count, clear |
| TrendChart | 6 | SVG, bars, empty, axes |
| CostSummary | 6 | 4 metric cards, dollar format, empty |
| ReviewerCosts | 6 | Bars, costs, providers, sorting |
| DiscussionList | 6 | Items, consensus, rounds, filtering |
| DebateTimeline | 6 | Prompts, responses, stances, DA highlight |
| ConsensusProgress | 6 | SVG bars, percentages, empty |
| ConfigSection | 6 | Collapse/expand, aria-expanded |
| ConfigField | 6 | text/number/boolean/select, validation errors |
| ConfigPreview | 5 | JSON render, copy button |
| Toast | 6 | Success/error styles, auto-dismiss, close |

## Test Plan
- [x] 336 total web tests pass (207 utility + 130 rendering - 1 overlap)
- [x] All 30 test files pass
- [x] jsdom environment isolated to render tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)