### PR TITLE
fix: route mixed-severity group docs individually after threshold miss (#249)

### DIFF
--- a/packages/core/src/l2/threshold.ts
+++ b/packages/core/src/l2/threshold.ts
@@ -62,14 +62,16 @@ export function applyThreshold(
       continue;
     }
 
-    // Single reviewer CRITICAL/WARNING → unconfirmed queue
-    if (group.docs.length === 1 && ['CRITICAL', 'WARNING'].includes(group.primarySeverity)) {
-      unconfirmed.push(...group.docs);
-      continue;
+    // Route individual docs by their own severity — handles both single-reviewer
+    // and mixed-severity groups (e.g. 1 CRITICAL + 1 WARNING) that failed to
+    // meet threshold. Prevents mixed groups from silently falling into SUGGESTION.
+    for (const doc of group.docs) {
+      if (doc.severity === 'CRITICAL' || doc.severity === 'HARSHLY_CRITICAL' || doc.severity === 'WARNING') {
+        unconfirmed.push(doc);
+      } else {
+        suggestions.push(doc);
+      }
     }
-
-    // Fallback: Low-priority suggestions
-    suggestions.push(...group.docs);
   }
 
   return { discussions, unconfirmed, suggestions };


### PR DESCRIPTION
## Summary
- **Bug**: A mixed-severity group (e.g. 1 CRITICAL + 1 WARNING) that failed threshold checks was silently downgraded to SUGGESTION. The old code required `docs.length === 1` to route to `unconfirmed`, so multi-doc groups fell through to the SUGGESTION fallback.
- **Fix**: Replace the single-reviewer check + fallback block with a per-doc loop that routes each doc by its own severity — CRITICAL/HARSHLY_CRITICAL/WARNING go to `unconfirmed`, everything else goes to `suggestions`.
- **Impact**: Mixed-severity groups are no longer silently lost; each doc is preserved at its intended severity level.

Closes #249

## Test plan
- [x] Existing 219 core tests pass (including 10 L2 threshold tests)
- [ ] Verify a mixed-severity group (1 CRITICAL + 1 WARNING) routes both docs to `unconfirmed` instead of `suggestions`
- [ ] Verify a single SUGGESTION doc still routes to `suggestions`
- [ ] Verify single-reviewer CRITICAL/WARNING docs still route to `unconfirmed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Enhanced document routing and classification** - Documents are now properly classified based on individual severity levels. Documents marked as critical or warning route correctly to the appropriate queue, preventing silent misclassification of mixed-severity groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->