### PR TITLE
feat: adversarial supporter prompt with dual-reasoning requirement

### DIFF
--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -428,7 +428,41 @@ async function executeSupporterResponse(
   }
 
   // Build prompt with persona
-  const basePrompt = `${moderatorPrompt}\n\nProvide your verdict:\n- AGREE: Evidence is valid and the issue is real\n- DISAGREE: Evidence is flawed, missing context, or the issue is a false positive\n- NEUTRAL: Needs more information\n\n**IMPORTANT: Do NOT conform simply because other reviewers agree. If you believe the evidence is wrong, say DISAGREE and explain why — even if you are the only one. Your independent judgment is more valuable than consensus.**\n\n**Response format — first line MUST be exactly one of:**\nStance: AGREE\nStance: DISAGREE\nStance: NEUTRAL\n\nThen provide your reasoning below.\n\nExample:\nStance: DISAGREE\nThe evidence cites line 42 but the actual vulnerability is mitigated by the input sanitizer at line 38.`;
+  const basePrompt = `${moderatorPrompt}
+
+## Your Task: Verify This Claim
+
+A reviewer has made the claim described above. Your job is to **verify** it by attempting to disprove it first.
+
+### Verification Process:
+1. Read the actual code carefully
+2. Try to find evidence that the claim is WRONG
+3. Consider: Is this a standard pattern? Does the surrounding code handle this case?
+4. Only agree if you genuinely cannot disprove the claim
+
+### Response Format
+
+**First line MUST be exactly one of:**
+Stance: AGREE
+Stance: DISAGREE
+Stance: NEUTRAL
+
+**Then provide your reasoning. BOTH agree and disagree require specific evidence:**
+
+If DISAGREE:
+- What specific evidence disproves the claim?
+- Is this a known pattern that the reviewer misidentified?
+- Does the surrounding context already handle the concern?
+
+If AGREE:
+- Why is the claim impossible to disprove?
+- What specific code proves the issue exists?
+- Why isn't this handled by surrounding context?
+
+If NEUTRAL:
+- What specific information is missing to make a judgment?
+
+**Do NOT agree just because a reviewer said it. Do NOT disagree just to be contrarian. Base your judgment on the actual code and evidence provided.**`;
 
   const prompt = personaContent
     ? `${personaContent}\n\n---\n\n${basePrompt}`

--- a/packages/core/src/tests/l2-adversarial-prompt.test.ts
+++ b/packages/core/src/tests/l2-adversarial-prompt.test.ts
@@ -1,0 +1,74 @@
+/**
+ * L2 Adversarial Supporter Prompt tests
+ *
+ * Validates that the supporter prompt in executeSupporterResponse
+ * uses adversarial verification language instead of agreement-seeking.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const moderatorSource = readFileSync(
+  resolve(__dirname, '../l2/moderator.ts'),
+  'utf-8',
+);
+
+describe('Adversarial Supporter Prompt', () => {
+  it('uses "verify" instead of "evaluate" in the supporter prompt', () => {
+    // The prompt should frame the task as verification, not evaluation
+    expect(moderatorSource).toContain('Verify This Claim');
+    expect(moderatorSource).toContain('verify');
+  });
+
+  it('instructs supporters to attempt disproval first', () => {
+    expect(moderatorSource).toContain('disprove');
+    expect(moderatorSource).toContain(
+      'Try to find evidence that the claim is WRONG',
+    );
+  });
+
+  it('requires specific evidence for BOTH agree and disagree', () => {
+    expect(moderatorSource).toContain(
+      'BOTH agree and disagree require specific evidence',
+    );
+  });
+
+  it('includes AGREE reasoning requirements', () => {
+    expect(moderatorSource).toContain(
+      'Why is the claim impossible to disprove?',
+    );
+    expect(moderatorSource).toContain(
+      'What specific code proves the issue exists?',
+    );
+  });
+
+  it('includes DISAGREE reasoning requirements', () => {
+    expect(moderatorSource).toContain(
+      'What specific evidence disproves the claim?',
+    );
+    expect(moderatorSource).toContain(
+      'Does the surrounding context already handle the concern?',
+    );
+  });
+
+  it('does not contain the old agreement-seeking language', () => {
+    // The old prompt said "Do NOT conform simply because..."
+    // which still implied the default was to conform
+    expect(moderatorSource).not.toContain(
+      'Do NOT conform simply because other reviewers agree',
+    );
+    expect(moderatorSource).not.toContain('Provide your verdict');
+  });
+
+  it('warns against both conformity and contrarianism', () => {
+    expect(moderatorSource).toContain(
+      'Do NOT agree just because a reviewer said it',
+    );
+    expect(moderatorSource).toContain(
+      'Do NOT disagree just to be contrarian',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replace agreement-seeking supporter prompt in `executeSupporterResponse` with adversarial verification prompt that instructs supporters to attempt disproval before agreeing
- Require specific evidence for **both** AGREE and DISAGREE stances, eliminating lazy conformity bias
- Add 7 tests validating the new prompt contains key adversarial phrases (`verify`, `disprove`, `BOTH agree and disagree require`)

## Context
Closes #430

Based on Free-MAD (2025) research: anti-conformity mechanism is essential for effective multi-agent debate. The old prompt said "Do NOT conform" but still framed agreement as the default. The new prompt reverses the framing — supporters must try to disprove first and only agree if they genuinely cannot.

## Changed Files
- `packages/core/src/l2/moderator.ts` — replaced `basePrompt` in `executeSupporterResponse`
- `packages/core/src/tests/l2-adversarial-prompt.test.ts` — new test file (7 tests)

## Test plan
- [x] `pnpm --filter @codeagora/core test` — all 296 tests pass (24 test files)
- [ ] Manual: run L2 discussion and verify supporter responses include specific evidence for their stance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite verifying moderation prompt structure, claim verification phrasing, and evidence-based reasoning requirements across all verdict types.

* **Improvements**
  * Updated moderator review instructions with structured claim verification methodology and enhanced evidence requirements, removing legacy consensus-focused language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->