### PR TITLE
fix: remove ghost config options and wire L1 reviewer persona

### DIFF
--- a/packages/core/src/config/templates.ts
+++ b/packages/core/src/config/templates.ts
@@ -181,7 +181,6 @@ const DECLARATIVE_TEMPLATE_DATA = {
       minFamilies: 3,
       reasoning: { min: 1, max: 2 },
       contextMin: '32k',
-      tierMin: 'B',
     },
   },
   supporters: {

--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -58,6 +58,16 @@ export async function executeReviewer(
   // Extract file list from diff for fallback parsing
   const diffFilePaths = extractFileListFromDiff(diffContent);
 
+  // Load persona if configured (prepended to review prompt)
+  let personaPrefix = '';
+  if (config.persona) {
+    const { loadPersona } = await import('../l2/moderator.js');
+    const content = await loadPersona(config.persona);
+    if (content) {
+      personaPrefix = `${content}\n\n---\n\n`;
+    }
+  }
+
   for (let attempt = 0; attempt <= retries; attempt++) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), config.timeout * 1000);
@@ -67,7 +77,7 @@ export async function executeReviewer(
         backend: config.backend,
         model: config.model,
         provider: config.provider,
-        prompt: buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
         timeout: config.timeout,
         signal: controller.signal,
       });
@@ -103,7 +113,7 @@ export async function executeReviewer(
         backend: fb.backend,
         model: fb.model,
         provider: fb.provider,
-        prompt: buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
         timeout: config.timeout,
       });
 
@@ -222,6 +232,16 @@ async function executeReviewerWithGuards(
     };
   }
 
+  // Load persona if configured (prepended to review prompt)
+  let personaPrefix = '';
+  if (config.persona) {
+    const { loadPersona } = await import('../l2/moderator.js');
+    const content = await loadPersona(config.persona);
+    if (content) {
+      personaPrefix = `${content}\n\n---\n\n`;
+    }
+  }
+
   let lastError: Error | undefined;
   const diffFilePaths = extractFileListFromDiff(diffContent);
 
@@ -236,7 +256,7 @@ async function executeReviewerWithGuards(
         backend: config.backend,
         model: config.model,
         provider: config.provider,
-        prompt: buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
         timeout: config.timeout,
         signal: controller.signal,
       });
@@ -287,7 +307,7 @@ async function executeReviewerWithGuards(
         backend: fb.backend,
         model: fb.model,
         provider: fb.provider,
-        prompt: buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
         timeout: config.timeout,
       });
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -107,10 +107,10 @@ export type ModeratorConfig = z.infer<typeof ModeratorConfigSchema>;
 export const SupporterPoolConfigSchema = z.object({
   pool: z.array(AgentConfigSchema).min(1),
   pickCount: z.number().int().positive().default(2),
-  pickStrategy: z.enum(['random', 'round-robin']).default('random'),
+  pickStrategy: z.literal('random').default('random'),
   devilsAdvocate: AgentConfigSchema,
   personaPool: z.array(z.string()).min(1),
-  personaAssignment: z.enum(['random', 'fixed']).default('random'),
+  personaAssignment: z.literal('random').default('random'),
 });
 export type SupporterPoolConfig = z.infer<typeof SupporterPoolConfigSchema>;
 
@@ -156,7 +156,6 @@ export const DeclarativeReviewersSchema = z.object({
         })
         .optional(),
       contextMin: z.string().default('32k'),
-      tierMin: z.string().default('B'),
       preferProviders: z.array(z.string()).optional(),
     })
     .optional(),

--- a/packages/tui/src/screens/config/SupportersTab.tsx
+++ b/packages/tui/src/screens/config/SupportersTab.tsx
@@ -69,11 +69,10 @@ export function SupportersTab({ config, isActive, onConfigChange }: Props): Reac
   }
 
   function cyclePickStrategy(): void {
-    const current = config.supporters.pickStrategy;
-    const next = current === 'random' ? 'round-robin' : 'random';
+    // Only 'random' is supported — round-robin was never implemented
     onConfigChange({
       ...config,
-      supporters: { ...config.supporters, pickStrategy: next },
+      supporters: { ...config.supporters, pickStrategy: 'random' },
     });
   }
 

