### PR TITLE
fix: Guard against empty discussions list in DebateScreen

### DIFF
--- a/packages/tui/src/screens/DebateScreen.tsx
+++ b/packages/tui/src/screens/DebateScreen.tsx
@@ -64,6 +64,7 @@ export function DebateScreen({ discussions }: Props): React.JSX.Element {
   const escalated = discussions.filter(d => d.status === 'escalated').length;
 
   useInput((_input, key) => {
+    if (total === 0) return; // Guard against empty list
     if (key.downArrow || _input === 'j') {
       setSelectedIndex(i => Math.min(i + 1, total - 1));
     } else if (key.upArrow || _input === 'k') {


### PR DESCRIPTION
## Summary

This PR fixes the bug described in Issue #322.

## Problem

In DebateScreen.tsx line 68, when discussions is empty (	otal=0), the expression Math.min(i+1, total-1) evaluates to Math.min(1, -1) = -1, causing selectedIndex to become -1.

While discussions[-1] ?? null handles the undefined case, it's logically wrong and could cause subtle bugs.

## Solution

Added an early return guard in the useInput hook:
`	ypescript
if (total === 0) return; // Guard against empty list
`

## Changes

- Added guard clause at the start of useInput callback
- Prevents navigation attempts on empty discussions list

## Testing

- Code compiles without errors
- Empty list now correctly ignores navigation input

Fixes: #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a navigation error that occurred when the discussions list was empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->