### PR TITLE
fix: Add catch-all 404 route in web dashboard

### DIFF
--- a/packages/web/src/frontend/App.tsx
+++ b/packages/web/src/frontend/App.tsx
@@ -9,6 +9,7 @@ import { Costs } from './pages/Costs.js';
 import { Discussions } from './pages/Discussions.js';
 import { ConfigPage } from './pages/Config.js';
 import { Pipeline } from './pages/Pipeline.js';
+import { NotFound } from './components/NotFound.js';
 
 export function App(): React.JSX.Element {
   return (
@@ -22,6 +23,7 @@ export function App(): React.JSX.Element {
         <Route path="/discussions" element={<Discussions />} />
         <Route path="/config" element={<ConfigPage />} />
         <Route path="/pipeline" element={<Pipeline />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </Layout>
   );

--- a/packages/web/src/frontend/components/NotFound.tsx
+++ b/packages/web/src/frontend/components/NotFound.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { colors } from '../theme.js';
+
+export function NotFound(): React.JSX.Element {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '60vh',
+      color: colors.muted,
+    }}>
+      <h1 style={{ fontSize: '4rem', margin: 0, color: colors.error }}>404</h1>
+      <p style={{ fontSize: '1.2rem', margin: '0.5rem 0' }}>Page not found</p>
+      <p style={{ margin: '0.5rem 0' }}>The page you're looking for doesn't exist.</p>
+      <Link 
+        to="/" 
+        style={{ 
+          marginTop: '1rem', 
+          color: colors.primary, 
+          textDecoration: 'none',
+        }}
+      >
+        ← Back to Dashboard
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
Fix the missing 404 route in web dashboard.

- Create NotFound component with 404 page
- Add catch-all route path='*' in App.tsx
- Invalid URLs now show proper 404 page

Fixes: #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a 404 error page that displays when users navigate to non-existent or invalid URLs within the application.
  * Improved user experience with a friendly error message and navigation link to return to the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->