### PR TITLE
feat: CLI improvements batch 2 — --staged, status, config-set, providers-test, --json-stream

### DIFF
--- a/packages/cli/src/commands/config-set.ts
+++ b/packages/cli/src/commands/config-set.ts
@@ -1,0 +1,106 @@
+/**
+ * Config Set / Config Edit Commands
+ * Set config values via dot notation or open config in $EDITOR.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { t } from '@codeagora/shared/i18n/index.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Resolve the config file path. Prefers JSON, falls back to YAML.
+ */
+async function resolveConfigPath(baseDir: string): Promise<string | null> {
+  const jsonPath = path.join(baseDir, '.ca', 'config.json');
+  const yamlPath = path.join(baseDir, '.ca', 'config.yaml');
+
+  for (const p of [jsonPath, yamlPath]) {
+    try {
+      await fs.access(p);
+      return p;
+    } catch { /* continue */ }
+  }
+  return null;
+}
+
+/**
+ * Parse a raw CLI value string into a typed value.
+ * Detects booleans, numbers, and falls back to string.
+ */
+function parseValue(raw: string): string | number | boolean {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  const num = Number(raw);
+  if (!isNaN(num) && raw.trim() !== '') return num;
+  return raw;
+}
+
+/**
+ * Set a nested key on an object using dot notation.
+ * E.g. setNestedKey(obj, 'discussion.maxRounds', 5)
+ */
+function setNestedKey(
+  obj: Record<string, unknown>,
+  dotKey: string,
+  value: unknown,
+): void {
+  const parts = dotKey.split('.');
+  let current: Record<string, unknown> = obj;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i]!;
+    if (typeof current[part] !== 'object' || current[part] === null) {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+
+  const lastKey = parts[parts.length - 1]!;
+  current[lastKey] = value;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export async function setConfigValue(
+  baseDir: string,
+  key: string,
+  rawValue: string,
+): Promise<void> {
+  const configPath = await resolveConfigPath(baseDir);
+  if (!configPath) {
+    throw new Error(t('cli.config.notFound', { cmd: 'agora' }));
+  }
+
+  if (configPath.endsWith('.yaml') || configPath.endsWith('.yml')) {
+    throw new Error('YAML config editing is not yet supported. Use .ca/config.json.');
+  }
+
+  const raw = await fs.readFile(configPath, 'utf-8');
+  const config = JSON.parse(raw) as Record<string, unknown>;
+
+  const typedValue = parseValue(rawValue);
+  setNestedKey(config, key, typedValue);
+
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+export async function editConfig(baseDir: string): Promise<void> {
+  const configPath = await resolveConfigPath(baseDir);
+  if (!configPath) {
+    throw new Error(t('cli.config.notFound', { cmd: 'agora' }));
+  }
+
+  const editor = process.env['VISUAL'] || process.env['EDITOR'] || 'vi';
+  const result = spawnSync(editor, [configPath], { stdio: 'inherit' });
+
+  if (result.error) {
+    throw new Error(`Failed to open editor: ${result.error.message}`);
+  }
+}

--- a/packages/cli/src/commands/providers-test.ts
+++ b/packages/cli/src/commands/providers-test.ts
@@ -1,0 +1,89 @@
+/**
+ * Providers Test Command
+ * Verify API key status for all known providers.
+ */
+
+import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
+import { bold, statusColor, dim } from '../utils/colors.js';
+import { t } from '@codeagora/shared/i18n/index.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ProviderTestResult {
+  name: string;
+  envVar: string;
+  status: 'set' | 'missing' | 'unusual';
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Basic format validation for common API key patterns.
+ * Returns true if the key looks like a plausible API key.
+ */
+function looksLikeApiKey(value: string): boolean {
+  // Most API keys are at least 20 chars and alphanumeric with dashes/underscores
+  if (value.length < 10) return false;
+  if (/\s/.test(value)) return false;
+  return true;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export function testProviders(): ProviderTestResult[] {
+  const results: ProviderTestResult[] = [];
+
+  for (const [name, envVar] of Object.entries(PROVIDER_ENV_VARS)) {
+    const value = process.env[envVar];
+    if (!value) {
+      results.push({ name, envVar, status: 'missing' });
+    } else if (!looksLikeApiKey(value)) {
+      results.push({ name, envVar, status: 'unusual' });
+    } else {
+      results.push({ name, envVar, status: 'set' });
+    }
+  }
+
+  return results;
+}
+
+export function formatProviderTestResults(results: ProviderTestResult[]): string {
+  const COL_PROVIDER = 18;
+  const COL_KEY = 24;
+
+  const lines: string[] = [];
+  lines.push(bold(t('cli.providers.test.title')));
+  lines.push('\u2500'.repeat(COL_PROVIDER + COL_KEY + 12));
+
+  for (const r of results) {
+    const nameCol = r.name.padEnd(COL_PROVIDER);
+    const envCol = r.envVar.padEnd(COL_KEY);
+
+    if (r.status === 'set') {
+      lines.push(`  ${statusColor.pass('\u2713')} ${bold(nameCol)} ${dim(envCol)} ${statusColor.pass('key set')}`);
+    } else if (r.status === 'unusual') {
+      lines.push(`  ${statusColor.warn('?')} ${bold(nameCol)} ${dim(envCol)} ${statusColor.warn('key format unusual')}`);
+    } else {
+      lines.push(`  ${statusColor.fail('\u2717')} ${bold(nameCol)} ${dim(envCol)} ${statusColor.fail('key missing')}`);
+    }
+  }
+
+  const setCount = results.filter((r) => r.status === 'set').length;
+  const unusualCount = results.filter((r) => r.status === 'unusual').length;
+  const missingCount = results.filter((r) => r.status === 'missing').length;
+
+  lines.push('');
+  lines.push(
+    `${statusColor.pass(String(setCount))} set, ` +
+    `${statusColor.warn(String(unusualCount))} unusual, ` +
+    `${statusColor.fail(String(missingCount))} missing`,
+  );
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,216 @@
+/**
+ * Status Command
+ * Show a one-screen overview of CodeAgora state.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { bold, dim, statusColor } from '../utils/colors.js';
+import { t } from '@codeagora/shared/i18n/index.js';
+import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function dirExists(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calculate total size of a directory tree (bytes).
+ */
+async function dirSize(dirPath: string): Promise<number> {
+  let total = 0;
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        total += await dirSize(full);
+      } else if (entry.isFile()) {
+        const stat = await fs.stat(full);
+        total += stat.size;
+      }
+    }
+  } catch {
+    // directory may not exist
+  }
+  return total;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export async function getStatus(baseDir: string): Promise<string> {
+  const caDir = path.join(baseDir, '.ca');
+  const lines: string[] = [];
+
+  lines.push(bold(t('cli.status.title')));
+  lines.push('\u2500'.repeat(40));
+
+  // --- Config ---
+  lines.push('');
+  lines.push(bold(t('cli.status.config')));
+
+  const jsonPath = path.join(caDir, 'config.json');
+  const yamlPath = path.join(caDir, 'config.yaml');
+  const jsonExists = await fileExists(jsonPath);
+  const yamlExists = await fileExists(yamlPath);
+
+  if (jsonExists || yamlExists) {
+    const configPath = jsonExists ? jsonPath : yamlPath;
+    const format = jsonExists ? 'json' : 'yaml';
+    const config = await readJsonFile(configPath);
+    const lang = config ? String(config['language'] ?? 'en') : 'en';
+    const mode = config && typeof config['reviewers'] === 'object' && config['reviewers'] !== null
+      && !Array.isArray(config['reviewers']) && 'count' in (config['reviewers'] as Record<string, unknown>)
+      ? 'declarative' : 'explicit';
+    lines.push(`  ${statusColor.pass('\u2713')} Found (.ca/config.${format})`);
+    lines.push(`  Language: ${lang}  Mode: ${mode}`);
+  } else {
+    lines.push(`  ${statusColor.fail('\u2717')} Not found`);
+  }
+
+  // --- Providers ---
+  lines.push('');
+  lines.push(bold(t('cli.status.providers')));
+
+  const providerNames = Object.keys(PROVIDER_ENV_VARS);
+  const configured: string[] = [];
+  const withKeys: string[] = [];
+
+  for (const name of providerNames) {
+    const envVar = PROVIDER_ENV_VARS[name]!;
+    const hasKey = Boolean(process.env[envVar]);
+    if (hasKey) {
+      configured.push(name);
+      withKeys.push(name);
+    }
+  }
+
+  lines.push(`  ${configured.length} with API keys: ${withKeys.length > 0 ? withKeys.join(', ') : dim('none')}`);
+
+  // --- Sessions ---
+  lines.push('');
+  lines.push(bold(t('cli.status.sessions')));
+
+  const sessionsDir = path.join(caDir, 'sessions');
+  if (await dirExists(sessionsDir)) {
+    let totalSessions = 0;
+    let lastDate = '';
+    let lastVerdict = '';
+
+    try {
+      const dateDirs = (await fs.readdir(sessionsDir))
+        .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))
+        .sort()
+        .reverse();
+
+      for (const dateDir of dateDirs) {
+        const datePath = path.join(sessionsDir, dateDir);
+        try {
+          const sessionIds = await fs.readdir(datePath);
+          const dirs = [];
+          for (const sid of sessionIds) {
+            try {
+              const stat = await fs.stat(path.join(datePath, sid));
+              if (stat.isDirectory()) dirs.push(sid);
+            } catch { /* skip */ }
+          }
+          totalSessions += dirs.length;
+          if (!lastDate && dirs.length > 0) {
+            lastDate = dateDir;
+            // Try reading verdict from the most recent session
+            const latestSid = dirs.sort().reverse()[0];
+            if (latestSid) {
+              const verdictData = await readJsonFile(
+                path.join(datePath, latestSid, 'head-verdict.json'),
+              );
+              if (verdictData) {
+                lastVerdict = String(verdictData['decision'] ?? '');
+              }
+            }
+          }
+        } catch { /* skip */ }
+      }
+
+      lines.push(`  Total: ${totalSessions}`);
+      if (lastDate) {
+        lines.push(`  ${t('cli.status.lastReview')}: ${lastDate}${lastVerdict ? ` (${lastVerdict})` : ''}`);
+      }
+    } catch {
+      lines.push(`  ${t('cli.status.noSessions')}`);
+    }
+  } else {
+    lines.push(`  ${t('cli.status.noSessions')}`);
+  }
+
+  // --- Models (top 3 by win rate) ---
+  const modelQualityPath = path.join(caDir, 'model-quality.json');
+  if (await fileExists(modelQualityPath)) {
+    const mqData = await readJsonFile(modelQualityPath);
+    if (mqData && typeof mqData['arms'] === 'object' && mqData['arms'] !== null) {
+      const arms = mqData['arms'] as Record<string, { alpha?: number; beta?: number }>;
+      const entries = Object.entries(arms)
+        .map(([name, arm]) => {
+          const alpha = arm.alpha ?? 1;
+          const beta = arm.beta ?? 1;
+          const winRate = alpha / (alpha + beta);
+          return { name, winRate };
+        })
+        .sort((a, b) => b.winRate - a.winRate)
+        .slice(0, 3);
+
+      if (entries.length > 0) {
+        lines.push('');
+        lines.push(bold('Models (top 3)'));
+        for (const e of entries) {
+          lines.push(`  ${e.name}  ${dim(`win rate: ${(e.winRate * 100).toFixed(1)}%`)}`);
+        }
+      }
+    }
+  }
+
+  // --- Disk usage ---
+  const sessionSize = await dirSize(sessionsDir);
+  if (sessionSize > 0) {
+    lines.push('');
+    lines.push(bold('Disk'));
+    lines.push(`  Sessions: ${formatBytes(sessionSize)}`);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,6 +36,9 @@ import { computeAgreementMatrix, formatAgreementMatrix } from './commands/agreem
 import { loadSessionForReplay } from './commands/replay.js';
 import { startDashboard } from './commands/dashboard.js';
 import { getCostSummary } from './commands/costs.js';
+import { getStatus } from './commands/status.js';
+import { setConfigValue, editConfig } from './commands/config-set.js';
+import { testProviders, formatProviderTestResults } from './commands/providers-test.js';
 
 // Load API keys from ~/.config/codeagora/credentials
 loadCredentials();
@@ -81,6 +84,8 @@ program
   .option('--pr <url-or-number>', 'GitHub PR URL or number (fetches diff from GitHub)')
   .option('--post-review', 'Post review comments back to the PR (requires --pr)', false)
   .option('--quick', 'Quick review (L1 only, skip discussion and verdict)')
+  .option('--staged', 'Review staged changes (git diff --staged)')
+  .option('--json-stream', 'Stream NDJSON events during review (for CI/pipelines)')
   .action(async (diffPath: string | undefined, options: {
     dryRun?: boolean;
     output: string;
@@ -96,6 +101,8 @@ program
     pr?: string;
     postReview: boolean;
     quick?: boolean;
+    staged?: boolean;
+    jsonStream?: boolean;
   }) => {
     // Hoist stdinTmpPath so finally block can clean it up (#77)
     let stdinTmpPath: string | undefined;
@@ -106,6 +113,28 @@ program
 
       const outputFormat = (['text', 'json', 'md', 'github', 'annotated'].includes(options.output)
         ? options.output : 'text') as OutputFormat;
+
+      // Handle --staged: run git diff --staged and use as input
+      if (options.staged) {
+        const { execFileSync } = await import('child_process');
+        let stagedDiff: string;
+        try {
+          stagedDiff = execFileSync('git', ['diff', '--staged'], { encoding: 'utf-8' });
+        } catch {
+          console.error('Failed to run "git diff --staged". Are you in a git repository?');
+          process.exit(1);
+        }
+        if (!stagedDiff.trim()) {
+          console.error(t('cli.staged.empty'));
+          process.exit(1);
+        }
+        const tmpDir = path.join(process.cwd(), '.ca', 'tmp');
+        await fs.mkdir(tmpDir, { recursive: true });
+        const tmpPath = path.join(tmpDir, `staged-${Date.now()}.diff`);
+        await fs.writeFile(tmpPath, stagedDiff, 'utf-8');
+        diffPath = tmpPath;
+        stdinTmpPath = tmpPath; // reuse cleanup variable
+      }
 
       // Handle --pr: fetch diff from GitHub
       let resolvedPath: string;
@@ -217,8 +246,15 @@ program
       let progress: ProgressEmitter | undefined;
       let spinner: ReturnType<typeof ora> | undefined;
 
+      if (options.jsonStream) {
+        progress = progress ?? new ProgressEmitter();
+        progress.onProgress((event) => {
+          process.stdout.write(JSON.stringify(event) + '\n');
+        });
+      }
+
       if (!options.quiet) {
-        progress = new ProgressEmitter();
+        progress = progress ?? new ProgressEmitter();
         spinner = ora({ stream: process.stderr });
 
         const stageLabels: Record<string, string> = {
@@ -265,6 +301,11 @@ program
         }
       }
       console.log(formatOutput(result, outputFormat, annotatedOptions));
+
+      // Emit final result as NDJSON for --json-stream consumers
+      if (options.jsonStream) {
+        process.stdout.write(JSON.stringify({ type: 'result', ...result }) + '\n');
+      }
 
       // Post review to GitHub if --post-review and --pr were used
       if (options.postReview && prContext && result.status === 'success' && result.summary) {
@@ -747,6 +788,54 @@ program
     }
   });
 
+// === CLI Improvements Batch 2 ===
+
+program
+  .command('status')
+  .description('Show CodeAgora status overview')
+  .action(async () => {
+    try {
+      const output = await getStatus(process.cwd());
+      console.log(output);
+    } catch (error) {
+      console.error('Error:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('config-set <key> <value>')
+  .description('Set a config value (dot notation: discussion.maxRounds)')
+  .action(async (key: string, value: string) => {
+    try {
+      await setConfigValue(process.cwd(), key, value);
+      console.log(t('cli.config.set.success', { key, value }));
+    } catch (error) {
+      console.error('Error:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('config-edit')
+  .description('Open config in $EDITOR')
+  .action(async () => {
+    try {
+      await editConfig(process.cwd());
+    } catch (error) {
+      console.error('Error:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('providers-test')
+  .description('Verify API key status for all providers')
+  .action(() => {
+    const results = testProviders();
+    console.log(formatProviderTestResults(results));
+  });
+
 // === Help text examples (#169) ===
 
 // Find registered commands and add help text
@@ -759,8 +848,10 @@ Examples:
   git diff HEAD~1 | ${displayName} review          Review last commit
   ${displayName} review changes.diff               Review a diff file
   ${displayName} review --pr 123                   Review a GitHub PR
+  ${displayName} review --staged                   Review staged changes
   ${displayName} review --quick                    Quick review (L1 only)
   ${displayName} review --output json              JSON output for CI
+  ${displayName} review --json-stream              Stream NDJSON for CI
 `);
       break;
     case 'init':
@@ -830,6 +921,31 @@ Examples:
   ${displayName} language                          Show current language
   ${displayName} language en                       Set language to English
   ${displayName} language ko                       Set language to Korean
+`);
+      break;
+    case 'status':
+      cmd.addHelpText('after', `
+Examples:
+  ${displayName} status                            Show CodeAgora status
+`);
+      break;
+    case 'config-set':
+      cmd.addHelpText('after', `
+Examples:
+  ${displayName} config-set discussion.maxRounds 5 Set max discussion rounds
+  ${displayName} config-set language ko            Set language to Korean
+`);
+      break;
+    case 'config-edit':
+      cmd.addHelpText('after', `
+Examples:
+  ${displayName} config-edit                       Open config in editor
+`);
+      break;
+    case 'providers-test':
+      cmd.addHelpText('after', `
+Examples:
+  ${displayName} providers-test                    Check API key status
 `);
       break;
   }

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -205,5 +205,16 @@
   "cli.language.current": "Current language: {lang}",
   "cli.language.set": "Language set to {lang}",
   "cli.learn.list.empty": "No learned patterns",
-  "cli.learn.cleared": "All learned patterns cleared"
+  "cli.learn.cleared": "All learned patterns cleared",
+
+  "cli.status.title": "CodeAgora Status",
+  "cli.status.config": "Config",
+  "cli.status.providers": "Providers",
+  "cli.status.sessions": "Sessions",
+  "cli.status.lastReview": "Last review",
+  "cli.status.noSessions": "No review sessions yet",
+  "cli.config.set.success": "Config updated: {key} = {value}",
+  "cli.config.set.invalidKey": "Invalid config key: {key}",
+  "cli.providers.test.title": "Provider Status",
+  "cli.staged.empty": "No staged changes. Stage files with 'git add' first."
 }

--- a/packages/shared/src/i18n/locales/ko.json
+++ b/packages/shared/src/i18n/locales/ko.json
@@ -205,5 +205,16 @@
   "cli.language.current": "현재 언어: {lang}",
   "cli.language.set": "언어가 {lang}(으)로 설정되었습니다",
   "cli.learn.list.empty": "학습된 패턴이 없습니다",
-  "cli.learn.cleared": "모든 학습 패턴이 초기화되었습니다"
+  "cli.learn.cleared": "모든 학습 패턴이 초기화되었습니다",
+
+  "cli.status.title": "CodeAgora 상태",
+  "cli.status.config": "설정",
+  "cli.status.providers": "프로바이더",
+  "cli.status.sessions": "세션",
+  "cli.status.lastReview": "마지막 리뷰",
+  "cli.status.noSessions": "아직 리뷰 세션이 없습니다",
+  "cli.config.set.success": "설정 업데이트: {key} = {value}",
+  "cli.config.set.invalidKey": "잘못된 설정 키: {key}",
+  "cli.providers.test.title": "프로바이더 상태",
+  "cli.staged.empty": "스테이지된 변경이 없습니다. 먼저 'git add'로 파일을 스테이지하세요."
 }


### PR DESCRIPTION
## Summary
5개 CLI 개선 구현.

| Feature | 설명 |
|---------|------|
| `agora review --staged` | `git diff --staged` 자동 리뷰 |
| `agora review --json-stream` | NDJSON 스트리밍 출력 (CI용) |
| `agora status` | 설정/프로바이더/세션/모델 한눈에 |
| `agora config-set <key> <value>` | dot notation으로 설정값 변경 |
| `agora config-edit` | $EDITOR로 설정 파일 열기 |
| `agora providers-test` | API 키 상태 검증 |

## New Commands
```bash
agora review --staged              # 스테이지된 변경 리뷰
agora review --json-stream         # NDJSON 스트리밍
agora status                       # 전체 상태 한눈에
agora config-set discussion.maxRounds 5
agora config-edit                  # $EDITOR로 설정 편집
agora providers-test               # API 키 검증
```

## Test Plan
- [x] `tsc --noEmit` — 0 errors
- [x] 1,544 tests — pass
- [x] i18n: 199/199 keys (en/ko 동기화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)