### PR TITLE
feat(shared): truncateLines utility + debug preview for unparseable responses

### DIFF
--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -9,15 +9,18 @@ import type { ReviewOutput } from '../types/core.js';
 import { parseEvidenceResponse, isExplicitNoIssues } from './parser.js';
 import { executeBackend } from './backend.js';
 import { extractFileListFromDiff } from '@codeagora/shared/utils/diff.js';
+import { truncateLines } from '@codeagora/shared/utils/truncate.js';
 import { CircuitBreaker, CircuitOpenError } from './circuit-breaker.js';
 import { HealthMonitor } from '../l0/health-monitor.js';
 import { classifyError } from './error-classifier.js';
 
 /** Log when parser returns 0 issues on a non-empty response — likely unparseable output */
-function logParseFailure(model: string, reviewerId: string, responseLength: number, isFallback: boolean): void {
+function logParseFailure(model: string, reviewerId: string, response: string, isFallback: boolean): void {
   const prefix = isFallback ? 'fallback ' : '';
+  const preview = truncateLines(response, 5);
   process.stderr.write(
-    `[Parser] ${prefix}model=${model} reviewer=${reviewerId}: 0 issues from ${responseLength} chars — possible unparseable response\n`
+    `[Parser] ${prefix}model=${model} reviewer=${reviewerId}: 0 issues from ${response.length} chars — possible unparseable response\n` +
+    `[Parser] preview:\n${preview}\n`
   );
 }
 
@@ -225,7 +228,7 @@ async function executeReviewerWithGuards(
       if (useGuards) cb.recordSuccess(provider!, config.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
       if (evidenceDocs.length === 0 && response.length > 0 && !isExplicitNoIssues(response)) {
-        logParseFailure(config.model, config.id, response.length, false);
+        logParseFailure(config.model, config.id, response, false);
       }
 
       return {
@@ -313,7 +316,7 @@ async function executeReviewerWithGuards(
       if (useFallbackGuards) cb.recordSuccess(fallbackProvider!, fb.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
       if (evidenceDocs.length === 0 && response.length > 0 && !isExplicitNoIssues(response)) {
-        logParseFailure(fb.model, config.id, response.length, true);
+        logParseFailure(fb.model, config.id, response, true);
       }
 
       return {

--- a/packages/shared/src/tests/utils-truncate.test.ts
+++ b/packages/shared/src/tests/utils-truncate.test.ts
@@ -15,14 +15,24 @@ describe('truncateLines', () => {
     expect(truncateLines('hello', -1)).toBe('');
   });
 
-  it('appends "more lines" indicator when truncated', () => {
+  it('keeps exactly `maxLines` lines when truncated', () => {
+    // 7 input lines, maxLines=3 → keep 3, indicator shows 4 omitted
     const result = truncateLines('a\nb\nc\nd\ne\nf\ng', 3);
-    expect(result).toContain('more lines');
+    const keptLines = result.split('\n').slice(0, 3);
+    expect(keptLines).toEqual(['a', 'b', 'c']);
+    expect(result).toContain('... (4 more lines)');
   });
 
   it('preserves content from the start of the input', () => {
     const result = truncateLines('first\nsecond\nthird\nfourth\nfifth', 2);
-    expect(result.startsWith('first')).toBe(true);
+    expect(result.startsWith('first\nsecond\n')).toBe(true);
+  });
+
+  it('keeps exactly 1 line when maxLines=1', () => {
+    // Edge case flagged by review on the off-by-one version
+    const result = truncateLines('a\nb\nc\nd', 1);
+    expect(result.split('\n')[0]).toBe('a');
+    expect(result).toContain('... (3 more lines)');
   });
 
   it('handles single-line input within the limit', () => {

--- a/packages/shared/src/tests/utils-truncate.test.ts
+++ b/packages/shared/src/tests/utils-truncate.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { truncateLines } from '../utils/truncate.js';
+
+describe('truncateLines', () => {
+  it('returns original text when within limit', () => {
+    expect(truncateLines('a\nb\nc', 5)).toBe('a\nb\nc');
+  });
+
+  it('returns original when line count exactly matches maxLines', () => {
+    expect(truncateLines('a\nb\nc', 3)).toBe('a\nb\nc');
+  });
+
+  it('returns empty string for non-positive maxLines', () => {
+    expect(truncateLines('hello', 0)).toBe('');
+    expect(truncateLines('hello', -1)).toBe('');
+  });
+
+  it('appends "more lines" indicator when truncated', () => {
+    const result = truncateLines('a\nb\nc\nd\ne\nf\ng', 3);
+    expect(result).toContain('more lines');
+  });
+
+  it('preserves content from the start of the input', () => {
+    const result = truncateLines('first\nsecond\nthird\nfourth\nfifth', 2);
+    expect(result.startsWith('first')).toBe(true);
+  });
+
+  it('handles single-line input within the limit', () => {
+    expect(truncateLines('only one line', 10)).toBe('only one line');
+  });
+});

--- a/packages/shared/src/utils/truncate.ts
+++ b/packages/shared/src/utils/truncate.ts
@@ -1,0 +1,25 @@
+/**
+ * Text truncation helpers for previews in logs, notifications, and
+ * GitHub review bodies where full content is too large.
+ */
+
+/**
+ * Truncate a multi-line text to at most `maxLines` lines.
+ * Appends an indicator showing how many lines were omitted.
+ *
+ * @param text Input text (lines separated by \n)
+ * @param maxLines Maximum lines to keep. Non-positive values return ''.
+ * @returns Truncated text, or the original if already within the limit.
+ *
+ * @example
+ *   truncateLines('a\nb\nc\nd\ne', 3)
+ *   // => 'a\nb\n... (3 more lines)'
+ */
+export function truncateLines(text: string, maxLines: number): string {
+  if (maxLines <= 0) return '';
+  const lines = text.split('\n');
+  if (lines.length <= maxLines) return text;
+  const kept = lines.slice(0, maxLines - 1);
+  const omitted = lines.length - kept.length;
+  return `${kept.join('\n')}\n... (${omitted} more lines)`;
+}

--- a/packages/shared/src/utils/truncate.ts
+++ b/packages/shared/src/utils/truncate.ts
@@ -19,7 +19,7 @@ export function truncateLines(text: string, maxLines: number): string {
   if (maxLines <= 0) return '';
   const lines = text.split('\n');
   if (lines.length <= maxLines) return text;
-  const kept = lines.slice(0, maxLines - 1);
+  const kept = lines.slice(0, maxLines);
   const omitted = lines.length - kept.length;
   return `${kept.join('\n')}\n... (${omitted} more lines)`;
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts", "./src/**/*.json"]
 }


### PR DESCRIPTION
## Summary
- \`packages/shared/src/utils/truncate.ts\` 신규 — 멀티라인 텍스트를 잘라서 "... (N more lines)" 표시자 붙이는 유틸
- \`reviewer.ts\` \`logParseFailure\`가 응답 첫 5줄 preview 로그로 찍게 업데이트 (디버그 개선)
- \`packages/shared/tsconfig.json\` 에 \`*.json\` include 추가 — i18n locale JSON import 시 TS6307 뜨던 pre-existing 이슈 수정

## Motivation
최근 smoke PR들에서 4/5 reviewer가 "unparseable"로 분류된 상태를 여러 번 목격. 로그가 응답 길이만 보여주고 내용은 안 보여줘서 원인 파악이 번거로움 (sessions/ 들어가야 함). 첫 5줄이라도 stderr에 같이 찍히면 디버깅 2배 빠름.

## Test plan
- [x] \`truncateLines\` 유닛 테스트 6개 (boundary, empty, 한도 내, 한도 초과 등)
- [x] 전체 suite 3196 → 3202 passed
- [x] Typecheck clean
- [ ] self-review에서 새 utility가 문제 없이 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)