### PR TITLE
fix: MCP error handling and reviewerCount wiring (#264, #262)

### DIFF
--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -27,6 +27,9 @@ async function runReviewWithDiff(
       diffPath: tmpFile,
       skipDiscussion: options.skipDiscussion,
       skipHead: options.skipHead,
+      ...(options.reviewerCount != null && {
+        reviewerSelection: { count: options.reviewerCount },
+      }),
     });
 
     if (result.status !== 'success' || !result.summary) {

--- a/packages/mcp/src/tools/review-full.ts
+++ b/packages/mcp/src/tools/review-full.ts
@@ -14,8 +14,13 @@ export function registerReviewFull(server: McpServer): void {
       diff: z.string().describe('Unified diff content'),
     },
     async ({ diff }) => {
-      const result = await runFullReview(diff);
-      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      try {
+        const result = await runFullReview(diff);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: msg }) }], isError: true };
+      }
     },
   );
 }

--- a/packages/mcp/src/tools/review-quick.ts
+++ b/packages/mcp/src/tools/review-quick.ts
@@ -15,8 +15,13 @@ export function registerReviewQuick(server: McpServer): void {
       reviewer_count: z.number().optional().default(3).describe('Number of reviewers (default: 3)'),
     },
     async ({ diff, reviewer_count }) => {
-      const result = await runQuickReview(diff, reviewer_count);
-      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      try {
+        const result = await runQuickReview(diff, reviewer_count);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: msg }) }], isError: true };
+      }
     },
   );
 }


### PR DESCRIPTION
## Summary
- **#264**: Add try/catch around pipeline calls in `review_quick` and `review_full` MCP tools. On error, returns `{ error: message }` with `isError: true`, matching the pattern used by `review_pr`, `explain_session`, and other MCP tools. Prevents pipeline crashes from taking down the MCP server.
- **#262**: Wire the `reviewerCount` parameter from `runQuickReview` through to `runPipeline`'s `reviewerSelection.count` field, so the `reviewer_count` parameter exposed by `review_quick` actually controls the number of reviewers.

## Test plan
- [x] `pnpm test` passes (2721/2721, 4 pre-existing e2e failures unrelated to this change)
- [ ] Manual: invoke `review_quick` with invalid diff to verify error is returned as `isError: true` instead of crashing
- [ ] Manual: invoke `review_quick` with `reviewer_count: 1` and verify only 1 reviewer runs

Closes #264, closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)