### PR TITLE
fix: use --no-frozen-lockfile in action for npm-based repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --no-frozen-lockfile
 
     - name: Fetch PR diff
       shell: bash


### PR DESCRIPTION
## Summary
- Changed `pnpm install --frozen-lockfile` to `pnpm install --no-frozen-lockfile` in `action.yml`
- The composite action is consumed by external repos that may use npm (not pnpm), so they won't have a `pnpm-lock.yaml`
- Internal CI workflows are unchanged since CodeAgora itself has a lockfile

Closes #210

## Test plan
- [ ] Verify the action runs successfully on an npm-based repo without `pnpm-lock.yaml`
- [ ] Verify the action still works on repos that do have `pnpm-lock.yaml`
- [ ] Confirm internal CI workflows (`.github/workflows/`) are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)