### PR TITLE
fix: resolve 5 final Sprint 7 review issues (#160)

### DIFF
--- a/packages/web/src/frontend/components/ConfigPreview.tsx
+++ b/packages/web/src/frontend/components/ConfigPreview.tsx
@@ -3,7 +3,7 @@
  * Syntax-highlighted read-only code block with copy to clipboard.
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 
 interface ConfigPreviewProps {
   config: Record<string, unknown>;
@@ -85,11 +85,16 @@ export function ConfigPreview({ config }: ConfigPreviewProps): React.JSX.Element
 
   const jsonStr = JSON.stringify(config, null, 2);
 
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => () => { clearTimeout(copyTimerRef.current); }, []);
+
   const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(jsonStr);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       // Clipboard API may not be available
     }

--- a/packages/web/src/frontend/hooks/usePipelineEvents.ts
+++ b/packages/web/src/frontend/hooks/usePipelineEvents.ts
@@ -3,7 +3,7 @@
  * Wraps useWebSocket and maintains pipeline state from ProgressEvents and DiscussionEvents.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useWebSocket } from './useWebSocket.js';
 
 // ============================================================================
@@ -293,30 +293,50 @@ export function getCurrentStage(stages: StageState[]): PipelineStage | null {
 
 export function usePipelineEvents(): UsePipelineEventsResult {
   const { messages, connected } = useWebSocket('/ws');
+  const lastProcessedRef = useRef(0);
+  const stateRef = useRef<{
+    stages: StageState[];
+    discussions: DiscussionState[];
+    events: PipelineEventEntry[];
+    eventId: number;
+  }>({
+    stages: createInitialStages(),
+    discussions: [],
+    events: [],
+    eventId: 0,
+  });
 
   const result = useMemo(() => {
-    let stages = createInitialStages();
-    let discussions: DiscussionState[] = [];
-    const events: PipelineEventEntry[] = [];
-    let eventId = 0;
+    const state = stateRef.current;
 
-    for (const msg of messages) {
+    // Reset if messages were trimmed (buffer wrapped)
+    if (messages.length < lastProcessedRef.current) {
+      state.stages = createInitialStages();
+      state.discussions = [];
+      state.events = [];
+      state.eventId = 0;
+      lastProcessedRef.current = 0;
+    }
+
+    // Only process new messages since last run
+    for (let i = lastProcessedRef.current; i < messages.length; i++) {
+      const msg = messages[i];
       if (!isWebSocketMessage(msg)) continue;
 
       if (msg.type === 'progress' && isProgressEvent(msg.data)) {
         const progressEvent = msg.data as ProgressEvent;
-        stages = processProgressEvent(stages, progressEvent);
-        events.push({
-          id: eventId++,
+        state.stages = processProgressEvent(state.stages, progressEvent);
+        state.events.push({
+          id: state.eventId++,
           source: 'progress',
           event: progressEvent,
           timestamp: progressEvent.timestamp,
         });
       } else if (msg.type === 'discussion' && isDiscussionEvent(msg.data)) {
         const discussionEvent = msg.data as DiscussionEvent;
-        discussions = processDiscussionEvent(discussions, discussionEvent);
-        events.push({
-          id: eventId++,
+        state.discussions = processDiscussionEvent(state.discussions, discussionEvent);
+        state.events.push({
+          id: state.eventId++,
           source: 'discussion',
           event: discussionEvent,
           timestamp: Date.now(),
@@ -324,14 +344,21 @@ export function usePipelineEvents(): UsePipelineEventsResult {
       }
     }
 
-    // Limit to MAX_EVENTS (keep most recent)
-    const trimmedEvents = events.length > MAX_EVENTS
-      ? events.slice(events.length - MAX_EVENTS)
-      : events;
+    lastProcessedRef.current = messages.length;
 
-    const currentStage = getCurrentStage(stages);
+    // Trim events to MAX_EVENTS
+    if (state.events.length > MAX_EVENTS) {
+      state.events = state.events.slice(state.events.length - MAX_EVENTS);
+    }
 
-    return { stages, currentStage, events: trimmedEvents, discussions };
+    const currentStage = getCurrentStage(state.stages);
+
+    return {
+      stages: state.stages,
+      currentStage,
+      events: state.events,
+      discussions: state.discussions,
+    };
   }, [messages]);
 
   return { ...result, connected };

--- a/packages/web/src/frontend/pages/ReviewDetail.tsx
+++ b/packages/web/src/frontend/pages/ReviewDetail.tsx
@@ -68,9 +68,21 @@ const statusClassMap: Record<string, string> = {
 
 export function ReviewDetail(): React.JSX.Element {
   const { date, id } = useParams<{ date: string; id: string }>();
+
+  const isValidParams = date && id && /^\d{4}-\d{2}-\d{2}$/.test(date) && /^\d{3}$/.test(id);
+
   const { data: session, loading, error } = useApi<SessionDetail>(
-    `/api/sessions/${date}/${id}`,
+    isValidParams ? `/api/sessions/${date}/${id}` : '',
   );
+
+  if (!isValidParams) {
+    return (
+      <div className="page">
+        <h2>Error</h2>
+        <p>Invalid session identifier</p>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/packages/web/src/frontend/pages/Sessions.tsx
+++ b/packages/web/src/frontend/pages/Sessions.tsx
@@ -104,6 +104,7 @@ export function Sessions(): React.JSX.Element {
   // Keyboard navigation
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent): void {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLSelectElement) return;
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setFocusedIndex((prev) => Math.min(prev + 1, sorted.length - 1));

--- a/packages/web/src/server/routes/costs.ts
+++ b/packages/web/src/server/routes/costs.ts
@@ -6,7 +6,6 @@
 import { Hono } from 'hono';
 import { readFile } from 'fs/promises';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { readJsonSafe, readdirSafe } from '../utils/fs-helpers.js';
 
 const CA_ROOT = '.ca';
@@ -75,8 +74,7 @@ costRoutes.get('/', async (c) => {
  */
 costRoutes.get('/pricing', async (c) => {
   try {
-    const __dirname = path.dirname(fileURLToPath(import.meta.url));
-    const pricingPath = path.resolve(__dirname, '../../../../shared/src/data/pricing.json');
+    const pricingPath = path.join(process.cwd(), 'packages', 'shared', 'src', 'data', 'pricing.json');
     const content = await readFile(pricingPath, 'utf-8');
     return c.json(JSON.parse(content));
   } catch {


### PR DESCRIPTION
## Summary
4차 코드 리뷰에서 발견된 5개 잔여 이슈 수정.

| # | Severity | Fix |
|---|----------|-----|
| 1 | HIGH | ReviewDetail useParams 검증 (path traversal 방어) |
| 2 | MEDIUM | ConfigPreview setTimeout 언마운트 시 cleanup |
| 3 | MEDIUM | usePipelineEvents 증분 처리 (O(n²) → O(1)/msg) |
| 4 | MEDIUM | pricing 경로 cwd 기반으로 변경 |
| 5 | LOW | Sessions 키보드 핸들러 input 포커스 시 스킵 |

## Test Plan
- [x] `tsc --noEmit` — 0 errors
- [x] 336 tests — all pass
- [x] Vite build — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)