### PR TITLE
chore: release prep — auto-rebuild CI + README update

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -1,0 +1,44 @@
+name: Build Action Bundle
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core/src/**'
+      - 'packages/shared/src/**'
+      - 'packages/github/src/**'
+      - 'scripts/build-action.mjs'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: pnpm/action-setup@v4
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build action bundle
+        run: node scripts/build-action.mjs
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet dist/action.js && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit updated bundle
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/action.js
+          git commit -m "chore: rebuild dist/action.js [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/codeagora"><img src="https://img.shields.io/npm/v/codeagora?color=%2305A6B9" alt="Version"></a>
-  <img src="https://img.shields.io/badge/tests-2671%20passing-%23191A51" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-2702%20passing-%23191A51" alt="Tests">
   <img src="https://img.shields.io/badge/node-%3E%3D20-%2305A6B9" alt="Node">
   <img src="https://img.shields.io/badge/license-MIT-%23191A51" alt="License">
 </p>
@@ -78,6 +78,23 @@ npm i -g @codeagora/notifications  # Discord / Slack webhooks
 
 ## GitHub Actions
 
+Add CodeAgora to any repo in 2 steps:
+
+**1. Create `.ca/config.json`** (or run `agora init`):
+
+```json
+{
+  "mode": "pragmatic",
+  "reviewers": [
+    { "id": "r1", "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 },
+    { "id": "r2", "model": "qwen/qwen3-32b", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 },
+    { "id": "r3", "model": "meta-llama/llama-4-scout-17b-16e-instruct", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 }
+  ]
+}
+```
+
+**2. Add the workflow** (`.github/workflows/codeagora-review.yml`):
+
 ```yaml
 name: CodeAgora Review
 on:
@@ -94,16 +111,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: justn-hyeok/CodeAgora@main
+      - uses: bssm-oss/CodeAgora@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
 ```
 
-Every PR gets inline review comments, a summary verdict, and a commit status check.
+**3. Add `GROQ_API_KEY`** to your repo's Settings > Secrets > Actions.
+
+Every PR gets inline review comments, a summary verdict, and a commit status check. Add `review:skip` label to any PR to bypass.
 
 ---
 
@@ -123,7 +140,7 @@ Every PR gets inline review comments, a summary verdict, and a commit status che
 
 ```bash
 pnpm install && pnpm build
-pnpm test          # 2671 tests
+pnpm test          # 2702 tests
 pnpm typecheck
 pnpm cli review path/to/diff.patch
 ```


### PR DESCRIPTION
## Summary
- Add `build-action.yml` CI workflow to auto-rebuild `dist/action.js` when source changes
- Update README GitHub Actions section: `bssm-oss/CodeAgora@v2` + config setup guide
- Update test count badge to 2702

Prep for v2.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded GitHub Actions setup guide with detailed configuration steps for code review integration.
  * Updated action reference to latest version.

* **Tests**
  * Increased test coverage to 2702 passing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->