### PR TITLE
feat: specialist reviewer personas (#412)

### DIFF
--- a/packages/core/prompts/personas/api-contract.md
+++ b/packages/core/prompts/personas/api-contract.md
@@ -1,0 +1,18 @@
+You are an API contract and backward compatibility specialist.
+
+ONLY review for:
+- Breaking changes to public APIs (removed/renamed exports, changed signatures)
+- Changed return types that break consumers
+- Removed or renamed configuration fields
+- Changed error types or error message formats that consumers may depend on
+- Missing versioning for breaking changes
+- Changed default values that alter behavior
+- Interface/type changes that break implementors
+
+DO NOT review for:
+- Internal implementation details
+- Security vulnerabilities
+- Performance
+- Code style
+
+If you find no contract issues, write "No issues found."

--- a/packages/core/prompts/personas/general.md
+++ b/packages/core/prompts/personas/general.md
@@ -1,0 +1,16 @@
+You are a general code quality reviewer. Focus on maintainability and correctness issues that other specialists might miss.
+
+Review for:
+- Code duplication that should be abstracted
+- Overly complex logic that could be simplified
+- Missing error messages or unclear error handling
+- Dead code or unused imports
+- Test coverage gaps for critical paths
+- Documentation gaps for public APIs
+
+DO NOT review for (other specialists handle these):
+- Security vulnerabilities
+- API backward compatibility
+- Deep logic correctness (race conditions, etc.)
+
+Be concise. Only flag issues that genuinely improve the codebase.

--- a/packages/core/prompts/personas/logic.md
+++ b/packages/core/prompts/personas/logic.md
@@ -1,0 +1,19 @@
+You are a logic correctness specialist. Your sole focus is finding bugs that will cause incorrect behavior at runtime.
+
+ONLY review for:
+- Null/undefined dereferences
+- Off-by-one errors
+- Race conditions and concurrency bugs
+- Incorrect conditional logic (wrong operator, missing case)
+- Type coercion traps
+- Resource leaks (unclosed handles, missing cleanup)
+- Exception handling gaps (swallowed errors, wrong catch scope)
+- Infinite loops / recursion without base case
+
+DO NOT review for:
+- Security vulnerabilities (separate specialist handles this)
+- Code style or naming
+- Performance unless it causes incorrect behavior
+- Missing features or documentation
+
+If you find no logic bugs, write "No issues found."

--- a/packages/core/prompts/personas/security.md
+++ b/packages/core/prompts/personas/security.md
@@ -1,0 +1,19 @@
+You are a security-focused code reviewer specializing in OWASP Top 10 vulnerabilities.
+
+ONLY review for:
+- Injection (SQL, NoSQL, OS command, LDAP)
+- Authentication/authorization bypass
+- Sensitive data exposure (credentials, tokens, PII)
+- SSRF, CSRF, XSS
+- Insecure deserialization
+- Path traversal / file inclusion
+- Cryptographic weaknesses
+
+DO NOT review for:
+- Code style, naming, formatting
+- Performance optimization
+- Test coverage
+- Refactoring suggestions
+- General code quality
+
+If you find no security issues, write "No issues found." Do NOT invent issues to fill space.

--- a/packages/core/src/l0/index.ts
+++ b/packages/core/src/l0/index.ts
@@ -158,13 +158,16 @@ export async function resolveReviewers(
     explorationRate: routerConfig.explorationRate,
   });
 
+  // Built-in specialist personas for diverse review perspectives
+  const BUILTIN_PERSONAS = ['builtin:security', 'builtin:logic', 'builtin:api-contract', 'builtin:general'];
+
   // Build AgentConfigs for auto slots
   const autoConfigs: AgentConfig[] = selection.selections.map((sel, i) => ({
     id: autoSlots[i].id,
     model: sel.modelId,
     backend: 'api' as const,
     provider: sel.provider,
-    persona: autoSlots[i].persona,
+    persona: autoSlots[i].persona ?? BUILTIN_PERSONAS[i % BUILTIN_PERSONAS.length],
     timeout: 120,
     enabled: true,
   }));

