### PR TITLE
fix: Add null guards to SupportersTab pickCount and pickStrategy access

### DIFF
--- a/packages/tui/src/screens/config/SupportersTab.tsx
+++ b/packages/tui/src/screens/config/SupportersTab.tsx
@@ -127,7 +127,7 @@ export function SupportersTab({ config, isActive, onConfigChange }: Props): Reac
         setMode('confirm-delete');
       }
     } else if (input === 'p') {
-      setPickCountInput(String(config.supporters.pickCount));
+      setPickCountInput(String(config.supporters?.pickCount ?? 2));
       setMode('edit-pick-count');
     } else if (input === 's') {
       cyclePickStrategy();
@@ -190,8 +190,8 @@ export function SupportersTab({ config, isActive, onConfigChange }: Props): Reac
 
             <Box marginTop={1} flexDirection="column">
               <Text dimColor bold>{icons.separator} {t('config.supporter.poolSettings')}</Text>
-              <DetailRow label={t('config.pool.pickCount')} value={String(config.supporters.pickCount)} labelWidth={14} />
-              <DetailRow label={t('config.pool.pickStrategy')} value={config.supporters.pickStrategy} labelWidth={14} />
+              <DetailRow label={t('config.pool.pickCount')} value={String(config.supporters?.pickCount ?? 2)} labelWidth={14} />
+              <DetailRow label={t('config.pool.pickStrategy')} value={config.supporters?.pickStrategy ?? 'random'} labelWidth={14} />
             </Box>
 
             <Box marginTop={1}>


### PR DESCRIPTION
## Summary

This PR fixes the missing null guard issue described in Issue #324.

## Problem

In SupportersTab.tsx, lines 130 and 193-194 accessed config.supporters.pickCount and config.supporters.pickStrategy without optional chaining, while other lines in the same component used config.supporters?.pool. This inconsistency could cause a crash if config.supporters is undefined.

## Solution

Added optional chaining with fallback values:
- config.supporters?.pickCount ?? 2
- config.supporters?.pickStrategy ?? 'random'

## Changes

- Line 130: Added ?. and fallback ?? 2
- Line 193: Added ?. and fallback ?? 2
- Line 194: Added ?. and fallback ?? 'random'

## Testing

- Code compiles without errors
- Behavior is consistent with other accesses in the same file

Fixes: #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the supporter configuration settings by adding better handling for cases where configuration data might be missing. The application now gracefully applies default values for pick-count and pick-strategy settings, ensuring the configuration interface remains stable and functional even with incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->