### PR TITLE
fix: remove severity escalation for unknown filePath (#248)

### DIFF
--- a/packages/core/src/l1/parser.ts
+++ b/packages/core/src/l1/parser.ts
@@ -33,16 +33,8 @@ export function parseEvidenceResponse(
         .map((line) => line.replace(/^\d+\.\s*/, ''));
 
       const { severity: parsedSeverity, confidence: reviewerConfidence } = parseSeverity(severityText.trim());
-      let severity = parsedSeverity;
+      const severity = parsedSeverity;
       const fileInfo = extractFileInfo(problem, diffFilePaths);
-
-      // Escalate severity to CRITICAL minimum when file path is unknown
-      if (fileInfo.filePath === 'unknown') {
-        if (severity === 'SUGGESTION' || severity === 'WARNING') {
-          severity = 'CRITICAL';
-        }
-        // CRITICAL and HARSHLY_CRITICAL are preserved as-is
-      }
 
       documents.push({
         issueTitle: title.trim(),


### PR DESCRIPTION
## Summary
- **Bug**: The L1 parser escalated SUGGESTION/WARNING severity to CRITICAL when `filePath` was `'unknown'`, meaning a parser failure to extract a file path silently inflated issue severity.
- **Fix**: Removed the severity escalation block in `packages/core/src/l1/parser.ts`. The parsed severity is now preserved as-is regardless of file path resolution status.
- **Impact**: Eliminates false CRITICAL issues that cascaded into L2 discussion and L3 verdicts, reducing noise in review output.

Closes #248

## Test plan
- [x] All 219 core package tests pass (`pnpm --filter @codeagora/core test`)
- [x] No test modifications needed — existing tests already validate correct severity parsing without the escalation logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Severity levels in evidence responses are now accurately preserved regardless of file path availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->