### PR TITLE
fix: orchestrator, circuit breaker, and Windows path bugs (#300, #270, #272)

### DIFF
--- a/packages/core/src/l0/model-registry.ts
+++ b/packages/core/src/l0/model-registry.ts
@@ -125,9 +125,10 @@ export function initFromData(
 export async function loadRegistry(): Promise<void> {
   const fs = await import('fs/promises');
   const path = await import('path');
+  const { fileURLToPath } = await import('url');
 
   const dataDir = path.resolve(
-    new URL('.', import.meta.url).pathname,
+    path.dirname(fileURLToPath(import.meta.url)),
     '../../../shared/src/data'
   );
 

--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -328,8 +328,24 @@ async function executeReviewerWithGuards(
           error: error.message,
         };
       }
-      if (useGuards) cb.recordFailure(provider!, config.model);
       lastError = error instanceof Error ? error : new Error(String(error));
+
+      // Auth errors (401/403) are permanent — forfeit immediately without
+      // recording to circuit breaker to avoid blocking the model (#270)
+      const errMsg = lastError.message;
+      if (/\b(401|403)\b/.test(errMsg) || /\b(Unauthorized|Forbidden)\b/i.test(errMsg)) {
+        return {
+          reviewerId: config.id,
+          model: config.model,
+          group: groupName,
+          evidenceDocs: [],
+          rawResponse: '',
+          status: 'forfeit',
+          error: `Auth error (permanent): ${errMsg}`,
+        };
+      }
+
+      if (useGuards) cb.recordFailure(provider!, config.model);
 
       if (attempt < retries) {
         await new Promise((resolve) => setTimeout(resolve, 1000 * (attempt + 1)));

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -531,9 +531,11 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
     );
 
     // === RULES: Apply custom review rules ===
+    // Use filtered diff from chunks (respects .reviewignore) instead of raw diffContent (#300)
+    const filteredDiffContent = chunks.map(c => c.diffContent).join('\n');
     const compiledRules = await loadReviewRules(input.repoPath ?? process.cwd());
     if (compiledRules && compiledRules.length > 0) {
-      const ruleEvidence = matchRules(diffContent, compiledRules);
+      const ruleEvidence = matchRules(filteredDiffContent, compiledRules);
       if (ruleEvidence.length > 0) {
         console.log(`[Rules] Matched ${ruleEvidence.length} rule-based issue(s)`);
         allEvidenceDocs.push(...ruleEvidence);


### PR DESCRIPTION
## Summary
- **#300**: `matchRules` in orchestrator now uses filtered diff content (from chunks that respect `.reviewignore`) instead of raw `diffContent`, so files in `.reviewignore` are no longer matched by custom rules.
- **#270**: Auth errors (HTTP 401/403) in reviewer execution now forfeit immediately without recording to the circuit breaker, preventing permanent auth failures from unnecessarily blocking models for 30s.
- **#272**: `model-registry.ts` `loadRegistry()` now uses `fileURLToPath()` instead of `new URL(...).pathname`, fixing the leading-slash issue on Windows paths (`/C:/Users/...`).

## Test plan
- [x] `pnpm test` passes (2721/2721, 4 pre-existing e2e failures unrelated to changes)
- [ ] Verify `.reviewignore` patterns are respected by `matchRules` in a real review
- [ ] Verify 401/403 errors no longer open the circuit breaker
- [ ] Verify `loadRegistry()` works on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)