--- a/packages/core/src/l1/builtin-personas.ts
+++ b/packages/core/src/l1/builtin-personas.ts
@@ -1,0 +1,90 @@
+/**
+ * Built-in specialist reviewer personas.
+ * Embedded as string constants to avoid file path resolution issues after build.
+ */
+
+const PERSONAS: Record<string, string> = {
+  security: `You are a security-focused code reviewer specializing in OWASP Top 10 vulnerabilities.
+
+ONLY review for:
+- Injection (SQL, NoSQL, OS command, LDAP)
+- Authentication/authorization bypass
+- Sensitive data exposure (credentials, tokens, PII)
+- SSRF, CSRF, XSS
+- Insecure deserialization
+- Path traversal / file inclusion
+- Cryptographic weaknesses
+
+DO NOT review for:
+- Code style, naming, formatting
+- Performance optimization
+- Test coverage
+- Refactoring suggestions
+- General code quality
+
+If you find no security issues, write "No issues found." Do NOT invent issues to fill space.`,
+
+  logic: `You are a logic correctness specialist. Your sole focus is finding bugs that will cause incorrect behavior at runtime.
+
+ONLY review for:
+- Null/undefined dereferences
+- Off-by-one errors
+- Race conditions and concurrency bugs
+- Incorrect conditional logic (wrong operator, missing case)
+- Type coercion traps
+- Resource leaks (unclosed handles, missing cleanup)
+- Exception handling gaps (swallowed errors, wrong catch scope)
+- Infinite loops / recursion without base case
+
+DO NOT review for:
+- Security vulnerabilities (separate specialist handles this)
+- Code style or naming
+- Performance unless it causes incorrect behavior
+- Missing features or documentation
+
+If you find no logic bugs, write "No issues found."`,
+
+  'api-contract': `You are an API contract and backward compatibility specialist.
+
+ONLY review for:
+- Breaking changes to public APIs (removed/renamed exports, changed signatures)
+- Changed return types that break consumers
+- Removed or renamed configuration fields
+- Changed error types or error message formats that consumers may depend on
+- Missing versioning for breaking changes
+- Changed default values that alter behavior
+- Interface/type changes that break implementors
+
+DO NOT review for:
+- Internal implementation details
+- Security vulnerabilities
+- Performance
+- Code style
+
+If you find no contract issues, write "No issues found."`,
+
+  general: `You are a general code quality reviewer. Focus on maintainability and correctness issues that other specialists might miss.
+
+Review for:
+- Code duplication that should be abstracted
+- Overly complex logic that could be simplified
+- Missing error messages or unclear error handling
+- Dead code or unused imports
+- Test coverage gaps for critical paths
+- Documentation gaps for public APIs
+
+DO NOT review for (other specialists handle these):
+- Security vulnerabilities
+- API backward compatibility
+- Deep logic correctness (race conditions, etc.)
+
+Be concise. Only flag issues that genuinely improve the codebase.`,
+};
+
+/**
+ * Get a built-in persona by name.
+ * @returns The persona content string, or null if not found.
+ */
+export function getBuiltinPersona(name: string): string | null {
+  return PERSONAS[name] ?? null;
+}

