### PR TITLE
fix: inject actual L1 evidence content into moderator prompt (#246)

### DIFF
--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -570,8 +570,38 @@ ${rounds.map((r, i) => `Round ${i + 1}:\n${r.supporterResponses.map(s => `- ${s.
 // Helpers
 // ============================================================================
 
+function buildEvidenceSection(discussion: Discussion, isKo: boolean): string {
+  const content = discussion.evidenceContent;
+  if (!content || content.length === 0) {
+    return isKo
+      ? `근거 문서: ${discussion.evidenceDocs.length}명의 리뷰어`
+      : `Evidence documents: ${discussion.evidenceDocs.length} reviewer(s)`;
+  }
+
+  const sections = content.map((doc, i) => {
+    if (isKo) {
+      return [
+        `**리뷰어 ${i + 1}** (${doc.severity}):`,
+        `문제: ${doc.problem}`,
+        doc.evidence.length > 0 ? `근거: ${doc.evidence.join('; ')}` : '',
+        doc.suggestion ? `제안: ${doc.suggestion}` : '',
+      ].filter(Boolean).join('\n');
+    }
+    return [
+      `**Reviewer ${i + 1}** (${doc.severity}):`,
+      `Problem: ${doc.problem}`,
+      doc.evidence.length > 0 ? `Evidence: ${doc.evidence.join('; ')}` : '',
+      doc.suggestion ? `Suggestion: ${doc.suggestion}` : '',
+    ].filter(Boolean).join('\n');
+  });
+
+  const label = isKo ? '리뷰어 근거' : 'Reviewer Evidence';
+  return `${label}:\n\n${sections.join('\n\n')}`;
+}
+
 function buildModeratorPrompt(discussion: Discussion, roundNum: number, language?: 'en' | 'ko'): string {
   const isKo = language === 'ko';
+  const evidenceSection = buildEvidenceSection(discussion, isKo);
 
   if (isKo) {
     const snippetSection = discussion.codeSnippet && discussion.codeSnippet.trim()
@@ -587,7 +617,7 @@ ${discussion.codeSnippet}
 파일: ${discussion.filePath}:${discussion.lineRange[0]}-${discussion.lineRange[1]}
 주장된 심각도: ${discussion.severity}
 
-근거 문서: ${discussion.evidenceDocs.length}명의 리뷰어
+${evidenceSection}
 
 ${snippetSection}
 
@@ -612,11 +642,11 @@ Issue: ${discussion.issueTitle}
 File: ${discussion.filePath}:${discussion.lineRange[0]}-${discussion.lineRange[1]}
 Claimed Severity: ${discussion.severity}
 
-Evidence documents: ${discussion.evidenceDocs.length} reviewer(s)
+${evidenceSection}
 
 ${snippetSection}
 
-Evaluate the evidence and provide your verdict.`;
+Evaluate the evidence above and provide your verdict.`;
 }
 
 type Stance = 'agree' | 'disagree' | 'neutral';

--- a/packages/core/src/l2/threshold.ts
+++ b/packages/core/src/l2/threshold.ts
@@ -169,6 +169,7 @@ function createDiscussion(group: LocationGroup, severity: Severity, counter: { v
     lineRange: group.lineRange,
     codeSnippet: '', // Populated by moderator
     evidenceDocs: group.docs.map((d) => `evidence-${d.issueTitle.replace(/\s+/g, '-')}.md`),
+    evidenceContent: group.docs, // Actual L1 content for supporter prompts (#246)
     status: 'pending',
   };
 }

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -92,6 +92,7 @@ export interface Discussion {
   lineRange: [number, number];
   codeSnippet: string; // ±10 lines
   evidenceDocs: string[]; // Paths to reviewer evidence .md files
+  evidenceContent?: EvidenceDocument[]; // Actual L1 evidence for supporter prompts
   status: 'pending' | 'in_progress' | 'resolved' | 'escalated';
 }
 


### PR DESCRIPTION
## Summary
- **Before:** The moderator prompt only told supporters *how many* evidence docs existed (`Evidence documents: 3 reviewer(s)`) but never included the actual problem descriptions, evidence, severity, or suggestions. Supporters were judging issues blind.
- **After:** The full L1 reviewer findings (problem, evidence lines, severity, suggestion) are now injected into the moderator prompt via a new `buildEvidenceSection()` helper. When `evidenceContent` is populated, each reviewer's findings are rendered inline; when absent, the old count-only fallback is preserved for backward compatibility.
- Both Korean and English prompt branches are updated.

Closes #246

## Changed files
- `packages/core/src/types/core.ts` -- added optional `evidenceContent` field to `Discussion` interface
- `packages/core/src/l2/threshold.ts` -- populated `evidenceContent` with `group.docs` in `createDiscussion`
- `packages/core/src/l2/moderator.ts` -- added `buildEvidenceSection()` and wired it into `buildModeratorPrompt`

## Test plan
- [x] `pnpm --filter @codeagora/core test` -- all 219 tests pass (18 files)
- [ ] Manual: run a review pipeline and inspect the moderator prompt to confirm reviewer evidence text appears
- [ ] Verify Korean language branch renders `리뷰어 근거:` with individual reviewer sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)