### PR TITLE
fix: diff parser, supporter prompt, and parse failure logging (#253, #250, #308, #309)

### DIFF
--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -12,6 +12,14 @@ import { extractFileListFromDiff } from '@codeagora/shared/utils/diff.js';
 import { CircuitBreaker, CircuitOpenError } from './circuit-breaker.js';
 import { HealthMonitor } from '../l0/health-monitor.js';
 
+/** Log when parser returns 0 issues on a non-empty response — likely unparseable output */
+function logParseFailure(model: string, reviewerId: string, responseLength: number, isFallback: boolean): void {
+  const prefix = isFallback ? 'fallback ' : '';
+  process.stderr.write(
+    `[Parser] ${prefix}model=${model} reviewer=${reviewerId}: 0 issues from ${responseLength} chars — possible unparseable response\n`
+  );
+}
+
 // ============================================================================
 // Fallback Normalization
 // ============================================================================
@@ -105,6 +113,9 @@ export async function executeReviewer(
 
       // Parse response into evidence documents with diff file paths for fallback
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        logParseFailure(config.model, config.id, response.length, false);
+      }
 
       return {
         reviewerId: config.id,
@@ -140,6 +151,9 @@ export async function executeReviewer(
       });
 
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        logParseFailure(fb.model, config.id, response.length, true);
+      }
 
       return {
         reviewerId: config.id,
@@ -307,6 +321,9 @@ async function executeReviewerWithGuards(
 
       if (useGuards) cb.recordSuccess(provider!, config.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        logParseFailure(config.model, config.id, response.length, false);
+      }
 
       return {
         reviewerId: config.id,
@@ -374,6 +391,9 @@ async function executeReviewerWithGuards(
 
       if (useFallbackGuards) cb.recordSuccess(fallbackProvider!, fb.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+      if (evidenceDocs.length === 0 && response.length > 0) {
+        logParseFailure(fb.model, config.id, response.length, true);
+      }
 
       return {
         reviewerId: config.id,

--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -437,7 +437,7 @@ async function executeSupporterResponse(
   }
 
   // Build prompt with persona
-  const basePrompt = `${moderatorPrompt}\n\nProvide your verdict:\n- AGREE: Evidence is valid and the issue is real\n- DISAGREE: Evidence is flawed, missing context, or the issue is a false positive\n- NEUTRAL: Needs more information\n\n**IMPORTANT: Do NOT conform simply because other reviewers agree. If you believe the evidence is wrong, say DISAGREE and explain why — even if you are the only one. Your independent judgment is more valuable than consensus.**\n\nProvide your stance and reasoning.`;
+  const basePrompt = `${moderatorPrompt}\n\nProvide your verdict:\n- AGREE: Evidence is valid and the issue is real\n- DISAGREE: Evidence is flawed, missing context, or the issue is a false positive\n- NEUTRAL: Needs more information\n\n**IMPORTANT: Do NOT conform simply because other reviewers agree. If you believe the evidence is wrong, say DISAGREE and explain why — even if you are the only one. Your independent judgment is more valuable than consensus.**\n\n**Response format — first line MUST be exactly one of:**\nStance: AGREE\nStance: DISAGREE\nStance: NEUTRAL\n\nThen provide your reasoning below.\n\nExample:\nStance: DISAGREE\nThe evidence cites line 42 but the actual vulnerability is mitigated by the input sanitizer at line 38.`;
 
   const prompt = personaContent
     ? `${personaContent}\n\n---\n\n${basePrompt}`

--- a/packages/shared/src/utils/diff.ts
+++ b/packages/shared/src/utils/diff.ts
@@ -5,6 +5,10 @@
 import fsPromises from 'fs/promises';
 import path from 'path';
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // ============================================================================
 // Diff File Range Parsing (Context-Aware Review)
 // ============================================================================
@@ -174,6 +178,14 @@ export function extractFileListFromDiff(diffContent: string): string[] {
     }
   }
 
+  // Fallback: parse +++ b/ lines for bare unified diffs without diff --git headers
+  if (files.length === 0) {
+    const plusMatches = diffContent.matchAll(/^\+\+\+ b\/(.+)$/gm);
+    for (const m of plusMatches) {
+      files.push(m[1]);
+    }
+  }
+
   return files;
 }
 
@@ -198,13 +210,15 @@ export function fuzzyMatchFilePath(
     if (exact) return exact;
   }
 
-  // Try partial match (filename without extension)
+  // Try partial match using path-segment boundary to avoid false positives
   for (const filename of matches) {
     const nameWithoutExt = filename.replace(/\.[^.]+$/, '');
-    const partial = filePaths.find((path) =>
-      path.toLowerCase().includes(nameWithoutExt.toLowerCase())
+    const segmentRegex = new RegExp(
+      `(?:^|/)${escapeRegExp(nameWithoutExt)}(?:\\.[^/]*)?$`,
+      'i'
     );
-    if (partial) return partial;
+    const candidates = filePaths.filter((p) => segmentRegex.test(p));
+    if (candidates.length === 1) return candidates[0];
   }
 
   return null;

--- a/src/tests/utils-diff.test.ts
+++ b/src/tests/utils-diff.test.ts
@@ -120,12 +120,10 @@ describe('fuzzyMatchFilePath', () => {
     expect(result).toBe('src/parser.ts');
   });
 
-  it('finds the path via partial match when the base name is a substring of a path', () => {
-    // "parse.ts" → exact: no path ends with "parse.ts"; partial: base "parse" is
-    // a substring of "src/parseResult.ts" → partial branch returns that path.
+  it('rejects prefix false positive — "parse" must not match "parseResult.ts" (#253)', () => {
     const partialPaths = ['src/parseResult.ts', 'src/validator.ts'];
     const result = fuzzyMatchFilePath('parse.ts', partialPaths);
-    expect(result).toBe('src/parseResult.ts');
+    expect(result).toBeNull();
   });
 
   it('returns null when no filename token matches any path', () => {


### PR DESCRIPTION
## Summary

Review-corrected fixes for the 4 pipeline issues that failed initial review.

## Fixes

| Issue | Fix |
|-------|-----|
| #253 | fuzzyMatchFilePath regex uses `(?:\.[^/]*)?$` — prevents prefix false positives (string→stringify.ts), returns null on ambiguous basenames |
| #250 | extractFileListFromDiff fallback parses `+++ b/` lines for bare unified diffs |
| #308 | Supporter prompt requires `Stance: AGREE/DISAGREE/NEUTRAL` first-line format with example |
| #309 | `logParseFailure` helper — failure-only logging (no success noise), 1 helper replaces 4x copy-paste |

## Review corrections applied
- #253: Changed `[^/]*$` to `(?:\.[^/]*)?$` to block prefix matches (review finding)
- #309: Removed success-path logging, extracted helper function (review finding)

## Test Plan
- [x] 2749 tests passing
- [x] utils-diff test updated: prefix false positive now correctly returns null

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added diagnostic logging for parse failures with detailed metadata to aid troubleshooting

* **Bug Fixes**
  * Improved stance detection with stricter response format requirements
  * Enhanced diff file extraction with fallback parsing and more accurate path matching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->