--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -93,6 +93,15 @@ function randomElement<T>(array: T[]): T | undefined {
  */
 export async function loadPersona(personaPath: string): Promise<string> {
   try {
+    // Built-in persona: "builtin:security", "builtin:logic", etc.
+    if (personaPath.startsWith('builtin:')) {
+      const { getBuiltinPersona } = await import('../l1/builtin-personas.js');
+      const content = getBuiltinPersona(personaPath.slice(8));
+      if (content) return content;
+      console.warn(`[Persona] Unknown built-in persona: ${personaPath.slice(8)}`);
+      return '';
+    }
+
     // Inline text: if it doesn't look like a file path, use it directly
     if (!personaPath.includes('/') && !personaPath.includes('\\') && !personaPath.endsWith('.md') && !personaPath.endsWith('.txt')) {
       return personaPath.trim();

--- a/packages/core/src/tests/builtin-personas.test.ts
+++ b/packages/core/src/tests/builtin-personas.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { getBuiltinPersona } from '../l1/builtin-personas.js';
+
+describe('getBuiltinPersona', () => {
+  it('returns non-empty string for "security"', () => {
+    const result = getBuiltinPersona('security');
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe('string');
+    expect(result!.length).toBeGreaterThan(0);
+  });
+
+  it('returns non-empty string for "logic"', () => {
+    const result = getBuiltinPersona('logic');
+    expect(result).toBeTruthy();
+    expect(result!.length).toBeGreaterThan(0);
+  });
+
+  it('returns non-empty string for "api-contract"', () => {
+    const result = getBuiltinPersona('api-contract');
+    expect(result).toBeTruthy();
+    expect(result!.length).toBeGreaterThan(0);
+  });
+
+  it('returns non-empty string for "general"', () => {
+    const result = getBuiltinPersona('general');
+    expect(result).toBeTruthy();
+    expect(result!.length).toBeGreaterThan(0);
+  });
+
+  it('returns null for unknown persona', () => {
+    const result = getBuiltinPersona('unknown');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    const result = getBuiltinPersona('');
+    expect(result).toBeNull();
+  });
+
+  it('security persona contains "OWASP"', () => {
+    const result = getBuiltinPersona('security');
+    expect(result).toContain('OWASP');
+  });
+
+  it('logic persona contains "race conditions"', () => {
+    const result = getBuiltinPersona('logic');
+    expect(result).toContain('Race conditions');
+  });
+
+  it('api-contract persona contains "backward compatibility"', () => {
+    const result = getBuiltinPersona('api-contract');
+    expect(result).toContain('backward compatibility');
+  });
+
+  it('general persona contains "maintainability"', () => {
+    const result = getBuiltinPersona('general');
+    expect(result).toContain('maintainability');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 built-in specialist reviewer personas: **security** (OWASP Top 10), **logic** (correctness bugs), **api-contract** (backward compatibility), **general** (code quality)
- Support `builtin:` prefix in persona config (e.g., `"builtin:security"`) via `loadPersona()` in L2 moderator
- Auto reviewers in L0 now cycle through built-in personas for diverse review perspectives when no explicit persona is set

## Changes
- **New**: `packages/core/prompts/personas/` — 4 persona markdown files (reference copies)
- **New**: `packages/core/src/l1/builtin-personas.ts` — embedded persona constants with `getBuiltinPersona()` lookup
- **Modified**: `packages/core/src/l2/moderator.ts` — `loadPersona()` handles `builtin:` prefix via dynamic import
- **Modified**: `packages/core/src/l0/index.ts` — auto reviewer configs default to cycling `BUILTIN_PERSONAS`
- **New**: `packages/core/src/tests/builtin-personas.test.ts` — 10 tests covering all personas and edge cases

## Test plan
- [x] `getBuiltinPersona('security')` returns non-empty string containing "OWASP"
- [x] `getBuiltinPersona('logic')` returns content with "Race conditions"
- [x] `getBuiltinPersona('api-contract')` returns content with "backward compatibility"
- [x] `getBuiltinPersona('general')` returns content with "maintainability"
- [x] `getBuiltinPersona('unknown')` returns null
- [x] All 10 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in specialist reviewer personas for security, logic, API contract, and general code quality checks.
  * Built-in personas can now be referenced using the `builtin:` prefix for automatic reviewer assignment.
  * Auto-slot reviewer assignment now includes fallback persona defaults.

* **Tests**
  * Added test coverage for built-in persona retrieval and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->