--- a/packages/web/src/frontend/pages/Config.tsx
+++ b/packages/web/src/frontend/pages/Config.tsx
@@ -274,7 +274,7 @@ export function ConfigPage(): React.JSX.Element {
             type="select"
             value={getNestedValue(config, 'supporters.pickStrategy') ?? 'random'}
             onChange={(v) => updateField('supporters.pickStrategy', v)}
-            options={['random', 'round-robin']}
+            options={['random']}
             error={errors['supporters.pickStrategy']}
           />
           <ConfigField
@@ -283,7 +283,7 @@ export function ConfigPage(): React.JSX.Element {
             type="select"
             value={getNestedValue(config, 'supporters.personaAssignment') ?? 'random'}
             onChange={(v) => updateField('supporters.personaAssignment', v)}
-            options={['random', 'fixed']}
+            options={['random']}
             error={errors['supporters.personaAssignment']}
           />
           <ConfigField

--- a/packages/web/src/frontend/utils/config-helpers.ts
+++ b/packages/web/src/frontend/utils/config-helpers.ts
@@ -149,15 +149,15 @@ function validateConfigField(field: string, value: unknown): string | null {
 
   // Pick strategy
   if (field === 'pickStrategy') {
-    if (typeof value === 'string' && !['random', 'round-robin'].includes(value)) {
-      return `${field} must be "random" or "round-robin"`;
+    if (typeof value === 'string' && value !== 'random') {
+      return `${field} must be "random"`;
     }
   }
 
   // Persona assignment
   if (field === 'personaAssignment') {
-    if (typeof value === 'string' && !['random', 'fixed'].includes(value)) {
-      return `${field} must be "random" or "fixed"`;
+    if (typeof value === 'string' && value !== 'random') {
+      return `${field} must be "random"`;
     }
   }
 

--- a/packages/web/tests/frontend/config.test.ts
+++ b/packages/web/tests/frontend/config.test.ts
@@ -108,7 +108,7 @@ describe('validateConfigField', () => {
 
   it('should validate pickStrategy field', () => {
     expect(validateConfigField('pickStrategy', 'random')).toBeNull();
-    expect(validateConfigField('pickStrategy', 'round-robin')).toBeNull();
+    expect(validateConfigField('pickStrategy', 'round-robin')).not.toBeNull();
     expect(validateConfigField('pickStrategy', 'invalid')).not.toBeNull();
   });
 

--- a/src/tests/config-declarative.test.ts
+++ b/src/tests/config-declarative.test.ts
@@ -37,7 +37,6 @@ describe('DeclarativeReviewersSchema', () => {
         minFamilies: 3,
         reasoning: { min: 1, max: 2 },
         contextMin: '32k',
-        tierMin: 'A-',
       },
     });
 

--- a/src/tests/l2-supporter-selection.test.ts
+++ b/src/tests/l2-supporter-selection.test.ts
@@ -1,6 +1,6 @@
 /**
  * #187 Supporter Selection Tests
- * Verifies pickStrategy (round-robin vs random) and personaAssignment (fixed vs random)
+ * Verifies random selection and persona assignment
  * in selectSupporters from @codeagora/core/l2/moderator.js
  */
 
@@ -74,36 +74,6 @@ describe('pickStrategy: random', () => {
 });
 
 // ============================================================================
-// pickStrategy: 'round-robin'
-// ============================================================================
-
-describe('pickStrategy: round-robin', () => {
-  it('selects exactly pickCount supporters', () => {
-    const config = makeConfig({ pickStrategy: 'round-robin', pickCount: 2 });
-    const selected = selectSupporters(config);
-    // round-robin may not be implemented differently from random in current code;
-    // verify the contract: correct count, no duplicates, from enabled pool
-    expect(selected).toHaveLength(2);
-  });
-
-  it('selected supporters are from the enabled pool', () => {
-    const config = makeConfig({ pickStrategy: 'round-robin', pickCount: 2 });
-    const selected = selectSupporters(config);
-    const poolIds = basePool.map((s) => s.id);
-    for (const s of selected) {
-      expect(poolIds).toContain(s.id);
-    }
-  });
-
-  it('does not include duplicates', () => {
-    const config = makeConfig({ pickStrategy: 'round-robin', pickCount: 2 });
-    const selected = selectSupporters(config);
-    const ids = selected.map((s) => s.id);
-    expect(new Set(ids).size).toBe(ids.length);
-  });
-});
-
-// ============================================================================
 // personaAssignment: 'random'
 // ============================================================================
 
@@ -137,43 +107,11 @@ describe('personaAssignment: random', () => {
 });
 
 // ============================================================================
-// personaAssignment: 'fixed'
-// ============================================================================
-
-describe('personaAssignment: fixed', () => {
-  it('assigns personas in fixed order (index 0 to first, index 1 to second)', () => {
-    const config = makeConfig({ personaAssignment: 'fixed', pickCount: 2 });
-    // Run multiple times — fixed assignment should be deterministic in terms of
-    // personas coming from personaPool in order
-    const selected = selectSupporters(config);
-
-    for (const s of selected) {
-      expect(s.assignedPersona).toBeDefined();
-      expect(personaPool).toContain(s.assignedPersona!);
-    }
-  });
-
-  it('assigns personas consistently across multiple calls (same pool order)', () => {
-    const config = makeConfig({ personaAssignment: 'fixed', pickCount: 2 });
-
-    // With fixed persona assignment, all calls should assign personas from
-    // the personaPool (the exact index depends on implementation)
-    const result1 = selectSupporters(config);
-    const result2 = selectSupporters(config);
-
-    // Both results should have valid personas from the pool
-    for (const s of [...result1, ...result2]) {
-      expect(personaPool).toContain(s.assignedPersona!);
-    }
-  });
-});
-
-// ============================================================================
 // Devil's Advocate interaction
 // ============================================================================
 
 describe('Devil\'s Advocate with selection strategies', () => {
-  it('devil is prepended before pool supporters regardless of pickStrategy', () => {
+  it('devil is prepended before pool supporters', () => {
     const configWithDevil = makeConfig({
       pickStrategy: 'random',
       devilsAdvocate: { ...baseDevil, enabled: true },


### PR DESCRIPTION
## Summary
- Remove unimplemented `pickStrategy: 'round-robin'` and `personaAssignment: 'fixed'` from schema
- Remove dead `tierMin` field from `DeclarativeReviewersSchema`
- Wire `persona` field on L1 reviewers into `buildReviewerPrompt()` so it actually affects review output
- Update TUI, web dashboard, and tests to match

Closes #204

## Test plan
- [x] `pnpm typecheck` passes
- [x] 2702 tests pass (170 files)
- [x] Existing configs without these fields continue to work (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reviewers now support persona configuration during execution.

* **Configuration Updates**
  * Simplified reviewer pool strategy options to random selection only.
  * Simplified persona assignment to random selection only.
  * Removed minimum tier constraint from reviewer templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->