### PR TITLE
fix: Validate non-empty model name before saving in HeadTab

### DIFF
--- a/packages/tui/src/screens/config/HeadTab.tsx
+++ b/packages/tui/src/screens/config/HeadTab.tsx
@@ -24,6 +24,7 @@ export function HeadTab({ config, isActive, onConfigChange }: Props): React.JSX.
   const [editBackend, setEditBackend] = useState('');
   const [editTimeout, setEditTimeout] = useState('');
   const [activeField, setActiveField] = useState(0);
+  const [validationError, setValidationError] = useState('');
 
   const head = config.head ?? { model: '', backend: 'api' as const, provider: '', timeout: 120, enabled: true };
 
@@ -33,6 +34,7 @@ export function HeadTab({ config, isActive, onConfigChange }: Props): React.JSX.
     setEditBackend(head.backend ?? 'api');
     setEditTimeout(String(head.timeout ?? 120));
     setActiveField(0);
+    setValidationError('');
     setEditMode(true);
   }
 
@@ -49,10 +51,10 @@ export function HeadTab({ config, isActive, onConfigChange }: Props): React.JSX.
     
     // Validate model name is not empty before saving
     if (!trimmedModel) {
-      // Don't save if model is empty - keep current config
-      setEditMode(false);
+      setValidationError('Model name cannot be empty');
       return;
     }
+    setValidationError('');
     
     onConfigChange({
       ...config,
@@ -140,6 +142,11 @@ export function HeadTab({ config, isActive, onConfigChange }: Props): React.JSX.
             </Box>
           );
         })}
+        {validationError ? (
+          <Box marginTop={1}>
+            <Text color={colors.error}>{icons.cross} {validationError}</Text>
+          </Box>
+        ) : null}
         <Box marginTop={1}>
           <Text dimColor>Enter save  Esc cancel  Tab next field</Text>
         </Box>


### PR DESCRIPTION
Fix empty model name validation in HeadTab.

- Check if trimmedModel is empty before saving
- Return early without saving if model is empty
- Prevents runtime pipeline failure from model:'' in config

Priority: HIGH

Fixes: #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model field validation in configuration: input is now trimmed before saving, empty/whitespace-only values are blocked, and a validation error prevents the save.

* **UI**
  * Edit mode clears prior validation errors and displays inline error messages beneath the input when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->