### PR TITLE
improve: expand reviewer context with build/deploy detection and user config (#405)

### DIFF
--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -41,7 +41,7 @@ import { lookupCache, addToCache } from '@codeagora/shared/utils/cache.js';
 import { CA_ROOT } from '@codeagora/shared/utils/fs.js';
 import fs from 'fs/promises';
 import path from 'path';
-import type { Config, ReviewerEntry } from '../types/config.js';
+import type { Config, ReviewerEntry, ReviewContext } from '../types/config.js';
 import type { ModeratorReport } from '../types/core.js';
 
 // ============================================================================
@@ -122,61 +122,111 @@ export interface PipelineResult {
  * Returned string is injected into reviewer prompts to prevent false positives
  * (e.g. flagging workspace:* in pnpm monorepos, suggesting wrong libraries).
  */
-async function detectProjectContext(repoPath: string): Promise<string | undefined> {
+async function detectProjectContext(repoPath: string, userContext?: ReviewContext): Promise<string | undefined> {
   try {
-    const pkgPath = path.join(repoPath, 'package.json');
-    const pkgRaw = await fs.readFile(pkgPath, 'utf-8').catch(() => null);
-    if (!pkgRaw) return undefined;
-
-    const pkg = JSON.parse(pkgRaw) as {
-      name?: string;
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-      packageManager?: string;
-    };
-
-    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
-    const depNames = Object.keys(allDeps);
-
     const lines: string[] = [];
 
-    if (pkg.name) lines.push(`Project: ${pkg.name}`);
-
-    // Monorepo detection
-    const isMonorepo = await fs.access(path.join(repoPath, 'pnpm-workspace.yaml')).then(() => true).catch(() => false)
-      || await fs.access(path.join(repoPath, 'lerna.json')).then(() => true).catch(() => false)
-      || await fs.access(path.join(repoPath, 'nx.json')).then(() => true).catch(() => false);
-    if (isMonorepo) {
-      lines.push('Architecture: monorepo (workspace:* dependencies are STANDARD and correct — do NOT flag them)');
+    // ── 1. User-defined deployment type (highest priority) ──────────────
+    if (userContext?.deploymentType) {
+      const deployDescriptions: Record<string, string> = {
+        'github-action': 'Deployment: GitHub Action — dist/ is a SELF-CONTAINED BUNDLE. All dependencies MUST be inlined. Do NOT flag bundled dependencies as external or missing.',
+        'cli': 'Deployment: CLI tool — distributed as a standalone executable or npm package.',
+        'library': 'Deployment: Library — published to a package registry. Public API surface matters.',
+        'web-app': 'Deployment: Web application — bundled for browser delivery.',
+        'api-server': 'Deployment: API server — runs as a long-lived process.',
+        'lambda': 'Deployment: Serverless function (Lambda/Cloud Function) — cold-start and bundle size matter.',
+        'docker': 'Deployment: Docker container — multi-stage builds and image size matter.',
+        'edge-function': 'Deployment: Edge function — strict runtime constraints, limited APIs.',
+        'monorepo': 'Architecture: monorepo (workspace:* dependencies are STANDARD and correct — do NOT flag them).',
+      };
+      lines.push(deployDescriptions[userContext.deploymentType] ?? `Deployment: ${userContext.deploymentType}`);
     }
 
-    // Package manager
-    if (pkg.packageManager?.startsWith('pnpm') || depNames.includes('pnpm')) {
-      lines.push('Package manager: pnpm');
-    }
-
-    // Key frameworks / libraries — used to prevent wrong-library suggestions
-    const knownLibs: Array<[string[], string]> = [
-      [['zod'], 'Validation: zod (do NOT suggest joi, yup, or other validation libraries)'],
-      [['joi'], 'Validation: joi'],
-      [['express'], 'Framework: Express'],
-      [['fastify'], 'Framework: Fastify'],
-      [['hono'], 'Framework: Hono'],
-      [['next'], 'Framework: Next.js'],
-      [['nuxt'], 'Framework: Nuxt'],
-      [['react'], 'UI: React'],
-      [['vue'], 'UI: Vue'],
-      [['prisma', '@prisma/client'], 'ORM: Prisma'],
-      [['typeorm'], 'ORM: TypeORM'],
-      [['drizzle-orm'], 'ORM: Drizzle'],
-      [['vitest'], 'Test: vitest'],
-      [['jest'], 'Test: jest'],
-      [['typescript'], 'Language: TypeScript (strict mode expected)'],
+    // ── 2. Auto-detect build/deploy from marker files ──────────────────
+    const markerFiles: Array<[string[], string]> = [
+      [['action.yml', 'action.yaml'], 'Deployment: GitHub Action — dist/ is a SELF-CONTAINED BUNDLE. All dependencies MUST be inlined. Do NOT flag bundled dependencies as external or missing.'],
+      [['Dockerfile'], 'Build: Docker container detected.'],
+      [['serverless.yml', 'serverless.yaml'], 'Deployment: Serverless Framework detected.'],
+      [['vercel.json'], 'Deployment: Vercel detected.'],
+      [['netlify.toml'], 'Deployment: Netlify detected.'],
+      [['fly.toml'], 'Deployment: Fly.io detected.'],
+      [['wrangler.toml'], 'Deployment: Cloudflare Workers detected.'],
     ];
 
-    for (const [keys, label] of knownLibs) {
-      if (keys.some((k) => depNames.includes(k))) {
-        lines.push(label);
+    for (const [files, label] of markerFiles) {
+      for (const f of files) {
+        const exists = await fs.access(path.join(repoPath, f)).then(() => true).catch(() => false);
+        if (exists) {
+          lines.push(label);
+          break; // only add once per marker group
+        }
+      }
+    }
+
+    // ── 3. User-defined bundled outputs ────────────────────────────────
+    if (userContext?.bundledOutputs && userContext.bundledOutputs.length > 0) {
+      lines.push(`Bundled outputs: ${userContext.bundledOutputs.join(', ')} — all deps inlined, do NOT flag external/missing dependency issues in these paths.`);
+    }
+
+    // ── 4. package.json analysis (existing logic) ──────────────────────
+    const pkgPath = path.join(repoPath, 'package.json');
+    const pkgRaw = await fs.readFile(pkgPath, 'utf-8').catch(() => null);
+    if (pkgRaw) {
+      const pkg = JSON.parse(pkgRaw) as {
+        name?: string;
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+        packageManager?: string;
+      };
+
+      const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+      const depNames = Object.keys(allDeps);
+
+      if (pkg.name) lines.push(`Project: ${pkg.name}`);
+
+      // Monorepo detection
+      const isMonorepo = await fs.access(path.join(repoPath, 'pnpm-workspace.yaml')).then(() => true).catch(() => false)
+        || await fs.access(path.join(repoPath, 'lerna.json')).then(() => true).catch(() => false)
+        || await fs.access(path.join(repoPath, 'nx.json')).then(() => true).catch(() => false);
+      if (isMonorepo) {
+        lines.push('Architecture: monorepo (workspace:* dependencies are STANDARD and correct — do NOT flag them)');
+      }
+
+      // Package manager
+      if (pkg.packageManager?.startsWith('pnpm') || depNames.includes('pnpm')) {
+        lines.push('Package manager: pnpm');
+      }
+
+      // Key frameworks / libraries — used to prevent wrong-library suggestions
+      const knownLibs: Array<[string[], string]> = [
+        [['zod'], 'Validation: zod (do NOT suggest joi, yup, or other validation libraries)'],
+        [['joi'], 'Validation: joi'],
+        [['express'], 'Framework: Express'],
+        [['fastify'], 'Framework: Fastify'],
+        [['hono'], 'Framework: Hono'],
+        [['next'], 'Framework: Next.js'],
+        [['nuxt'], 'Framework: Nuxt'],
+        [['react'], 'UI: React'],
+        [['vue'], 'UI: Vue'],
+        [['prisma', '@prisma/client'], 'ORM: Prisma'],
+        [['typeorm'], 'ORM: TypeORM'],
+        [['drizzle-orm'], 'ORM: Drizzle'],
+        [['vitest'], 'Test: vitest'],
+        [['jest'], 'Test: jest'],
+        [['typescript'], 'Language: TypeScript (strict mode expected)'],
+      ];
+
+      for (const [keys, label] of knownLibs) {
+        if (keys.some((k) => depNames.includes(k))) {
+          lines.push(label);
+        }
+      }
+    }
+
+    // ── 5. User-defined notes (appended last) ─────────────────────────
+    if (userContext?.notes && userContext.notes.length > 0) {
+      for (const note of userContext.notes) {
+        lines.push(note);
       }
     }
 
@@ -588,7 +638,7 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
 
     // === PROJECT CONTEXT: Detect for false-positive prevention (#237) ===
     const projectContext = input.repoPath
-      ? await detectProjectContext(input.repoPath).catch(() => undefined)
+      ? await detectProjectContext(input.repoPath, config.reviewContext).catch(() => undefined)
       : undefined;
 
     // === L1 REVIEWERS: Chunk Processing ===

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -230,6 +230,23 @@ export const PromptsConfigSchema = z.object({
 }).optional();
 export type PromptsConfig = z.infer<typeof PromptsConfigSchema>;
 
+// ============================================================================
+// Review Context (user-defined project context for reviewers)
+// ============================================================================
+
+export const ReviewContextSchema = z.object({
+  /** Deployment type — tells reviewers how the project is built and deployed */
+  deploymentType: z.enum([
+    'github-action', 'cli', 'library', 'web-app', 'api-server',
+    'lambda', 'docker', 'edge-function', 'monorepo',
+  ]).optional(),
+  /** Free-form context lines injected into reviewer prompt */
+  notes: z.array(z.string()).optional(),
+  /** Files/patterns that are bundled outputs (all deps inlined, do NOT flag external issues) */
+  bundledOutputs: z.array(z.string()).optional(),
+}).optional();
+export type ReviewContext = z.infer<typeof ReviewContextSchema>;
+
 export const ConfigSchema = z.object({
   mode: ReviewModeSchema.optional(),
   language: LanguageSchema.optional(),
@@ -245,6 +262,7 @@ export const ConfigSchema = z.object({
   github: GitHubIntegrationSchema.optional(),
   autoApprove: AutoApproveConfigSchema,
   prompts: PromptsConfigSchema,
+  reviewContext: ReviewContextSchema,
   plugins: z.array(z.string()).optional(),
 });
 export type Config = z.infer<typeof ConfigSchema>;


### PR DESCRIPTION
## Summary
- **Before**: `detectProjectContext` only analyzed `package.json` (deps, monorepo, package manager). GitHub Actions with bundled `dist/` had no deployment context, causing reviewers to flag correct dependency removal as HARSHLY_CRITICAL (PR #404).
- **After**: Expanded context detection with three new capabilities:
  - **Auto-detect deployment** from marker files (`action.yml`, `Dockerfile`, `serverless.yml`, `vercel.json`, `netlify.toml`, `fly.toml`, `wrangler.toml`)
  - **User-defined `reviewContext`** in `.ca/config.json` — `deploymentType`, `notes`, and `bundledOutputs`
  - **Bundled output patterns** tell reviewers explicitly not to flag inlined dependency issues

### Config example
```json
{
  "reviewContext": {
    "deploymentType": "github-action",
    "bundledOutputs": ["dist/**"],
    "notes": ["This action bundles all deps via ncc"]
  }
}
```

Closes #405

## Test plan
- [x] All 219 existing core tests pass (`pnpm --filter @codeagora/core test`)
- [ ] Manual: run pipeline on a GitHub Action repo with `action.yml` — verify context includes self-contained bundle note
- [ ] Manual: add `reviewContext` to config and verify it appears in reviewer prompt
- [ ] Manual: verify bundled output patterns suppress external dependency warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)