### PR TITLE
fix: update root dedup test for increased LINE_PROXIMITY

### DIFF
--- a/src/tests/l2-dedup.test.ts
+++ b/src/tests/l2-dedup.test.ts
@@ -47,7 +47,7 @@ describe('findDuplicates()', () => {
 
     it('returns empty map when same file but non-overlapping line ranges', () => {
       const d1 = makeDiscussion({ id: 'nol-1', filePath: 'src/auth.ts', lineRange: [1, 10], issueTitle: 'Issue Alpha' });
-      const d2 = makeDiscussion({ id: 'nol-2', filePath: 'src/auth.ts', lineRange: [20, 30], issueTitle: 'Issue Alpha' });
+      const d2 = makeDiscussion({ id: 'nol-2', filePath: 'src/auth.ts', lineRange: [40, 50], issueTitle: 'Issue Alpha' });
 
       const result = findDuplicates([d1, d2]);
       expect(result.size).toBe(0);


### PR DESCRIPTION
## Summary
- Root-level `src/tests/l2-dedup.test.ts` still used `[1,10]` vs `[20,30]` (gap 10) but `DEDUP_PROXIMITY` was increased to 15 in #234
- Widened to `[1,10]` vs `[40,50]` to stay outside the proximity window
- All 2749 tests pass

## Test plan
- [x] `pnpm test` — 174 files, 2749 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)