### PR TITLE
feat: add pre-debate hallucination filter (#428)

### DIFF
--- a/packages/core/src/pipeline/hallucination-filter.ts
+++ b/packages/core/src/pipeline/hallucination-filter.ts
@@ -1,0 +1,90 @@
+/**
+ * Pre-Debate Hallucination Filter (#428)
+ * Validates evidence documents against the actual diff before L2 debate.
+ * Removes findings that reference non-existent files, lines outside diff
+ * hunks, or fabricated code quotes. Zero model cost.
+ */
+
+import type { EvidenceDocument } from '../types/core.js';
+import { extractFileListFromDiff, parseDiffFileRanges } from '@codeagora/shared/utils/diff.js';
+
+export interface FilterResult {
+  filtered: EvidenceDocument[];
+  removed: EvidenceDocument[];
+}
+
+/**
+ * Filter out hallucinated evidence documents.
+ *
+ * Checks:
+ * 1. File existence: filePath must be in diff file list
+ * 2. Line range: lineRange must overlap with at least one diff hunk for that file
+ * 3. Code quote: inline code in problem text should exist in diff
+ */
+export function filterHallucinations(
+  docs: EvidenceDocument[],
+  diffContent: string,
+): FilterResult {
+  const diffFiles = new Set(extractFileListFromDiff(diffContent));
+  const diffRanges = parseDiffFileRanges(diffContent);
+
+  // Build a map of file -> hunk ranges for quick lookup
+  const hunkMap = new Map<string, Array<[number, number]>>();
+  for (const { file, ranges } of diffRanges) {
+    hunkMap.set(file, ranges);
+  }
+
+  const filtered: EvidenceDocument[] = [];
+  const removed: EvidenceDocument[] = [];
+
+  for (const doc of docs) {
+    // Skip rule-based findings (they come from static analysis, not LLM)
+    if (doc.source === 'rule') {
+      filtered.push(doc);
+      continue;
+    }
+
+    // Check 1: File exists in diff
+    if (doc.filePath !== 'unknown' && !diffFiles.has(doc.filePath)) {
+      removed.push(doc);
+      continue;
+    }
+
+    // Check 2: Line range overlaps with diff hunks
+    if (doc.filePath !== 'unknown' && doc.lineRange[0] > 0) {
+      const hunks = hunkMap.get(doc.filePath);
+      if (hunks && hunks.length > 0) {
+        const HUNK_TOLERANCE = 10; // Allow some tolerance for context lines
+        const overlaps = hunks.some(([start, end]) =>
+          doc.lineRange[0] <= end + HUNK_TOLERANCE &&
+          doc.lineRange[1] >= start - HUNK_TOLERANCE
+        );
+        if (!overlaps) {
+          removed.push(doc);
+          continue;
+        }
+      }
+    }
+
+    // Check 3: Code quote verification
+    // Extract inline code from problem text (backtick-wrapped)
+    const codeQuotes = doc.problem.match(/`([^`]{10,})`/g);
+    if (codeQuotes && codeQuotes.length > 0) {
+      let fabricatedCount = 0;
+      for (const quote of codeQuotes) {
+        const code = quote.slice(1, -1); // Remove backticks
+        if (!diffContent.includes(code)) {
+          fabricatedCount++;
+        }
+      }
+      // If majority of code quotes are fabricated, penalize confidence
+      if (fabricatedCount > codeQuotes.length / 2) {
+        doc.confidence = Math.round((doc.confidence ?? 50) * 0.5);
+      }
+    }
+
+    filtered.push(doc);
+  }
+
+  return { filtered, removed };
+}

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -740,6 +740,14 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
       allEvidenceDocs = filtered;
     }
 
+    // === HALLUCINATION FILTER: Remove findings referencing non-existent code (#428) ===
+    const { filterHallucinations } = await import('./hallucination-filter.js');
+    const hallucinationResult = filterHallucinations(allEvidenceDocs, filteredDiffContent);
+    if (hallucinationResult.removed.length > 0) {
+      console.log(`[Hallucination Filter] Removed ${hallucinationResult.removed.length} finding(s) referencing non-existent code`);
+    }
+    allEvidenceDocs = hallucinationResult.filtered;
+
     // === CONFIDENCE: Compute L1 confidence for non-rule docs ===
     const totalReviewers = allReviewerInputs.length;
     for (const doc of allEvidenceDocs) {

--- a/packages/core/src/tests/hallucination-filter.test.ts
+++ b/packages/core/src/tests/hallucination-filter.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { filterHallucinations } from '../pipeline/hallucination-filter.js';
+import type { EvidenceDocument } from '../types/core.js';
+
+// Minimal diff for testing
+const SAMPLE_DIFF = `diff --git a/src/utils.ts b/src/utils.ts
+--- a/src/utils.ts
++++ b/src/utils.ts
+@@ -10,7 +10,8 @@ export function helper() {
+   const a = 1;
+-  const b = 2;
++  const b = computeValue();
++  const c = 3;
+   return a + b;
+ }
+diff --git a/src/index.ts b/src/index.ts
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,5 +1,6 @@
+ import { helper } from './utils.js';
++import { newModule } from './new-module.js';
+
+ export function main() {
+   return helper();
+`;
+
+function makeDoc(overrides: Partial<EvidenceDocument> = {}): EvidenceDocument {
+  return {
+    issueTitle: 'Test Issue',
+    problem: 'Some problem description',
+    evidence: ['evidence line'],
+    severity: 'WARNING',
+    suggestion: 'Fix it',
+    filePath: 'src/utils.ts',
+    lineRange: [10, 12] as [number, number],
+    source: 'llm',
+    confidence: 80,
+    ...overrides,
+  };
+}
+
+describe('filterHallucinations', () => {
+  it('should remove findings referencing files not in diff', () => {
+    const docs = [makeDoc({ filePath: 'src/nonexistent.ts' })];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(0);
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0].filePath).toBe('src/nonexistent.ts');
+  });
+
+  it('should keep findings for files in diff with lines in hunk', () => {
+    const docs = [makeDoc({ filePath: 'src/utils.ts', lineRange: [11, 12] })];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.removed).toHaveLength(0);
+  });
+
+  it('should remove findings with line ranges outside all hunks', () => {
+    // Hunk is at lines 10-17, tolerance is 10, so line 500 is well outside
+    const docs = [makeDoc({ filePath: 'src/utils.ts', lineRange: [500, 510] })];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(0);
+    expect(result.removed).toHaveLength(1);
+  });
+
+  it('should penalize confidence for fabricated code quotes', () => {
+    const docs = [makeDoc({
+      problem: 'The code `thisIsAFabricatedCodeSnippetThatDoesNotExist` is wrong',
+      confidence: 80,
+    })];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].confidence).toBe(40); // 80 * 0.5
+  });
+
+  it('should not penalize confidence for real code quotes', () => {
+    const docs = [makeDoc({
+      problem: 'The code `const b = computeValue()` is problematic',
+      confidence: 80,
+    })];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].confidence).toBe(80);
+  });
+
+  it('should always keep rule-source findings', () => {
+    const docs = [makeDoc({
+      source: 'rule',
+      filePath: 'src/nonexistent.ts', // Even if file doesn't exist in diff
+      lineRange: [999, 999],
+    })];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.removed).toHaveLength(0);
+  });
+
+  it('should keep findings with unknown filePath', () => {
+    const docs = [makeDoc({ filePath: 'unknown' })];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.removed).toHaveLength(0);
+  });
+
+  it('should return empty results for empty docs', () => {
+    const result = filterHallucinations([], SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(0);
+    expect(result.removed).toHaveLength(0);
+  });
+
+  it('should correctly split mixed valid/invalid docs', () => {
+    const docs = [
+      makeDoc({ filePath: 'src/utils.ts', lineRange: [11, 12] }), // valid
+      makeDoc({ filePath: 'src/nonexistent.ts' }), // invalid: file not in diff
+      makeDoc({ filePath: 'src/index.ts', lineRange: [1, 3] }), // valid
+      makeDoc({ filePath: 'src/utils.ts', lineRange: [500, 510] }), // invalid: out of range
+      makeDoc({ source: 'rule', filePath: 'any-file.ts' }), // valid: rule source
+    ];
+    const result = filterHallucinations(docs, SAMPLE_DIFF);
+
+    expect(result.filtered).toHaveLength(3);
+    expect(result.removed).toHaveLength(2);
+    expect(result.removed.map(d => d.filePath)).toEqual([
+      'src/nonexistent.ts',
+      'src/utils.ts',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- L1 리뷰어가 생성한 evidence documents를 L2 debate 전에 실제 diff와 대조하여 hallucination을 필터링하는 모듈 추가
- diff에 존재하지 않는 파일, diff hunk 범위 밖의 라인, 날조된 코드 인용을 검출하여 제거 또는 confidence 감소
- 모델 호출 없이 순수 문자열 매칭으로 동작 (zero model cost)

## Changes
- **New**: `packages/core/src/pipeline/hallucination-filter.ts` - 3단계 검증 로직 (파일 존재, 라인 범위, 코드 인용)
- **Updated**: `packages/core/src/pipeline/orchestrator.ts` - LEARNING 단계 이후, CONFIDENCE 계산 이전에 hallucination filter 삽입
- **New**: `packages/core/src/tests/hallucination-filter.test.ts` - 9개 테스트 케이스

## Test plan
- [x] 파일이 diff에 없는 finding → 제거됨
- [x] 파일이 diff에 있고 라인이 hunk 안 → 유지됨
- [x] 파일이 diff에 있지만 라인이 hunk 밖 → 제거됨
- [x] 날조된 코드 인용 → confidence 감소
- [x] 실제 코드 인용 → 패널티 없음
- [x] rule source → 항상 유지
- [x] unknown filePath → 유지
- [x] 빈 docs → 빈 결과
- [x] mixed valid/invalid → 올바른 분리

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hallucination detection and filtering to the analysis pipeline. The system now automatically removes or reduces confidence scores for findings that may be false positives by validating them against actual code changes. This enhancement improves the accuracy and reliability of detected findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->