### PR TITLE
fix: add missing failOnReject to CLI options type

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -111,6 +111,7 @@ program
     contextLines?: number;
     jsonStream?: boolean;
     cache: boolean;
+    failOnReject?: boolean;
   }) => {
     // Hoist stdinTmpPath so finally block can clean it up (#77)
     let stdinTmpPath: string | undefined;


### PR DESCRIPTION
## Summary
- The `--fail-on-reject` CLI option was defined via `.option()` but its camelCase property `failOnReject` was missing from the inline options type literal, causing `TS2339` on main.
- Added `failOnReject?: boolean` to the options type to match the Commander option definition.

## Test plan
- [x] `pnpm typecheck` passes cleanly (was failing with `TS2339` at `packages/cli/src/index.ts:412`)
- [x] No other type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)