### PR TITLE
fix: resolve 3 remaining Sprint 7 re-review issues (#158)

### DIFF
--- a/packages/web/src/frontend/utils/session-filters.ts
+++ b/packages/web/src/frontend/utils/session-filters.ts
@@ -29,7 +29,7 @@ export type SortDirection = 'asc' | 'desc';
 export interface SessionDetail {
   metadata: SessionMetadata;
   reviews: SessionReview[];
-  discussions: unknown[];
+  discussions: Record<string, unknown>[];
   verdict: SessionVerdict | null;
 }
 

--- a/packages/web/src/server/middleware.ts
+++ b/packages/web/src/server/middleware.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Context, Next } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 /**
  * CORS middleware — allows localhost origins in development.
@@ -36,7 +37,7 @@ export async function errorHandler(c: Context, next: Next): Promise<Response> {
     return c.res;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Internal server error';
-    const status = (error as { status?: number }).status ?? 500;
-    return c.json({ error: message }, { status });
+    const status = ((error as { status?: number }).status ?? 500) as ContentfulStatusCode;
+    return c.json({ error: message }, status);
   }
 }

--- a/packages/web/src/server/routes/config.ts
+++ b/packages/web/src/server/routes/config.ts
@@ -51,6 +51,14 @@ configRoutes.put('/', async (c) => {
   }
 
   const configPath = await getExistingConfigPath();
+
+  if (configPath?.endsWith('.yaml') || configPath?.endsWith('.yml')) {
+    return c.json(
+      { error: 'YAML config editing is not yet supported. Use .ca/config.json instead.' },
+      501,
+    );
+  }
+
   const targetPath = configPath ?? path.join(CA_ROOT, 'config.json');
 
   await writeFile(targetPath, JSON.stringify(result.data, null, 2), 'utf-8');


### PR DESCRIPTION
## Summary
코드 리뷰 재검토에서 발견된 3개 잔여 이슈 수정.

| Severity | Issue | Fix |
|----------|-------|-----|
| HIGH | `middleware.ts` TS 컴파일 에러 | `ContentfulStatusCode` import + 타입 안전 cast |
| MEDIUM | `session-filters.ts` `unknown[]` 타입 | `Record<string, unknown>[]`로 변경 |
| MEDIUM | PUT /api/config YAML 덮어쓰기 | YAML 파일이면 501 반환 |

## Test Plan
- [x] `tsc --noEmit` — 0 errors
- [x] 336 tests — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)