### PR TITLE
fix(confidence): use active-participants denominator in corroboration (#462)

### DIFF
--- a/packages/core/src/pipeline/confidence.ts
+++ b/packages/core/src/pipeline/confidence.ts
@@ -9,21 +9,31 @@ export interface DiscussionVerdictLike {
 }
 
 /**
- * L1 confidence: (agreeing reviewers / total reviewers) * 100
- * "Agreeing" = docs at same filePath + similar lineRange (within ±5 lines)
+ * L1 confidence: (agreeing reviewers / active reviewers) * 100
+ *
+ * "Agreeing" = docs at same filePath + similar lineRange (within ±5 lines).
+ * "Active" = reviewers whose output was usable: either produced evidence doc(s)
+ * or explicitly said "no issues". Reviewers that returned unparseable output
+ * or forfeited (timeout / 5xx / auth error) are NOT counted toward the
+ * denominator — they didn't effectively cast a vote.
+ *
+ * This corrects a false-positive-amplifier present in #432: when 4 of 5
+ * reviewers failed to produce parseable output, the single surviving finding
+ * was penalized as 1/5 "disagreement" even though 4 reviewers had simply
+ * been silent. See #462 for context.
  */
 export function computeL1Confidence(
   doc: EvidenceDocument,
   allDocs: EvidenceDocument[],
-  totalReviewers: number,
+  activeReviewers: number,
   totalDiffLines?: number,
 ): number {
-  if (totalReviewers <= 0) return 50;
+  if (activeReviewers <= 0) return 50;
   const agreeing = allDocs.filter(d =>
     d.filePath === doc.filePath &&
     Math.abs(d.lineRange[0] - doc.lineRange[0]) <= 5
   ).length;
-  const agreementRate = Math.round((agreeing / totalReviewers) * 100);
+  const agreementRate = Math.round((agreeing / activeReviewers) * 100);
 
   let base: number;
   if (doc.confidence !== undefined && doc.confidence >= 0 && doc.confidence <= 100) {
@@ -32,21 +42,33 @@ export function computeL1Confidence(
     base = agreementRate;
   }
 
-  // Corroboration scoring (#432)
-  // Single-reviewer findings are more likely hallucinations
-  if (agreeing === 1 && totalReviewers >= 3) {
-    // Diff-size correction: large diffs may have legitimate single-reviewer finds
+  // Corroboration scoring (#432, revised in #462)
+  // Two distinct low-corroboration regimes require different treatment:
+  //
+  //   Dissent:  3+ reviewers active but only 1 agreed → strong FP signal,
+  //             the others actively disagreed. Apply the original ×0.5
+  //             penalty (or ×0.7 on large diffs to tolerate legitimate
+  //             single-find discoveries in a wide-surface PR).
+  //
+  //   Sparse:   Only 1 reviewer active total (others were unparseable /
+  //             forfeited). This is low sample size, not dissent. Mild
+  //             ×0.8 penalty reflects uncertainty without punishing the
+  //             finding for information we simply don't have.
+  //
+  // Lonely-high-severity extra penalty only applies to the dissent regime
+  // — in sparse cases we cannot infer that other reviewers disagreed with
+  // a CRITICAL claim; we just don't know what they would have said.
+  if (agreeing === 1 && activeReviewers >= 3) {
     const isLargeDiff = (totalDiffLines ?? 0) > 500;
     let penalty = isLargeDiff ? 0.7 : 0.5;
-    // Lonely-high-severity correction: a single reviewer declaring
-    // CRITICAL/HARSHLY_CRITICAL with no independent corroboration is a
-    // common false-positive mode — they may be pattern-matching on
-    // security keywords without verifying the actual impact. Apply an
-    // additional dampener so such claims land in verify/suggestion rather
-    // than must-fix before L2 discussion has a chance to downgrade them.
     const isHighSeverity = doc.severity === 'CRITICAL' || doc.severity === 'HARSHLY_CRITICAL';
     if (isHighSeverity) penalty *= 0.75;
     base = Math.round(base * penalty);
+  } else if (agreeing === 1 && activeReviewers === 1) {
+    // Sparse regime: only one active reviewer, so we have no corroboration
+    // signal at all (neither agreement nor disagreement). Apply a mild
+    // penalty to reflect sample-size uncertainty.
+    base = Math.round(base * 0.8);
   } else if (agreeing >= 3) {
     // Strong corroboration boost (capped at 100)
     base = Math.min(100, Math.round(base * 1.2));

--- a/packages/core/src/pipeline/confidence.ts
+++ b/packages/core/src/pipeline/confidence.ts
@@ -29,11 +29,18 @@ export function computeL1Confidence(
   totalDiffLines?: number,
 ): number {
   if (activeReviewers <= 0) return 50;
+  // Count LLM-source docs that flagged approximately the same location.
+  // - Exclude `source === 'rule'`: static-analysis findings come from linters,
+  //   not from the reviewer pool, so they should not inflate reviewer agreement.
+  // - Clamp the rate at 100: a single reviewer can emit multiple docs at the
+  //   same location (e.g. duplicate findings in one chunk), which would
+  //   otherwise push agreeing > activeReviewers and yield a nonsensical rate.
   const agreeing = allDocs.filter(d =>
+    d.source !== 'rule' &&
     d.filePath === doc.filePath &&
     Math.abs(d.lineRange[0] - doc.lineRange[0]) <= 5
   ).length;
-  const agreementRate = Math.round((agreeing / activeReviewers) * 100);
+  const agreementRate = Math.min(100, Math.round((agreeing / activeReviewers) * 100));
 
   let base: number;
   if (doc.confidence !== undefined && doc.confidence >= 0 && doc.confidence <= 100) {

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -19,6 +19,7 @@ import type { ProgressEmitter } from './progress.js';
 import { chunkDiff } from './chunker.js';
 import { analyzeTrivialDiff } from './auto-approve.js';
 import { computeL1Confidence } from './confidence.js';
+import { isExplicitNoIssues } from '../l1/parser.js';
 import { loadLearnedPatterns } from '../learning/store.js';
 import { applyLearnedPatterns } from '../learning/filter.js';
 import { loadReviewRules } from '../rules/loader.js';
@@ -364,11 +365,17 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
     allEvidenceDocs = [...hallucinationResult.filtered, ...hallucinationResult.uncertain];
 
     // === CONFIDENCE: Compute L1 confidence for non-rule docs ===
-    const totalReviewers = allReviewerInputs.length;
+    // Active reviewers = those who produced usable output (issue docs OR explicit
+    // "no issues"). Unparseable / forfeited reviewers are excluded from the
+    // denominator — they didn't effectively cast a vote (see #462).
+    const activeReviewers = allReviewResults.filter(r =>
+      r.status === 'success' &&
+      (r.evidenceDocs.length > 0 || isExplicitNoIssues(r.rawResponse))
+    ).length;
     const totalDiffLines = filteredDiffContent.split('\n').length;
     for (const doc of allEvidenceDocs) {
       if (doc.source !== 'rule') {
-        const corroborated = computeL1Confidence(doc, allEvidenceDocs, totalReviewers, totalDiffLines);
+        const corroborated = computeL1Confidence(doc, allEvidenceDocs, activeReviewers, totalDiffLines);
         doc.confidence = corroborated; // BC: legacy single-field confidence
         // ConfidenceTrace: record post-corroboration confidence (stage 3 of 5).
         doc.confidenceTrace = {

--- a/packages/core/src/tests/parser-bilingual.test.ts
+++ b/packages/core/src/tests/parser-bilingual.test.ts
@@ -184,23 +184,27 @@ describe('computeL1Confidence — reviewer confidence blending (#238)', () => {
     expect(result).toBe(50);
   });
 
-  it('blends reviewer 100% + agreement 100% → 100', () => {
+  it('blends reviewer 100% + agreement 100%, single-active sparse → 80 (×0.8)', () => {
+    // Sparse regime (#462): only 1 active reviewer, no corroboration data.
+    // Previously this returned 100 because the old logic skipped the penalty
+    // when totalReviewers<3; that was an oversight — single-reviewer 100%
+    // confidence is a sample-size-1 claim, not a verified one.
     const doc = makeDoc('src/foo.ts', 10, 100);
     const allDocs = [makeDoc('src/foo.ts', 10)];
     const result = computeL1Confidence(doc, allDocs, 1);
-    // Math.round(100 * 0.6 + 100 * 0.4) = 100
-    expect(result).toBe(100);
+    // Math.round(100 * 0.6 + 100 * 0.4) = 100, then sparse ×0.8 = 80
+    expect(result).toBe(80);
   });
 
-  it('blends reviewer 0% + agreement 100% → 40', () => {
+  it('blends reviewer 0% + agreement 100%, single-active sparse → 32 (×0.8)', () => {
     const doc = makeDoc('src/foo.ts', 10, 0);
     const allDocs = [makeDoc('src/foo.ts', 10)];
     const result = computeL1Confidence(doc, allDocs, 1);
-    // Math.round(0 * 0.6 + 100 * 0.4) = 40
-    expect(result).toBe(40);
+    // Math.round(0 * 0.6 + 100 * 0.4) = 40, then sparse ×0.8 = 32
+    expect(result).toBe(32);
   });
 
-  it('returns 50 for zero totalReviewers regardless of reviewer confidence', () => {
+  it('returns 50 for zero activeReviewers regardless of reviewer confidence', () => {
     const doc = makeDoc('src/foo.ts', 10, 80);
     expect(computeL1Confidence(doc, [], 0)).toBe(50);
   });
@@ -224,8 +228,9 @@ describe('computeL1Confidence — corroboration scoring (#432)', () => {
     };
   }
 
-  it('single reviewer (1/5), small diff → confidence × 0.5', () => {
-    // Only 1 doc agrees (itself), totalReviewers >= 3, small diff
+  it('dissent (1 agree / 5 active), small diff → confidence × 0.5', () => {
+    // Dissent regime (#462): 5 reviewers active, only 1 agreed. The other 4
+    // effectively disagreed (they reviewed the same diff and didn't flag it).
     const doc = makeDoc('src/foo.ts', 10, 80);
     const allDocs = [
       makeDoc('src/foo.ts', 10),   // agreeing (same file+line)
@@ -234,14 +239,14 @@ describe('computeL1Confidence — corroboration scoring (#432)', () => {
       makeDoc('src/qux.ts', 300),
       makeDoc('src/quux.ts', 400),
     ];
-    // agreeing = 1, totalReviewers = 5, agreementRate = 20
+    // agreeing = 1, activeReviewers = 5, agreementRate = 20
     // base = Math.round(80 * 0.6 + 20 * 0.4) = Math.round(48 + 8) = 56
-    // penalty (small diff): 56 * 0.5 = 28
+    // dissent penalty (small diff): 56 * 0.5 = 28
     const result = computeL1Confidence(doc, allDocs, 5, 100);
     expect(result).toBe(28);
   });
 
-  it('single reviewer (1/5), large diff (>500 lines) → confidence × 0.7', () => {
+  it('dissent (1 agree / 5 active), large diff (>500 lines) → confidence × 0.7', () => {
     const doc = makeDoc('src/foo.ts', 10, 80);
     const allDocs = [
       makeDoc('src/foo.ts', 10),
@@ -304,13 +309,14 @@ describe('computeL1Confidence — corroboration scoring (#432)', () => {
     expect(result).toBe(64);
   });
 
-  it('totalReviewers < 3 → no penalty even for single reviewer', () => {
+  it('2 active reviewers (1 agree) → no penalty (between sparse and dissent)', () => {
     const doc = makeDoc('src/foo.ts', 10, 80);
     const allDocs = [
       makeDoc('src/foo.ts', 10),
       makeDoc('src/bar.ts', 100),
     ];
-    // agreeing = 1, but totalReviewers = 2 (< 3), so no penalty
+    // agreeing = 1, activeReviewers = 2 — neither sparse (requires active===1)
+    // nor dissent (requires active>=3). Middle ground: no penalty applied.
     // agreementRate = 50, base = Math.round(80 * 0.6 + 50 * 0.4) = 68
     const result = computeL1Confidence(doc, allDocs, 2, 100);
     expect(result).toBe(68);
@@ -416,5 +422,44 @@ describe('computeL1Confidence — corroboration scoring (#432)', () => {
     // base = 72, boost = 86 (from earlier test)
     const result = computeL1Confidence(doc, allDocs, 5);
     expect(result).toBe(86);
+  });
+
+  // -------------------------------------------------------------------------
+  // Active-participants denominator — sparse regime (#462)
+  // Observed scenario: 5 reviewers configured, 4 returned unparseable, only
+  // 1 produced a finding. Orchestrator now passes activeReviewers=1, not 5.
+  // -------------------------------------------------------------------------
+
+  it('sparse: 1 active reviewer (4 others unparseable) → ×0.8 mild penalty', () => {
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    const allDocs = [makeDoc('src/foo.ts', 10)];
+    // agreeing=1, activeReviewers=1 → sparse branch (not dissent)
+    // agreementRate = 100, base = Math.round(80 * 0.6 + 100 * 0.4) = 88
+    // sparse penalty ×0.8 → Math.round(70.4) = 70
+    const result = computeL1Confidence(doc, allDocs, 1, 100);
+    expect(result).toBe(70);
+  });
+
+  it('sparse: CRITICAL severity does NOT get lonely-HS extra (no dissent signal)', () => {
+    const doc = makeCriticalDoc('src/foo.ts', 10, 80, 'CRITICAL');
+    const allDocs = [makeCriticalDoc('src/foo.ts', 10, undefined, 'CRITICAL')];
+    // activeReviewers=1 → sparse branch, no extra lonely-HS multiplier
+    // base = 88, ×0.8 = 70 (same as WARNING above — high severity doesn't
+    // matter when we have zero dissent evidence)
+    const result = computeL1Confidence(doc, allDocs, 1, 100);
+    expect(result).toBe(70);
+  });
+
+  it('sparse regime preserves finding above uncertainty threshold for real bug scenario', () => {
+    // Matches the #462 motivation: real bug, raw 60%, only 1 active reviewer.
+    // Previously (pre-#462) this would have been 60%×0.5 = 30 (wrongly treated
+    // as dissent). Now it's base × 0.8 → stays well above the 20% uncertain
+    // threshold, so genuine single-reviewer finds don't get buried.
+    const doc = makeDoc('src/foo.ts', 10, 60);
+    const allDocs = [makeDoc('src/foo.ts', 10)];
+    // base = Math.round(60 * 0.6 + 100 * 0.4) = 76, ×0.8 = Math.round(60.8) = 61
+    const result = computeL1Confidence(doc, allDocs, 1, 100);
+    expect(result).toBe(61);
+    expect(result).toBeGreaterThan(20); // above uncertain threshold
   });
 });

--- a/packages/core/src/tests/parser-bilingual.test.ts
+++ b/packages/core/src/tests/parser-bilingual.test.ts
@@ -462,4 +462,56 @@ describe('computeL1Confidence — corroboration scoring (#432)', () => {
     expect(result).toBe(61);
     expect(result).toBeGreaterThan(20); // above uncertain threshold
   });
+
+  // -------------------------------------------------------------------------
+  // Agreement-rate clamp + rule-source exclusion (#484 self-review feedback)
+  // -------------------------------------------------------------------------
+
+  it('clamps agreementRate at 100 when one reviewer emits multiple docs at same location', () => {
+    // Pathological but possible: a single chunk/reviewer produces 3 findings
+    // at auth.ts:10. Without the clamp, agreeing=3 / active=1 → rate=300% →
+    // base blend = round(80*0.6 + 300*0.4) = 168 → clamped to 100 at the end,
+    // but the blend math was nonsensical mid-flight. Clamp prevents drift.
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    const allDocs = [
+      makeDoc('src/foo.ts', 10),
+      makeDoc('src/foo.ts', 11),
+      makeDoc('src/foo.ts', 12),
+    ];
+    // agreeing = 3 (all within ±5 of line 10), activeReviewers = 1
+    // raw rate = 300 → clamped to 100
+    // base = round(80 * 0.6 + 100 * 0.4) = round(48 + 40) = 88
+    // agreeing=3 hits BOOST branch (>= 3) → min(100, round(88 * 1.2)) = 100
+    const result = computeL1Confidence(doc, allDocs, 1, 100);
+    expect(result).toBe(100);
+    expect(result).toBeLessThanOrEqual(100); // invariant
+  });
+
+  it('excludes rule-source docs from agreeing count', () => {
+    const doc: EvidenceDocument = {
+      issueTitle: 'Test', problem: 'p', evidence: [], severity: 'WARNING',
+      suggestion: 's', filePath: 'src/foo.ts', lineRange: [10, 20],
+      confidence: 80,
+      source: 'llm',
+    };
+    const allDocs: EvidenceDocument[] = [
+      doc,
+      // This rule-source doc at the same location should NOT count as
+      // "reviewer agreement" — static analyzers are a separate signal class.
+      {
+        issueTitle: 'Linter', problem: 'p', evidence: [], severity: 'WARNING',
+        suggestion: 's', filePath: 'src/foo.ts', lineRange: [10, 10],
+        source: 'rule',
+      },
+      makeDoc('src/bar.ts', 100),
+      makeDoc('src/baz.ts', 200),
+      makeDoc('src/qux.ts', 300),
+    ];
+    // With the filter: agreeing = 1 (doc itself, rule doc excluded)
+    // Without the filter (bug): agreeing = 2 → no penalty, higher confidence
+    // activeReviewers = 5 → dissent branch → base × 0.5
+    // base = round(80 * 0.6 + 20 * 0.4) = 56, ×0.5 = 28
+    const result = computeL1Confidence(doc, allDocs, 5, 100);
+    expect(result).toBe(28);
+  });
 });


### PR DESCRIPTION
Closes #462.

## Summary
\`computeL1Confidence\` 가 \`agreementRate = agreeing / totalReviewers\` 로 계산하면서 unparseable/forfeit reviewer 를 denominator 에 포함 → 무응답을 반대표로 오해 → 진짜 버그를 \`ignore\` 탭 으로 매장.

## Changes
- \`computeL1Confidence(..., activeReviewers, ...)\` semantic rename
- Orchestrator 가 active count 계산 (issue 냈거나 explicit "no issues" 응답한 reviewer만)
- Penalty 분기를 **dissent** (active>=3, agreeing===1, ×0.5 + HS ×0.75) 와 **sparse** (active===1, agreeing===1, ×0.8) 로 분리

## Behavior table
| 케이스 | 기존 결과 | 신 결과 |
|---|---|---|
| 5 active, 1 agree, small diff | 28 (×0.5) | 28 (dissent, unchanged) |
| 5 active, 1 agree CRITICAL, small diff | 21 (×0.375) | 21 (dissent + lonely-HS, unchanged) |
| **1 active, 1 agree** (4 unparseable) | \*28 | **70-88** (sparse ×0.8) |
| 3 active, 3 agree | 86 (×1.2) | 86 (boost, unchanged) |
| 2 active, 1 agree | 68 (no-op) | 68 (middle ground, unchanged) |

\* 기존에도 orchestrator 가 \`allReviewerInputs.length\` (configured) 를 넘겨서 이 케이스는 "dissent 오분류" 였음. 이제 sparse branch 로 정확히 라우팅.

## Test plan
- [x] 기존 32 corroboration + blending 테스트 preservation
- [x] 신규 3 sparse-regime 테스트 (sparse WARNING, sparse CRITICAL 이 lonely-HS 면제, real-bug scenario 에서 uncertain threshold 유지)
- [x] 2 single-reviewer blending 테스트 예상값 갱신 (이전 오분류 고침, 의도된 behavior change)
- [x] 전체 suite 3206 passed, typecheck clean
- [ ] CodeAgora self-review 통과

## Breaking changes
- \`computeL1Confidence\` 파라미터명 변경 (\`totalReviewers\` → \`activeReviewers\`): core 내부 util, 외부 패키지 import 없음 → BC 영향 0
- 기존 single-reviewer (total=1) 테스트의 expected value 변경: 이전 결과 (100/40) 는 "totalReviewers<3 이므로 penalty skip" 이라는 bug 덕에 나온 값이었고, 신 결과 (80/32) 가 sparse penalty 적용된 올바른 값

🤖 Generated with [Claude Code](https://claude.com/claude-code)