### PR TITLE
fix: use github.action_path for correct module resolution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --no-frozen-lockfile
+      run: cd "${{ github.action_path }}" && pnpm install --no-frozen-lockfile
 
     - name: Fetch PR diff
       shell: bash
@@ -66,7 +66,7 @@ runs:
       id: review
       shell: bash
       run: |
-        npx tsx packages/github/src/action.ts \
+        npx tsx "${{ github.action_path }}/packages/github/src/action.ts" \
           --diff /tmp/codeagora-pr.diff \
           --pr "$PR_NUMBER" \
           --sha "$HEAD_SHA" \


### PR DESCRIPTION
## Summary

- Use `${{ github.action_path }}` in the composite action's "Install dependencies" and "Run CodeAgora review" steps so that `pnpm install` and `npx tsx` resolve paths relative to the **action's own directory**, not the consumer repo's working directory.
- Previously, consumers hit `Cannot find module '.../packages/github/src/action.ts'` because the action tried to find CodeAgora source files in the consumer repo.

Fixes #210

## Changes

- `action.yml`: `pnpm install` now runs inside `${{ github.action_path }}`
- `action.yml`: `npx tsx` now references `${{ github.action_path }}/packages/github/src/action.ts`

## Test plan

- [ ] Use the action from an external repo and confirm `pnpm install` installs CodeAgora's dependencies (not the consumer's)
- [ ] Confirm the review step finds and executes `packages/github/src/action.ts` successfully
- [ ] Verify no regressions on existing workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)