### PR TITLE
fix: increase line proximity for finding grouping and dedup (#234)

### DIFF
--- a/packages/core/src/l2/deduplication.ts
+++ b/packages/core/src/l2/deduplication.ts
@@ -83,9 +83,10 @@ function areDuplicates(d1: Discussion, d2: Discussion): boolean {
   const [start1, end1] = d1.lineRange;
   const [start2, end2] = d2.lineRange;
 
-  // Check for overlap
-  const overlaps = start1 <= end2 && start2 <= end1;
-  if (!overlaps) {
+  // Check for overlap or proximity (within 15 lines, matching threshold.ts)
+  const DEDUP_PROXIMITY = 15;
+  const overlapsOrNearby = start1 <= end2 + DEDUP_PROXIMITY && start2 <= end1 + DEDUP_PROXIMITY;
+  if (!overlapsOrNearby) {
     return false;
   }
 

--- a/packages/core/src/l2/threshold.ts
+++ b/packages/core/src/l2/threshold.ts
@@ -92,8 +92,9 @@ interface LocationGroup {
 /**
  * Fuzzy line-range tolerance for grouping — two reviewers flagging nearby
  * lines on the same file are treated as the same location.
+ * 15 lines covers most single-function bodies (#234).
  */
-const LINE_PROXIMITY = 5;
+const LINE_PROXIMITY = 15;
 
 function groupByLocation(docs: EvidenceDocument[]): LocationGroup[] {
   const groups: LocationGroup[] = [];

--- a/packages/core/src/tests/l2-dedup.test.ts
+++ b/packages/core/src/tests/l2-dedup.test.ts
@@ -53,7 +53,7 @@ describe('findDuplicates', () => {
 
   it('does NOT group discussions with non-overlapping line ranges', () => {
     const d1 = makeDiscussion({ id: 'd001', filePath: 'src/a.ts', lineRange: [1, 5] });
-    const d2 = makeDiscussion({ id: 'd002', filePath: 'src/a.ts', lineRange: [10, 20] });
+    const d2 = makeDiscussion({ id: 'd002', filePath: 'src/a.ts', lineRange: [30, 40] });
     expect(findDuplicates([d1, d2]).size).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- Increased `LINE_PROXIMITY` from 5 to 15 in `threshold.ts` so that findings on the same function but 10+ lines apart are grouped into a single discussion instead of creating duplicates.
- Relaxed the strict overlap check in `deduplication.ts` to also consider proximity (within 15 lines), matching the threshold grouping logic.
- Updated test expectation for non-overlapping ranges to use a wider gap (30+ lines) to reflect the new proximity value.

Closes #234

## Test plan
- [x] `pnpm --filter @codeagora/core test` — all 219 tests pass
- [ ] Manual verification: run pipeline on a diff with nearby findings (10-15 lines apart) and confirm they merge into a single discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)