### PR TITLE
feat: require debate for HARSHLY_CRITICAL findings

### DIFF
--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -213,24 +213,6 @@ async function runDiscussion(
 ): Promise<DiscussionResult> {
   const rounds: DiscussionRound[] = [];
 
-  // HARSHLY_CRITICAL: Skip discussion, escalate immediately
-  if (discussion.severity === 'HARSHLY_CRITICAL') {
-    const verdict: DiscussionVerdict = {
-      discussionId: discussion.id,
-      filePath: discussion.filePath,
-      lineRange: discussion.lineRange,
-      finalSeverity: 'HARSHLY_CRITICAL',
-      reasoning: 'HARSHLY_CRITICAL issues are escalated to Head without discussion',
-      consensusReached: false, // Escalated
-      rounds: 0,
-    };
-
-    // Write verdict file
-    await writeDiscussionVerdict(date, sessionId, verdict);
-
-    return { verdict, rounds };
-  }
-
   // L-15: If no supporters are enabled and devil's advocate is off, skip discussion
   const enabledPoolL15 = supporterPoolConfig.pool.filter((s) => s.enabled);
   if (enabledPoolL15.length === 0 && !supporterPoolConfig.devilsAdvocate.enabled) {
@@ -480,7 +462,7 @@ interface ConsensusResult {
   reasoning?: string;
 }
 
-function checkConsensus(round: DiscussionRound, discussion: Discussion, isLastRound = false): ConsensusResult {
+export function checkConsensus(round: DiscussionRound, discussion: Discussion, isLastRound = false): ConsensusResult {
   const supporters = round.supporterResponses;
 
   // No consensus possible with zero participants
@@ -501,6 +483,15 @@ function checkConsensus(round: DiscussionRound, discussion: Discussion, isLastRo
   // All disagree
   const allDisagree = supporters.every((s) => s.stance === 'disagree');
   if (allDisagree) {
+    // HC downgrade: unanimous disagree downgrades to CRITICAL, not DISMISSED
+    // Real HC issues should have at least some corroboration
+    if (discussion.severity === 'HARSHLY_CRITICAL') {
+      return {
+        reached: true,
+        severity: 'CRITICAL',
+        reasoning: 'All supporters rejected HARSHLY_CRITICAL claim — downgraded to CRITICAL for human review',
+      };
+    }
     return {
       reached: true,
       severity: 'DISMISSED',
@@ -522,6 +513,14 @@ function checkConsensus(round: DiscussionRound, discussion: Discussion, isLastRo
   }
 
   if (decidingVotes > 0 && disagreeCount > decidingVotes / 2) {
+    // HC downgrade: majority disagree downgrades to CRITICAL, not DISMISSED
+    if (discussion.severity === 'HARSHLY_CRITICAL') {
+      return {
+        reached: true,
+        severity: 'CRITICAL',
+        reasoning: `Majority rejected HARSHLY_CRITICAL claim (${disagreeCount}/${supporters.length} disagree) — downgraded to CRITICAL`,
+      };
+    }
     return {
       reached: true,
       severity: 'DISMISSED',

--- a/packages/core/src/tests/l2-hc-debate.test.ts
+++ b/packages/core/src/tests/l2-hc-debate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * L2 HARSHLY_CRITICAL debate tests
+ *
+ * Validates that HC findings go through discussion (no auto-escalation)
+ * and HC-specific downgrade logic in checkConsensus.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkConsensus } from '../l2/moderator.js';
+import type { Discussion, DiscussionRound } from '../types/core.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeDiscussion(severity: string): Discussion {
+  return {
+    id: 'd001',
+    severity: severity as Discussion['severity'],
+    issueTitle: 'SQL injection in user input',
+    filePath: 'src/db.ts',
+    lineRange: [10, 20] as [number, number],
+    codeSnippet: 'const q = `SELECT * FROM users WHERE id = ${input}`;',
+    evidenceDocs: ['evidence/r1.md'],
+    status: 'in_progress',
+  };
+}
+
+function makeRound(stances: Array<'agree' | 'disagree' | 'neutral'>): DiscussionRound {
+  return {
+    round: 1,
+    moderatorPrompt: 'Evaluate this issue.',
+    supporterResponses: stances.map((stance, i) => ({
+      supporterId: `supporter-${i + 1}`,
+      response: `I ${stance} with this finding.`,
+      stance,
+    })),
+  };
+}
+
+// ============================================================================
+// HC consensus: all agree → HC preserved
+// ============================================================================
+
+describe('checkConsensus — HARSHLY_CRITICAL all agree', () => {
+  it('preserves HC severity when all supporters agree', () => {
+    const discussion = makeDiscussion('HARSHLY_CRITICAL');
+    const round = makeRound(['agree', 'agree', 'agree']);
+    const result = checkConsensus(round, discussion);
+    expect(result.reached).toBe(true);
+    expect(result.severity).toBe('HARSHLY_CRITICAL');
+  });
+});
+
+// ============================================================================
+// HC consensus: majority disagree → downgraded to CRITICAL
+// ============================================================================
+
+describe('checkConsensus — HARSHLY_CRITICAL majority disagree', () => {
+  it('downgrades HC to CRITICAL when majority disagrees (not DISMISSED)', () => {
+    const discussion = makeDiscussion('HARSHLY_CRITICAL');
+    const round = makeRound(['disagree', 'disagree', 'agree']);
+    const result = checkConsensus(round, discussion);
+    expect(result.reached).toBe(true);
+    expect(result.severity).toBe('CRITICAL');
+    expect(result.reasoning).toContain('HARSHLY_CRITICAL');
+    expect(result.reasoning).toContain('downgraded');
+  });
+
+  it('non-HC majority disagree still returns DISMISSED', () => {
+    const discussion = makeDiscussion('WARNING');
+    const round = makeRound(['disagree', 'disagree', 'agree']);
+    const result = checkConsensus(round, discussion);
+    expect(result.reached).toBe(true);
+    expect(result.severity).toBe('DISMISSED');
+  });
+});
+
+// ============================================================================
+// HC consensus: all disagree → downgraded to CRITICAL
+// ============================================================================
+
+describe('checkConsensus — HARSHLY_CRITICAL all disagree', () => {
+  it('downgrades HC to CRITICAL when all supporters disagree', () => {
+    const discussion = makeDiscussion('HARSHLY_CRITICAL');
+    const round = makeRound(['disagree', 'disagree', 'disagree']);
+    const result = checkConsensus(round, discussion);
+    expect(result.reached).toBe(true);
+    expect(result.severity).toBe('CRITICAL');
+    expect(result.reasoning).toContain('human review');
+  });
+
+  it('non-HC all disagree returns DISMISSED', () => {
+    const discussion = makeDiscussion('CRITICAL');
+    const round = makeRound(['disagree', 'disagree', 'disagree']);
+    const result = checkConsensus(round, discussion);
+    expect(result.reached).toBe(true);
+    expect(result.severity).toBe('DISMISSED');
+  });
+});
+
+// ============================================================================
+// HC consensus: majority agree → HC preserved
+// ============================================================================
+
+describe('checkConsensus — HARSHLY_CRITICAL majority agree', () => {
+  it('preserves HC severity when majority agrees', () => {
+    const discussion = makeDiscussion('HARSHLY_CRITICAL');
+    const round = makeRound(['agree', 'agree', 'disagree']);
+    const result = checkConsensus(round, discussion);
+    expect(result.reached).toBe(true);
+    expect(result.severity).toBe('HARSHLY_CRITICAL');
+  });
+});
+
+// ============================================================================
+// HC consensus: tie on last round → HC preserved (benefit of the doubt)
+// ============================================================================
+
+describe('checkConsensus — HARSHLY_CRITICAL tie', () => {
+  it('preserves HC severity on tie during last round (benefit of the doubt)', () => {
+    const discussion = makeDiscussion('HARSHLY_CRITICAL');
+    const round = makeRound(['agree', 'disagree']);
+    const result = checkConsensus(round, discussion, /* isLastRound */ true);
+    expect(result.reached).toBe(true);
+    expect(result.severity).toBe('HARSHLY_CRITICAL');
+  });
+
+  it('does not reach consensus on tie during non-last round', () => {
+    const discussion = makeDiscussion('HARSHLY_CRITICAL');
+    const round = makeRound(['agree', 'disagree']);
+    const result = checkConsensus(round, discussion, /* isLastRound */ false);
+    expect(result.reached).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Remove HC auto-escalation**: HARSHLY_CRITICAL findings no longer skip L2 discussion — they go through the normal debate flow like CRITICAL and WARNING
- **HC-specific downgrade logic**: When supporters reject an HC claim, it downgrades to CRITICAL (not DISMISSED) to ensure human review
- **Export `checkConsensus`** for direct unit testing

## HC Consensus Rules
| Scenario | Result |
|---|---|
| All AGREE | HC preserved |
| Majority AGREE | HC preserved |
| Tie (last round) | HC preserved (benefit of the doubt) |
| Majority DISAGREE | Downgrade to CRITICAL |
| All DISAGREE | Downgrade to CRITICAL for human review |

## Changes
- `packages/core/src/l2/moderator.ts` — removed HC skip block in `runDiscussion`, added HC downgrade branches in `checkConsensus`
- `packages/core/src/tests/l2-hc-debate.test.ts` — 8 new tests covering all HC consensus scenarios

## Test plan
- [x] All 8 new HC debate tests pass
- [x] All 279 existing core tests pass (1 pre-existing timeout in suggestion-verifier unrelated)
- [ ] Manual: run pipeline with HC finding to verify it enters discussion

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)