### PR TITLE
fix: Bound ResultsScreen listHeight by terminal rows

### DIFF
--- a/packages/tui/src/screens/ResultsScreen.tsx
+++ b/packages/tui/src/screens/ResultsScreen.tsx
@@ -71,12 +71,12 @@ export function ResultsScreen({ result, onHome: _onHome, onViewContext }: Props)
   const summary = result.summary;
   const issues: Issue[] = summary?.topIssues ?? [];
 
-  const { cols } = getTerminalSize();
+  const { cols, rows } = getTerminalSize();
   const totalCols = Math.max(cols, MIN_COLS);
   const listWidth = Math.floor(totalCols * LIST_WIDTH_RATIO);
   const detailWidth = Math.floor(totalCols * DETAIL_WIDTH_RATIO);
-  // List viewport height: rows minus header/footer/border
-  const listHeight = Math.max(6, issues.length);
+  // List viewport height: bounded by terminal rows minus header/footer/border
+  const listHeight = Math.max(6, Math.min(issues.length, rows - 10));
 
   useInput((input, key) => {
     if (viewMode === 'list') {


### PR DESCRIPTION
Fix unbounded listHeight growth in ResultsScreen.

- Use rows from getTerminalSize() to limit listHeight
- Formula: Math.max(6, Math.min(issues.length, rows - 10))
- 100 issues no longer causes listHeight=100 with no scrolling

Fixes: #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Results screen now properly constrains list display height to fit within your terminal window. Previously, the list could grow indefinitely based on result count without accounting for available vertical space, potentially causing display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->