### PR TITLE
fix: Two pipeline bugs affecting rules loading and acceptance rate

### DIFF
--- a/packages/core/src/l0/quality-tracker.ts
+++ b/packages/core/src/l0/quality-tracker.ts
@@ -126,8 +126,9 @@ export class QualityTracker {
       data.peerValidationRate =
         totalInDiscussion > 0 ? peerValidated / totalInDiscussion : 1.0;
 
-      // Head acceptance: fraction of all raised issues accepted as actionable
-      data.headAcceptanceRate = headAccepted / data.issuesRaised;
+      // Head acceptance: fraction of discussed issues accepted as actionable
+      data.headAcceptanceRate =
+        totalInDiscussion > 0 ? headAccepted / totalInDiscussion : 1.0;
     }
   }
 

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -527,7 +527,7 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
     );
 
     // === RULES: Apply custom review rules ===
-    const compiledRules = await loadReviewRules(process.cwd());
+    const compiledRules = await loadReviewRules(input.repoPath ?? process.cwd());
     if (compiledRules && compiledRules.length > 0) {
       const ruleEvidence = matchRules(diffContent, compiledRules);
       if (ruleEvidence.length > 0) {
@@ -537,7 +537,7 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
     }
 
     // === LEARNING: Apply dismissed patterns ===
-    const learnedPatterns = await loadLearnedPatterns(process.cwd());
+    const learnedPatterns = await loadLearnedPatterns(input.repoPath ?? process.cwd());
     if (learnedPatterns && learnedPatterns.dismissedPatterns.length > 0) {
       const { filtered, suppressed } = applyLearnedPatterns(
         allEvidenceDocs,


### PR DESCRIPTION
Fix two high-priority pipeline bugs:

## 1. orchestrator.ts: Rules not found in CI/MCP (Issue #302)
- Was using \process.cwd()\ for \loadReviewRules\ and \loadLearnedPatterns\
- This fails when running in GitHub Actions or MCP with different working directory
- Now uses \input.repoPath ?? process.cwd()\ to respect the repository path

## 2. quality-tracker.ts: headAcceptanceRate penalizes thorough reviewers (Issue #303)
- Was dividing \headAccepted\ by \issuesRaised\
- \headAccepted\ only counts discussed issues
- \issuesRaised\ includes issues below threshold (never discussed)
- Result: thorough reviewers get lower scores than lazy ones
- Now divides by \	otalInDiscussion\ (the correct denominator)

Fixes: #302
Fixes: #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed quality metrics calculation to count only issues that participated in discussions when measuring acceptance rates.
* Fixed the pipeline to load custom review rules and learned patterns from the correct repository path when specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->