### PR TITLE
fix: add build step to composite action for monorepo packages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,10 @@ runs:
       shell: bash
       run: cd "${{ github.action_path }}" && pnpm install --no-frozen-lockfile
 
+    - name: Build packages
+      shell: bash
+      run: cd "${{ github.action_path }}" && pnpm build
+
     - name: Fetch PR diff
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- Adds a `pnpm build` step to the composite action (`action.yml`) after dependency installation
- Fixes `Cannot find module '@codeagora/core/pipeline/orchestrator.js'` error caused by workspace packages not being compiled before the review step runs

## Problem
The composite action installs dependencies with `pnpm install` but never builds the monorepo workspace packages. Since `@codeagora/core` is a TypeScript package that needs compilation, `packages/github/src/action.ts` fails at runtime when it tries to import the compiled output.

## Fix
Added a "Build packages" step that runs `pnpm build` in the action directory, ensuring all workspace packages (including `@codeagora/core`) are compiled before the review step executes.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)