### PR TITLE
fix: Align LiveDiscussion severity class map with pipeline domain

### DIFF
--- a/packages/web/src/frontend/components/LiveDiscussion.tsx
+++ b/packages/web/src/frontend/components/LiveDiscussion.tsx
@@ -17,10 +17,10 @@ const STANCE_CLASSES: Record<string, string> = {
 };
 
 const SEVERITY_CLASSES: Record<string, string> = {
+  HARSHLY_CRITICAL: 'severity--harshly-critical',
   CRITICAL: 'severity--critical',
-  ERROR: 'severity--error',
   WARNING: 'severity--warning',
-  INFO: 'severity--info',
+  SUGGESTION: 'severity--suggestion',
 };
 
 function getSeverityClass(severity: string): string {


### PR DESCRIPTION
Fix severity class map to match pipeline domain.

- Replace ERROR/INFO with HARSHLY_CRITICAL/SUGGESTION
- Match the pipeline severity levels

Fixes: #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Enhanced the Live Discussion feature with improved severity level classifications. New "Harshly Critical" and "Suggestion" severity types are now available to provide clearer feedback categorization. These replace the previous "Error" and "Info" severity levels, offering more specific options for communicating feedback intensity and discussion criticality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->