### PR TITLE
chore: bump all packages to v2.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeagora",
-  "version": "1.1.1-rc.2",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "description": "Multi-LLM code review pipeline — parallel reviewers, structured debate, consensus verdict",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/cli",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/core",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/github",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/mcp",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/notifications",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/shared",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/tui",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/web",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
9개 패키지 버전 `2.0.0-rc.1`로 동기화.

## Verification
- [x] `tsc --noEmit` — 0 errors
- [x] 1,544 root tests + 336 web tests = 1,880 tests pass
- [x] `tsup` build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)