### PR TITLE
fix: resolve all 12 Sprint 7 code review issues (#157)

### DIFF
--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -1,0 +1,2 @@
+.claude/worktrees/
+.claude/worktrees/

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,6 +19,11 @@
     "@hono/node-ws": "^1.1.0",
     "hono": "^4.7.0"
   },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0",
+    "react-router-dom": ">=6.0.0"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/web/src/frontend/hooks/useApi.ts
+++ b/packages/web/src/frontend/hooks/useApi.ts
@@ -22,6 +22,11 @@ export function useApi<T>(path: string): UseApiResult<T> {
   }, []);
 
   useEffect(() => {
+    if (!path) {
+      setLoading(false);
+      return;
+    }
+
     let cancelled = false;
 
     async function fetchData(): Promise<void> {

--- a/packages/web/src/frontend/hooks/useWebSocket.ts
+++ b/packages/web/src/frontend/hooks/useWebSocket.ts
@@ -1,8 +1,11 @@
 /**
  * useWebSocket — WebSocket connection hook for real-time events.
+ * Features: message buffer cap (500), exponential backoff reconnect.
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+
+const MAX_MESSAGES = 500;
 
 interface UseWebSocketResult {
   messages: unknown[];
@@ -14,6 +17,8 @@ export function useWebSocket(path: string): UseWebSocketResult {
   const [messages, setMessages] = useState<unknown[]>([]);
   const [connected, setConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
+  const attemptRef = useRef(0);
+  const unmountedRef = useRef(false);
 
   const send = useCallback((data: string) => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
@@ -22,36 +27,69 @@ export function useWebSocket(path: string): UseWebSocketResult {
   }, []);
 
   useEffect(() => {
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const url = `${protocol}//${window.location.host}${path}`;
+    unmountedRef.current = false;
+    attemptRef.current = 0;
 
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 
-    ws.onopen = () => {
-      setConnected(true);
-    };
+    function connect(): void {
+      if (unmountedRef.current) return;
 
-    ws.onmessage = (event: MessageEvent) => {
-      try {
-        const parsed: unknown = JSON.parse(event.data as string);
-        setMessages((prev) => [...prev, parsed]);
-      } catch {
-        // Ignore unparseable messages
-      }
-    };
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const url = `${protocol}//${window.location.host}${path}`;
 
-    ws.onclose = () => {
-      setConnected(false);
-    };
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
 
-    ws.onerror = () => {
-      setConnected(false);
-    };
+      ws.onopen = () => {
+        if (!unmountedRef.current) {
+          setConnected(true);
+          attemptRef.current = 0;
+        }
+      };
+
+      ws.onmessage = (event: MessageEvent) => {
+        try {
+          const parsed: unknown = JSON.parse(event.data as string);
+          setMessages((prev) => {
+            const next = [...prev, parsed];
+            return next.length > MAX_MESSAGES ? next.slice(-MAX_MESSAGES) : next;
+          });
+        } catch {
+          // Ignore unparseable messages
+        }
+      };
+
+      ws.onclose = () => {
+        if (unmountedRef.current) return;
+        setConnected(false);
+        wsRef.current = null;
+
+        // Exponential backoff: 1s → 2s → 4s → … → max 30s
+        const delay = Math.min(1000 * Math.pow(2, attemptRef.current), 30000);
+        attemptRef.current += 1;
+        reconnectTimeout = setTimeout(() => connect(), delay);
+      };
+
+      ws.onerror = () => {
+        if (!unmountedRef.current) {
+          setConnected(false);
+        }
+        // onclose will fire after onerror and handle reconnect
+      };
+    }
+
+    connect();
 
     return () => {
-      ws.close();
-      wsRef.current = null;
+      unmountedRef.current = true;
+      if (reconnectTimeout !== null) {
+        clearTimeout(reconnectTimeout);
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
     };
   }, [path]);
 

--- a/packages/web/src/frontend/pages/Discussions.tsx
+++ b/packages/web/src/frontend/pages/Discussions.tsx
@@ -28,6 +28,10 @@ interface SessionData {
   rounds: Record<string, DiscussionRound[]>;
 }
 
+// Validation patterns — defined outside component to avoid re-creation on renders
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const ID_PATTERN = /^\d{3}$/;
+
 // ============================================================================
 // Component
 // ============================================================================
@@ -37,16 +41,24 @@ export function Discussions(): React.JSX.Element {
   const [idInput, setIdInput] = useState('');
   const [sessionPath, setSessionPath] = useState<string | null>(null);
   const [selectedDiscussionId, setSelectedDiscussionId] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const { data: session, loading, error, refetch } = useApi<SessionData>(
     sessionPath ?? '',
   );
 
   const handleLoad = useCallback(() => {
-    if (dateInput.trim() && idInput.trim()) {
-      setSessionPath(`/api/sessions/${dateInput.trim()}/${idInput.trim()}`);
-      setSelectedDiscussionId(null);
+    const trimmedDate = dateInput.trim();
+    const trimmedId = idInput.trim();
+
+    if (!DATE_PATTERN.test(trimmedDate) || !ID_PATTERN.test(trimmedId)) {
+      setValidationError('Date must be YYYY-MM-DD and Session ID must be 3 digits.');
+      return;
     }
+
+    setValidationError(null);
+    setSessionPath(`/api/sessions/${trimmedDate}/${trimmedId}`);
+    setSelectedDiscussionId(null);
   }, [dateInput, idInput]);
 
   const handleKeyDown = useCallback(
@@ -103,7 +115,7 @@ export function Discussions(): React.JSX.Element {
           <input
             className="filter-input"
             type="text"
-            placeholder="Session ID"
+            placeholder="Session ID (3 digits)"
             value={idInput}
             onChange={(e) => setIdInput(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -118,6 +130,9 @@ export function Discussions(): React.JSX.Element {
             Load Session
           </button>
         </div>
+        {validationError && (
+          <p className="error-text" role="alert">{validationError}</p>
+        )}
       </div>
     );
   }

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -64,7 +64,7 @@ export function startServer(options: ServerOptions = {}): {
   close: () => void;
 } {
   const port = options.port ?? (Number(process.env['PORT']) || 6274);
-  const hostname = options.hostname ?? '0.0.0.0';
+  const hostname = options.hostname ?? '127.0.0.1';
 
   const app = createApp();
   const { injectWebSocket } = setupWebSocket(app);

--- a/packages/web/src/server/middleware.ts
+++ b/packages/web/src/server/middleware.ts
@@ -37,6 +37,6 @@ export async function errorHandler(c: Context, next: Next): Promise<Response> {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Internal server error';
     const status = (error as { status?: number }).status ?? 500;
-    return c.json({ error: message }, status as 500);
+    return c.json({ error: message }, { status });
   }
 }

--- a/packages/web/src/server/routes/config.ts
+++ b/packages/web/src/server/routes/config.ts
@@ -22,6 +22,17 @@ configRoutes.get('/', async (c) => {
     return c.json({ error: 'No configuration file found' }, 404);
   }
 
+  if (
+    typeof config === 'object' &&
+    '_format' in config &&
+    (config as Record<string, unknown>)['_format'] === 'yaml'
+  ) {
+    return c.json(
+      { error: 'YAML config editing is not yet supported in the dashboard. Use .ca/config.json instead.' },
+      501,
+    );
+  }
+
   return c.json(config);
 });
 
@@ -44,7 +55,7 @@ configRoutes.put('/', async (c) => {
 
   await writeFile(targetPath, JSON.stringify(result.data, null, 2), 'utf-8');
 
-  return c.json({ status: 'saved', path: targetPath });
+  return c.json({ status: 'saved' });
 });
 
 /**
@@ -86,10 +97,9 @@ async function loadConfig(): Promise<unknown | null> {
   }
 
   try {
-    const content = await readFile(yamlPath, 'utf-8');
-    // YAML parsing: for now return raw string wrapped in object
-    // Full YAML support can be added via js-yaml dependency later
-    return { _raw: content, _format: 'yaml' };
+    await readFile(yamlPath, 'utf-8');
+    // YAML config detected — return sentinel so caller can respond with 501
+    return { _format: 'yaml' } as { _format: string };
   } catch {
     return null;
   }

--- a/packages/web/src/server/routes/costs.ts
+++ b/packages/web/src/server/routes/costs.ts
@@ -4,8 +4,10 @@
  */
 
 import { Hono } from 'hono';
-import { readdir, readFile } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import { readJsonSafe, readdirSafe } from '../utils/fs-helpers.js';
 
 const CA_ROOT = '.ca';
 
@@ -73,7 +75,8 @@ costRoutes.get('/', async (c) => {
  */
 costRoutes.get('/pricing', async (c) => {
   try {
-    const pricingPath = path.join('packages', 'shared', 'src', 'data', 'pricing.json');
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const pricingPath = path.resolve(__dirname, '../../../../shared/src/data/pricing.json');
     const content = await readFile(pricingPath, 'utf-8');
     return c.json(JSON.parse(content));
   } catch {
@@ -122,25 +125,3 @@ function extractCosts(
   return { date, sessionId, totalCost, reviewerCosts, layerCosts };
 }
 
-/**
- * Safely read directory entries, returning empty array on failure.
- */
-async function readdirSafe(dirPath: string): Promise<string[]> {
-  try {
-    return await readdir(dirPath);
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Safely read and parse a JSON file, returning null on failure.
- */
-async function readJsonSafe<T>(filePath: string): Promise<T | null> {
-  try {
-    const content = await readFile(filePath, 'utf-8');
-    return JSON.parse(content) as T;
-  } catch {
-    return null;
-  }
-}

--- a/packages/web/src/server/routes/sessions.ts
+++ b/packages/web/src/server/routes/sessions.ts
@@ -4,34 +4,11 @@
  */
 
 import { Hono } from 'hono';
-import { readdir, readFile } from 'fs/promises';
 import path from 'path';
 import type { SessionMetadata } from '@codeagora/core/types/core.js';
+import { readJsonSafe, readdirSafe } from '../utils/fs-helpers.js';
 
 const CA_ROOT = '.ca';
-
-/**
- * Safely read and parse a JSON file, returning null on failure.
- */
-async function readJsonSafe<T>(filePath: string): Promise<T | null> {
-  try {
-    const content = await readFile(filePath, 'utf-8');
-    return JSON.parse(content) as T;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * List directory entries safely, returning empty array on failure.
- */
-async function readdirSafe(dirPath: string): Promise<string[]> {
-  try {
-    return await readdir(dirPath);
-  } catch {
-    return [];
-  }
-}
 
 export const sessionRoutes = new Hono();
 
@@ -142,14 +119,14 @@ sessionRoutes.get('/:date/:id/verdict', async (c) => {
 /**
  * Load all review JSON files from a session's reviews/ directory.
  */
-async function loadSessionReviews(sessionDir: string): Promise<unknown[]> {
+async function loadSessionReviews(sessionDir: string): Promise<Record<string, unknown>[]> {
   const reviewsDir = path.join(sessionDir, 'reviews');
   const files = await readdirSafe(reviewsDir);
-  const reviews: unknown[] = [];
+  const reviews: Record<string, unknown>[] = [];
 
   for (const file of files) {
     if (!file.endsWith('.json')) continue;
-    const data = await readJsonSafe(path.join(reviewsDir, file));
+    const data = await readJsonSafe<Record<string, unknown>>(path.join(reviewsDir, file));
     if (data) reviews.push(data);
   }
 
@@ -159,14 +136,14 @@ async function loadSessionReviews(sessionDir: string): Promise<unknown[]> {
 /**
  * Load all discussion JSON files from a session's discussions/ directory.
  */
-async function loadSessionDiscussions(sessionDir: string): Promise<unknown[]> {
+async function loadSessionDiscussions(sessionDir: string): Promise<Record<string, unknown>[]> {
   const discussionsDir = path.join(sessionDir, 'discussions');
   const files = await readdirSafe(discussionsDir);
-  const discussions: unknown[] = [];
+  const discussions: Record<string, unknown>[] = [];
 
   for (const file of files) {
     if (!file.endsWith('.json')) continue;
-    const data = await readJsonSafe(path.join(discussionsDir, file));
+    const data = await readJsonSafe<Record<string, unknown>>(path.join(discussionsDir, file));
     if (data) discussions.push(data);
   }
 

--- a/packages/web/src/server/utils/fs-helpers.ts
+++ b/packages/web/src/server/utils/fs-helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared filesystem utility helpers for server routes.
+ */
+
+import { readdir, readFile } from 'fs/promises';
+
+/**
+ * Safely read directory entries, returning empty array on failure.
+ */
+export async function readdirSafe(dirPath: string): Promise<string[]> {
+  try {
+    return await readdir(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Safely read and parse a JSON file, returning null on failure.
+ */
+export async function readJsonSafe<T>(filePath: string): Promise<T | null> {
+  try {
+    const content = await readFile(filePath, 'utf-8');
+    return JSON.parse(content) as T;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Sprint 7 코드 리뷰에서 발견된 12개 이슈 전부 수정.

## Fixes

### CRITICAL (1)
- **Path traversal** — Discussions 페이지에서 date/id 입력값 정규식 검증 추가

### HIGH (3)
- **0.0.0.0 → 127.0.0.1** — 서버 기본 바인딩을 loopback으로 변경
- **파일 경로 노출** — PUT /api/config 응답에서 `path` 필드 제거
- **메모리 누수** — WebSocket 메시지 버퍼 500개 제한 + 지수 백오프 재연결

### MEDIUM (5)
- **DRY 위반** — `readdirSafe`/`readJsonSafe`를 `server/utils/fs-helpers.ts`로 추출
- **YAML 미지원** — YAML config일 때 501 응답 반환
- **빈 path fetch** — `useApi`에 빈 path 가드 추가
- **재연결 없음** — WebSocket 끊김 시 지수 백오프 재연결 로직 추가
- **타입 안전성** — `unknown[]` → `Record<string, unknown>[]`

### LOW (3)
- **peerDependencies** — react/react-dom/react-router-dom 추가
- **pricing 경로** — `import.meta.url` 기반 상대 경로로 변경
- **에러 status** — unsafe cast 제거

## Test Plan
- [x] 336 tests 전부 통과 (변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)