### PR TITLE
fix: remove hardcoded pnpm version 9 from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Remove `version: 9` from `pnpm/action-setup@v4` in `ci.yml` and `review.yml`
- `pnpm/action-setup@v4` auto-detects version from `package.json` `packageManager` field (`pnpm@10.30.3`)
- This was causing all PR checks to fail with "Multiple versions of pnpm specified" error

## Test plan
- [x] CI should pass on this PR itself (self-validating)
- [x] No other workflows reference `version: 9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to use automatic package manager version resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->