### PR TITLE
fix: structured supporter prompt and parse failure metric (#308, #309)

### DIFF
--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -106,6 +106,17 @@ export async function executeReviewer(
       // Parse response into evidence documents with diff file paths for fallback
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
 
+      // Log parse result per model for failure rate tracking (#309)
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        process.stderr.write(
+          `[Parser] Parse returned 0 issues for model=${config.model} reviewer=${config.id} (response length=${response.length}). Possible unparseable response.\n`
+        );
+      } else {
+        process.stderr.write(
+          `[Parser] Parsed ${evidenceDocs.length} issue(s) from model=${config.model} reviewer=${config.id}\n`
+        );
+      }
+
       return {
         reviewerId: config.id,
         model: config.model,
@@ -140,6 +151,17 @@ export async function executeReviewer(
       });
 
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+
+      // Log parse result for fallback model (#309)
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        process.stderr.write(
+          `[Parser] Parse returned 0 issues for fallback model=${fb.model} reviewer=${config.id} (response length=${response.length}). Possible unparseable response.\n`
+        );
+      } else {
+        process.stderr.write(
+          `[Parser] Parsed ${evidenceDocs.length} issue(s) from fallback model=${fb.model} reviewer=${config.id}\n`
+        );
+      }
 
       return {
         reviewerId: config.id,
@@ -308,6 +330,17 @@ async function executeReviewerWithGuards(
       if (useGuards) cb.recordSuccess(provider!, config.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
 
+      // Log parse result per model for failure rate tracking (#309)
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        process.stderr.write(
+          `[Parser] Parse returned 0 issues for model=${config.model} reviewer=${config.id} (response length=${response.length}). Possible unparseable response.\n`
+        );
+      } else {
+        process.stderr.write(
+          `[Parser] Parsed ${evidenceDocs.length} issue(s) from model=${config.model} reviewer=${config.id}\n`
+        );
+      }
+
       return {
         reviewerId: config.id,
         model: config.model,
@@ -358,6 +391,17 @@ async function executeReviewerWithGuards(
 
       if (useFallbackGuards) cb.recordSuccess(fallbackProvider!, fb.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+
+      // Log parse result for fallback model (#309)
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        process.stderr.write(
+          `[Parser] Parse returned 0 issues for fallback model=${fb.model} reviewer=${config.id} (response length=${response.length}). Possible unparseable response.\n`
+        );
+      } else {
+        process.stderr.write(
+          `[Parser] Parsed ${evidenceDocs.length} issue(s) from fallback model=${fb.model} reviewer=${config.id}\n`
+        );
+      }
 
       return {
         reviewerId: config.id,

--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -437,7 +437,7 @@ async function executeSupporterResponse(
   }
 
   // Build prompt with persona
-  const basePrompt = `${moderatorPrompt}\n\nProvide your verdict:\n- AGREE: Evidence is valid and the issue is real\n- DISAGREE: Evidence is flawed, missing context, or the issue is a false positive\n- NEUTRAL: Needs more information\n\n**IMPORTANT: Do NOT conform simply because other reviewers agree. If you believe the evidence is wrong, say DISAGREE and explain why — even if you are the only one. Your independent judgment is more valuable than consensus.**\n\nProvide your stance and reasoning.`;
+  const basePrompt = `${moderatorPrompt}\n\nProvide your verdict:\n- AGREE: Evidence is valid and the issue is real\n- DISAGREE: Evidence is flawed, missing context, or the issue is a false positive\n- NEUTRAL: Needs more information\n\n**IMPORTANT: Do NOT conform simply because other reviewers agree. If you believe the evidence is wrong, say DISAGREE and explain why — even if you are the only one. Your independent judgment is more valuable than consensus.**\n\n**RESPONSE FORMAT (mandatory):**\nYour response MUST start with a stance line in exactly this format:\n\nStance: AGREE|DISAGREE|NEUTRAL\n\nFollowed by your reasoning on subsequent lines. Example:\n\nStance: DISAGREE\nThe evidence lacks context because...`;
 
   const prompt = personaContent
     ? `${personaContent}\n\n---\n\n${basePrompt}`


### PR DESCRIPTION
## Summary
- **#308**: Added explicit structured output format to L2 supporter prompt — response must start with `Stance: AGREE|DISAGREE|NEUTRAL` on the first line, making the P1 structured parser in `parseStance()` match reliably instead of falling through to heuristic keyword scanning.
- **#309**: Added per-model parse success/failure stderr logging after every `parseEvidenceResponse()` call in the reviewer execution flow (primary, fallback, and guarded paths). Logs model name, reviewer ID, issue count, and response length when parse returns empty results.

## Test plan
- [x] `pnpm test` passes (2721/2721 tests pass; 4 pre-existing e2e failures unrelated to changes)
- [ ] Verify supporter responses now start with `Stance:` line in a live L2 discussion
- [ ] Verify stderr shows `[Parser]` log lines with model names during a review run

🤖 Generated with [Claude Code](https://claude.com/claude-code)