### PR TITLE
fix: add notifications package to action build resolver

### DIFF
--- a/scripts/build-action.mjs
+++ b/scripts/build-action.mjs
@@ -15,8 +15,8 @@ const root = path.resolve(__dirname, '..');
 const workspaceResolverPlugin = {
   name: 'workspace-resolver',
   setup(build) {
-    build.onResolve({ filter: /^@codeagora\/(core|shared|github)/ }, (args) => {
-      const match = args.path.match(/^@codeagora\/(core|shared|github)\/(.+?)(?:\.js)?$/);
+    build.onResolve({ filter: /^@codeagora\/(core|shared|github|notifications)/ }, (args) => {
+      const match = args.path.match(/^@codeagora\/(core|shared|github|notifications)\/(.+?)(?:\.js)?$/);
       if (!match) return null;
       const [, pkg, subpath] = match;
       const tsPath = path.resolve(root, 'packages', pkg, 'src', subpath + '.ts');


### PR DESCRIPTION
## Summary
- Added `notifications` to the workspace resolver regex in `scripts/build-action.mjs`
- The `workspaceResolverPlugin` only matched `@codeagora/(core|shared|github)` but `action.ts` now imports from `@codeagora/notifications/webhook.js`, causing the GitHub Action build to fail

## Test plan
- [x] Ran `node scripts/build-action.mjs` locally -- builds with 0 errors, 0 warnings
- [ ] Verify CI build passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)