### PR TITLE
fix: specify pnpm version in action-setup to support npm-based repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,8 @@ runs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
+      with:
+        version: 9
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Summary
- Add `version: 9` to all `pnpm/action-setup@v4` usages that were missing an explicit version (`action.yml`, `ci.yml`, `review.yml`)
- The composite action (`action.yml`) is consumed by external repos that may use npm and lack a `packageManager` field in their `package.json`, causing `pnpm/action-setup` to fail with: *"No pnpm version is specified"*
- `release.yml` and `provider-health.yml` already had `version: 10` and were not changed

## Test plan
- [ ] Verify CI passes on this PR (pnpm installs successfully with the pinned version)
- [ ] Test the composite action from an npm-based repo without `packageManager` in `package.json`

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration across CI/CD workflows to ensure consistent tooling versions during development and testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->