### PR TITLE
feat: corroboration scoring with diff-size correction (#432)

### DIFF
--- a/packages/core/src/pipeline/confidence.ts
+++ b/packages/core/src/pipeline/confidence.ts
@@ -15,7 +15,8 @@ export interface DiscussionVerdictLike {
 export function computeL1Confidence(
   doc: EvidenceDocument,
   allDocs: EvidenceDocument[],
-  totalReviewers: number
+  totalReviewers: number,
+  totalDiffLines?: number,
 ): number {
   if (totalReviewers <= 0) return 50;
   const agreeing = allDocs.filter(d =>
@@ -24,10 +25,26 @@ export function computeL1Confidence(
   ).length;
   const agreementRate = Math.round((agreeing / totalReviewers) * 100);
 
+  let base: number;
   if (doc.confidence !== undefined && doc.confidence >= 0 && doc.confidence <= 100) {
-    return Math.round(doc.confidence * 0.6 + agreementRate * 0.4);
+    base = Math.round(doc.confidence * 0.6 + agreementRate * 0.4);
+  } else {
+    base = agreementRate;
   }
-  return agreementRate;
+
+  // Corroboration scoring (#432)
+  // Single-reviewer findings are more likely hallucinations
+  if (agreeing === 1 && totalReviewers >= 3) {
+    // Diff-size correction: large diffs may have legitimate single-reviewer finds
+    const isLargeDiff = (totalDiffLines ?? 0) > 500;
+    const penalty = isLargeDiff ? 0.7 : 0.5;
+    base = Math.round(base * penalty);
+  } else if (agreeing >= 3) {
+    // Strong corroboration boost (capped at 100)
+    base = Math.min(100, Math.round(base * 1.2));
+  }
+
+  return Math.max(0, Math.min(100, base));
 }
 
 /**

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -752,9 +752,10 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
 
     // === CONFIDENCE: Compute L1 confidence for non-rule docs ===
     const totalReviewers = allReviewerInputs.length;
+    const totalDiffLines = filteredDiffContent.split('\n').length;
     for (const doc of allEvidenceDocs) {
       if (doc.source !== 'rule') {
-        doc.confidence = computeL1Confidence(doc, allEvidenceDocs, totalReviewers);
+        doc.confidence = computeL1Confidence(doc, allEvidenceDocs, totalReviewers, totalDiffLines);
       }
     }
 

--- a/packages/core/src/tests/parser-bilingual.test.ts
+++ b/packages/core/src/tests/parser-bilingual.test.ts
@@ -205,3 +205,114 @@ describe('computeL1Confidence — reviewer confidence blending (#238)', () => {
     expect(computeL1Confidence(doc, [], 0)).toBe(50);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Corroboration scoring in computeL1Confidence (#432)
+// ---------------------------------------------------------------------------
+
+describe('computeL1Confidence — corroboration scoring (#432)', () => {
+  function makeDoc(filePath: string, lineStart: number, confidence?: number): EvidenceDocument {
+    return {
+      issueTitle: 'Test',
+      problem: 'Test problem',
+      evidence: [],
+      severity: 'WARNING',
+      suggestion: 'Fix it',
+      filePath,
+      lineRange: [lineStart, lineStart + 10],
+      ...(confidence !== undefined && { confidence }),
+    };
+  }
+
+  it('single reviewer (1/5), small diff → confidence × 0.5', () => {
+    // Only 1 doc agrees (itself), totalReviewers >= 3, small diff
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    const allDocs = [
+      makeDoc('src/foo.ts', 10),   // agreeing (same file+line)
+      makeDoc('src/bar.ts', 100),
+      makeDoc('src/baz.ts', 200),
+      makeDoc('src/qux.ts', 300),
+      makeDoc('src/quux.ts', 400),
+    ];
+    // agreeing = 1, totalReviewers = 5, agreementRate = 20
+    // base = Math.round(80 * 0.6 + 20 * 0.4) = Math.round(48 + 8) = 56
+    // penalty (small diff): 56 * 0.5 = 28
+    const result = computeL1Confidence(doc, allDocs, 5, 100);
+    expect(result).toBe(28);
+  });
+
+  it('single reviewer (1/5), large diff (>500 lines) → confidence × 0.7', () => {
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    const allDocs = [
+      makeDoc('src/foo.ts', 10),
+      makeDoc('src/bar.ts', 100),
+      makeDoc('src/baz.ts', 200),
+      makeDoc('src/qux.ts', 300),
+      makeDoc('src/quux.ts', 400),
+    ];
+    // agreeing = 1, totalReviewers = 5, agreementRate = 20
+    // base = 56, penalty (large diff): Math.round(56 * 0.7) = 39
+    const result = computeL1Confidence(doc, allDocs, 5, 600);
+    expect(result).toBe(39);
+  });
+
+  it('triple corroboration (3/5) → confidence × 1.2', () => {
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    const allDocs = [
+      makeDoc('src/foo.ts', 10),
+      makeDoc('src/foo.ts', 12),
+      makeDoc('src/foo.ts', 14),
+      makeDoc('src/bar.ts', 100),
+      makeDoc('src/baz.ts', 200),
+    ];
+    // agreeing = 3, totalReviewers = 5, agreementRate = 60
+    // base = Math.round(80 * 0.6 + 60 * 0.4) = Math.round(48 + 24) = 72
+    // boost: Math.round(72 * 1.2) = 86
+    const result = computeL1Confidence(doc, allDocs, 5);
+    expect(result).toBe(86);
+  });
+
+  it('all reviewers agree (5/5) → confidence × 1.2 (capped at 100)', () => {
+    const doc = makeDoc('src/foo.ts', 10, 100);
+    const allDocs = [
+      makeDoc('src/foo.ts', 10),
+      makeDoc('src/foo.ts', 11),
+      makeDoc('src/foo.ts', 12),
+      makeDoc('src/foo.ts', 13),
+      makeDoc('src/foo.ts', 14),
+    ];
+    // agreeing = 5, totalReviewers = 5, agreementRate = 100
+    // base = Math.round(100 * 0.6 + 100 * 0.4) = 100
+    // boost: Math.min(100, Math.round(100 * 1.2)) = 100 (capped)
+    const result = computeL1Confidence(doc, allDocs, 5);
+    expect(result).toBe(100);
+  });
+
+  it('2 reviewers agree → no penalty/boost (middle ground)', () => {
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    const allDocs = [
+      makeDoc('src/foo.ts', 10),
+      makeDoc('src/foo.ts', 12),
+      makeDoc('src/bar.ts', 100),
+      makeDoc('src/baz.ts', 200),
+      makeDoc('src/qux.ts', 300),
+    ];
+    // agreeing = 2, totalReviewers = 5, agreementRate = 40
+    // base = Math.round(80 * 0.6 + 40 * 0.4) = Math.round(48 + 16) = 64
+    // No penalty (agreeing != 1), no boost (agreeing < 3) → 64
+    const result = computeL1Confidence(doc, allDocs, 5);
+    expect(result).toBe(64);
+  });
+
+  it('totalReviewers < 3 → no penalty even for single reviewer', () => {
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    const allDocs = [
+      makeDoc('src/foo.ts', 10),
+      makeDoc('src/bar.ts', 100),
+    ];
+    // agreeing = 1, but totalReviewers = 2 (< 3), so no penalty
+    // agreementRate = 50, base = Math.round(80 * 0.6 + 50 * 0.4) = 68
+    const result = computeL1Confidence(doc, allDocs, 2, 100);
+    expect(result).toBe(68);
+  });
+});


### PR DESCRIPTION
## Summary
- **Single-reviewer penalty**: Findings reported by only 1 out of N reviewers (N>=3) get confidence reduced by 0.5x (small diffs) or 0.7x (large diffs >500 lines), targeting likely hallucinations
- **Triple+ corroboration boost**: Findings confirmed by 3+ reviewers get a 1.2x confidence boost (capped at 100)
- **Diff-size correction**: Large diffs are treated more leniently for single-reviewer findings since they may contain legitimate unique issues

## Changes
- `packages/core/src/pipeline/confidence.ts` — Extended `computeL1Confidence` with corroboration penalty/boost logic and optional `totalDiffLines` parameter
- `packages/core/src/pipeline/orchestrator.ts` — Pass `totalDiffLines` (from filtered diff content) to `computeL1Confidence`
- `packages/core/src/tests/parser-bilingual.test.ts` — Added 6 new test cases covering all corroboration scoring scenarios

## Test plan
- [x] Single reviewer (1/5), small diff: confidence x 0.5
- [x] Single reviewer (1/5), large diff (>500 lines): confidence x 0.7
- [x] Triple corroboration (3/5): confidence x 1.2
- [x] All reviewers agree (5/5): confidence x 1.2 (capped at 100)
- [x] 2 reviewers agree: no penalty/boost (middle ground)
- [x] totalReviewers < 3: no penalty (not enough data)
- [x] All 26 tests pass (20 existing + 6 new)

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced confidence scoring to account for reviewer agreement and corroboration levels.
  * Penalties applied for single-reviewer scenarios; boosts applied when consensus is strong (3+ reviewers).

* **Tests**
  * Added comprehensive test coverage for the updated confidence-scoring logic with various reviewer agreement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->