### PR TITLE
fix: guarantee exploration slot and cap posterior in Thompson Sampling (#232)

### DIFF
--- a/packages/core/src/l0/model-selector.ts
+++ b/packages/core/src/l0/model-selector.ts
@@ -130,7 +130,10 @@ export function selectModels(request: SelectionRequest): ModelSelection {
   const actualCount = Math.min(count, availableModels.length);
 
   // 1. Determine exploration slots
-  const explorationSlots = Math.max(0, Math.floor(actualCount * explorationRate));
+  // Guarantee at least 1 exploration slot when 2+ models selected (#232)
+  const explorationSlots = actualCount >= 2
+    ? Math.max(1, Math.floor(actualCount * explorationRate))
+    : 0;
   const _samplingSlots = actualCount - explorationSlots;
 
   const selected: Array<{
@@ -162,9 +165,12 @@ export function selectModels(request: SelectionRequest): ModelSelection {
     .filter((m) => !usedKeys.has(armKey(m)))
     .map((model) => {
       const arm = banditState.get(armKey(model));
-      // Cold start: optimistic initialization α=2, β=1
-      const alpha = arm ? arm.alpha + 1 : 3;
-      const beta = arm ? arm.beta + 1 : 2;
+      // Cap prior strength to prevent posterior collapse (#232).
+      // Without a cap, a model with early luck accumulates alpha >> beta
+      // and permanently dominates selection.
+      const MAX_PRIOR = 20;
+      const alpha = arm ? Math.min(arm.alpha + 1, MAX_PRIOR) : 3;
+      const beta = arm ? Math.min(arm.beta + 1, MAX_PRIOR) : 2;
       const theta = sampleBeta(alpha, beta, rng);
       return { model, theta };
     })


### PR DESCRIPTION
## Summary
- **Exploration slot guarantee**: `Math.floor(count * 0.1)` yielded 0 for typical reviewer counts (≤9), so exploration never fired. Now guarantees at least 1 exploration slot when 2+ models are selected.
- **Posterior collapse cap**: Alpha on successful models grew unbounded, causing the Beta posterior to collapse and permanently favor one model. Both alpha and beta are now capped at 20 (`MAX_PRIOR`).

Closes #232

## Test plan
- [x] All 219 existing core tests pass (`pnpm --filter @codeagora/core test`)
- [ ] Manual: run pipeline with ≤9 reviewers and verify exploration slot appears in selection metadata
- [ ] Manual: run repeated sessions and confirm no single model permanently dominates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection reliability by ensuring exploration happens consistently when selecting multiple models.

* **Performance**
  * Enhanced Thompson Sampling stability by implementing bounds on prior strength calculations for more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->