### PR TITLE
feat: expose hardcoded timeouts in config schema

### DIFF
--- a/packages/core/src/config/migrator.ts
+++ b/packages/core/src/config/migrator.ts
@@ -271,6 +271,7 @@ export function applyMigration(config: Config, result: MigrationResult): Config 
     backend: 'api' as const,
     model: newModerator.model,
     provider: newModerator.provider,
+    timeout: 120,
     enabled: true,
   };
 

--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -255,7 +255,7 @@ async function runDiscussion(
 
   // Track objection rounds to prevent infinite loops
   let objectionRoundsUsed = 0;
-  const maxObjectionRounds = 1;
+  const maxObjectionRounds = settings.maxObjectionRounds ?? 1;
 
   // Run up to maxRounds
   for (let roundNum = 1; roundNum <= settings.maxRounds; roundNum++) {
@@ -559,7 +559,7 @@ ${rounds.map((r, i) => `Round ${i + 1}:\n${r.supporterResponses.map(s => `- ${s.
     model: config.model,
     provider: config.provider,
     prompt,
-    timeout: 120,
+    timeout: config.timeout ?? 120,
     temperature: 0.2,
   });
 

--- a/packages/core/src/l2/objection.ts
+++ b/packages/core/src/l2/objection.ts
@@ -61,7 +61,7 @@ async function executeSupporterObjectionCheck(
     backend: config.backend,
     model: config.model,
     prompt,
-    timeout: 60,
+    timeout: config.timeout ?? 60,
     temperature: config.temperature,
   });
 

--- a/packages/core/src/l3/verdict.ts
+++ b/packages/core/src/l3/verdict.ts
@@ -44,7 +44,7 @@ async function llmVerdict(report: ModeratorReport, config: HeadConfig, language?
     model: config.model,
     provider: config.provider,
     prompt,
-    timeout: 120,
+    timeout: config.timeout ?? 120,
     temperature: 0.2,
   });
 

--- a/packages/core/src/tests/edge-cases.test.ts
+++ b/packages/core/src/tests/edge-cases.test.ts
@@ -265,6 +265,8 @@ describe('runModerator — maxRounds=0 (8)', () => {
         maxRounds: 0,
         registrationThreshold: { HARSHLY_CRITICAL: 1, CRITICAL: 1, WARNING: 2, SUGGESTION: null },
         codeSnippetRange: 10,
+        objectionTimeout: 60,
+        maxObjectionRounds: 1,
       },
       date: '2026-03-21',
       sessionId: '001',

--- a/packages/core/src/tests/l2-threshold.test.ts
+++ b/packages/core/src/tests/l2-threshold.test.ts
@@ -20,6 +20,8 @@ const defaultSettings: DiscussionSettings = {
   },
   maxRounds: 3,
   codeSnippetRange: 10,
+  objectionTimeout: 60,
+  maxObjectionRounds: 1,
 };
 
 function makeDoc(overrides: Partial<EvidenceDocument> = {}): EvidenceDocument {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -98,6 +98,7 @@ export const ModeratorConfigSchema = z.object({
   backend: BackendSchema,
   model: z.string(),
   provider: z.string().optional(),
+  timeout: z.number().default(120),
 });
 export type ModeratorConfig = z.infer<typeof ModeratorConfigSchema>;
 
@@ -128,6 +129,8 @@ export const DiscussionSettingsSchema = z.object({
     SUGGESTION: z.null(), // Discussion 미등록
   }),
   codeSnippetRange: z.number().default(10), // ±N lines
+  objectionTimeout: z.number().default(60),
+  maxObjectionRounds: z.number().int().min(0).default(1),
 });
 export type DiscussionSettings = z.infer<typeof DiscussionSettingsSchema>;
 
@@ -200,6 +203,7 @@ export const HeadConfigSchema = z.object({
   backend: BackendSchema,
   model: z.string(),
   provider: z.string().optional(),
+  timeout: z.number().default(120),
   enabled: z.boolean().default(true),
 });
 export type HeadConfig = z.infer<typeof HeadConfigSchema>;

--- a/packages/tui/src/screens/config/PresetsTab.tsx
+++ b/packages/tui/src/screens/config/PresetsTab.tsx
@@ -21,14 +21,16 @@ interface PresetDef {
 
 // Shared defaults every preset must include
 const PRESET_DEFAULTS = {
-  moderator: { model: 'llama-3.3-70b-versatile', backend: 'api' as const, provider: 'groq' },
+  moderator: { model: 'llama-3.3-70b-versatile', backend: 'api' as const, provider: 'groq', timeout: 120 },
   discussion: {
     maxRounds: 3,
     registrationThreshold: { HARSHLY_CRITICAL: 1, CRITICAL: 1, WARNING: 2, SUGGESTION: null },
     codeSnippetRange: 10,
+    objectionTimeout: 60,
+    maxObjectionRounds: 1,
   },
   errorHandling: { maxRetries: 2, forfeitThreshold: 0.7 },
-  head: { backend: 'api' as const, model: 'llama-3.3-70b-versatile', provider: 'groq', enabled: true },
+  head: { backend: 'api' as const, model: 'llama-3.3-70b-versatile', provider: 'groq', timeout: 120, enabled: true },
 };
 
 const PRESETS: PresetDef[] = [


### PR DESCRIPTION
## Summary
- Add `timeout` field to `ModeratorConfigSchema` (default 120s) and `HeadConfigSchema` (default 120s)
- Add `objectionTimeout` (default 60s) and `maxObjectionRounds` (default 1) to `DiscussionSettingsSchema`
- Replace all hardcoded timeout values with config reads + backward-compatible defaults
- Update TUI presets, migrator, and tests

Closes #209

## Test plan
- [x] `pnpm typecheck` passes
- [x] 2702 tests pass (170 files)
- [x] Backward compatible — new fields have defaults matching previous hardcoded values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moderation and objection operation timeouts are now configurable with sensible defaults.
  * Maximum objection rounds limit is now configurable.
  * Updated default configuration presets with new timeout and objection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->