### PR TITLE
feat: custom reviewer prompt via config

### DIFF
--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -42,6 +42,8 @@ export interface ReviewerInput {
   };
   /** Surrounding code context from source files (context-aware review) */
   surroundingContext?: string;
+  /** Custom reviewer prompt file path (overrides built-in prompt) */
+  customPromptPath?: string;
 }
 
 /**
@@ -68,6 +70,23 @@ export async function executeReviewer(
     }
   }
 
+  // Build prompt: custom file (with {{DIFF}} placeholder) or built-in
+  let reviewPrompt: string;
+  if (input.customPromptPath) {
+    try {
+      const { loadPersona } = await import('../l2/moderator.js');
+      const template = await loadPersona(input.customPromptPath);
+      reviewPrompt = template
+        ? template.replace('{{DIFF}}', diffContent).replace('{{SUMMARY}}', prSummary)
+        : buildReviewerPrompt(diffContent, prSummary, surroundingContext);
+    } catch {
+      reviewPrompt = buildReviewerPrompt(diffContent, prSummary, surroundingContext);
+    }
+  } else {
+    reviewPrompt = buildReviewerPrompt(diffContent, prSummary, surroundingContext);
+  }
+  const fullPrompt = personaPrefix + reviewPrompt;
+
   for (let attempt = 0; attempt <= retries; attempt++) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), config.timeout * 1000);
@@ -77,7 +96,7 @@ export async function executeReviewer(
         backend: config.backend,
         model: config.model,
         provider: config.provider,
-        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: fullPrompt,
         timeout: config.timeout,
         signal: controller.signal,
         temperature: config.temperature,
@@ -114,7 +133,7 @@ export async function executeReviewer(
         backend: fb.backend,
         model: fb.model,
         provider: fb.provider,
-        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: fullPrompt,
         timeout: config.timeout,
         temperature: config.temperature,
       });
@@ -244,6 +263,23 @@ async function executeReviewerWithGuards(
     }
   }
 
+  // Build prompt: custom file (with {{DIFF}} placeholder) or built-in
+  let reviewPrompt: string;
+  if (input.customPromptPath) {
+    try {
+      const { loadPersona } = await import('../l2/moderator.js');
+      const template = await loadPersona(input.customPromptPath);
+      reviewPrompt = template
+        ? template.replace('{{DIFF}}', diffContent).replace('{{SUMMARY}}', prSummary)
+        : buildReviewerPrompt(diffContent, prSummary, surroundingContext);
+    } catch {
+      reviewPrompt = buildReviewerPrompt(diffContent, prSummary, surroundingContext);
+    }
+  } else {
+    reviewPrompt = buildReviewerPrompt(diffContent, prSummary, surroundingContext);
+  }
+  const fullPrompt = personaPrefix + reviewPrompt;
+
   let lastError: Error | undefined;
   const diffFilePaths = extractFileListFromDiff(diffContent);
 
@@ -258,7 +294,7 @@ async function executeReviewerWithGuards(
         backend: config.backend,
         model: config.model,
         provider: config.provider,
-        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: fullPrompt,
         timeout: config.timeout,
         signal: controller.signal,
         temperature: config.temperature,
@@ -310,7 +346,7 @@ async function executeReviewerWithGuards(
         backend: fb.backend,
         model: fb.model,
         provider: fb.provider,
-        prompt: personaPrefix + buildReviewerPrompt(diffContent, prSummary, surroundingContext),
+        prompt: fullPrompt,
         timeout: config.timeout,
         temperature: config.temperature,
       });

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -169,6 +169,13 @@ async function executeL1Reviews(
       }
     }
 
+    // Inject custom reviewer prompt path from config
+    if (config.prompts?.reviewer) {
+      for (const ri of reviewerInputs) {
+        ri.customPromptPath = config.prompts.reviewer;
+      }
+    }
+
     const reviewResults = await executeReviewers(
       reviewerInputs,
       config.errorHandling.maxRetries

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -221,6 +221,13 @@ export const AutoApproveConfigSchema = z.object({
 }).optional();
 export type AutoApproveConfig = z.infer<typeof AutoApproveConfigSchema>;
 
+export const PromptsConfigSchema = z.object({
+  reviewer: z.string().optional(),
+  supporter: z.string().optional(),
+  head: z.string().optional(),
+}).optional();
+export type PromptsConfig = z.infer<typeof PromptsConfigSchema>;
+
 export const ConfigSchema = z.object({
   mode: ReviewModeSchema.optional(),
   language: LanguageSchema.optional(),
@@ -235,6 +242,7 @@ export const ConfigSchema = z.object({
   notifications: NotificationsConfigSchema.optional(),
   github: GitHubIntegrationSchema.optional(),
   autoApprove: AutoApproveConfigSchema,
+  prompts: PromptsConfigSchema,
   plugins: z.array(z.string()).optional(),
 });
 export type Config = z.infer<typeof ConfigSchema>;


### PR DESCRIPTION
## Summary
- Add `prompts` field to config schema: `{ reviewer?, supporter?, head? }`
- When `prompts.reviewer` is set, loads markdown file and substitutes `{{DIFF}}` / `{{SUMMARY}}` placeholders
- Falls back to built-in prompt if custom file can't be loaded
- Supporter/head prompt customization schema added for future use

Closes #203

## Usage
```json
{
  "prompts": {
    "reviewer": ".ca/prompts/my-reviewer.md"
  }
}
```

## Test plan
- [x] `pnpm typecheck` passes
- [x] 2702 tests pass
- [x] Without `prompts` config — existing behavior unchanged
- [x] Path validation via `loadPersona()` (path traversal protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)