### PR TITLE
fix: web session detail test mock uses endsWith for diff path

### DIFF
--- a/packages/web/tests/server/sessions-detail.test.ts
+++ b/packages/web/tests/server/sessions-detail.test.ts
@@ -165,7 +165,7 @@ describe('GET /api/sessions/:date/:id — diff field', () => {
       const p = String(filePath);
       if (p.includes('metadata.json')) return JSON.stringify(sampleMetadata);
       if (p.includes('head-verdict.json')) return sampleVerdictContent;
-      if (p === 'test.diff') return diffContent;
+      if (p.endsWith('test.diff')) return diffContent;
       return '{}';
     });
 
@@ -188,7 +188,7 @@ describe('GET /api/sessions/:date/:id — diff field', () => {
       if (p.includes('metadata.json')) return JSON.stringify(sampleMetadata);
       if (p.includes('head-verdict.json')) return sampleVerdictContent;
       // diff file read throws
-      if (p === 'test.diff') throw new Error('ENOENT: no such file');
+      if (p.endsWith('test.diff')) throw new Error('ENOENT: no such file');
       return '{}';
     });
 


### PR DESCRIPTION
## Summary
- `validateDiffPath('test.diff')` resolves to an absolute path (e.g. `/cwd/test.diff`), but the `mockReadFile` checked `p === 'test.diff'` (exact match)
- Changed both mock checks (lines 168 and 191) from `===` to `.endsWith()` so the mock correctly matches the resolved absolute path
- Fixes 2 failing tests in `sessions-detail.test.ts`: diff content return and ENOENT fallback

## Test plan
- [x] `pnpm --filter @codeagora/web test` — all 424 tests pass (37 files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)