### PR TITLE
feat(l2): enforce JSON schema on moderator forced decision (#465)

### DIFF
--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -3,6 +3,7 @@
  * Manages discussion lifecycle, coordinates supporters, writes final report
  */
 
+import { z } from 'zod';
 import type { Discussion, DiscussionRound, DiscussionVerdict, ModeratorReport } from '../types/core.js';
 import type { ModeratorConfig, DiscussionSettings, SupporterPoolConfig } from '../types/config.js';
 import { executeBackend } from '../l1/backend.js';
@@ -484,7 +485,28 @@ async function moderatorForcedDecision(
   rounds: DiscussionRound[],
   config: ModeratorConfig
 ): Promise<{ severity: 'HARSHLY_CRITICAL' | 'CRITICAL' | 'WARNING' | 'SUGGESTION' | 'DISMISSED'; reasoning: string }> {
-  const prompt = `You are the moderator. The discussion has reached max rounds without consensus.
+  const useJsonFormat = config.outputFormat === 'json';
+  const roundsBlock = rounds.map((r, i) =>
+    `Round ${i + 1}:\n${r.supporterResponses.map(s => `- ${s.supporterId}: ${s.stance} — ${s.response.substring(0, 200)}`).join('\n')}`
+  ).join('\n\n');
+
+  const prompt = useJsonFormat
+    ? `You are the moderator. The discussion has reached max rounds without consensus.
+
+Issue: ${discussion.issueTitle}
+Severity claimed: ${discussion.severity}
+
+Review all rounds and make a final decision. Respond with VALID JSON only — no code fences, no prose before or after.
+
+{
+  "severity": "HARSHLY_CRITICAL" | "CRITICAL" | "WARNING" | "SUGGESTION" | "DISMISSED",
+  "reasoning": "string (1-3 sentences explaining your decision)"
+}
+
+Rounds:
+${roundsBlock}
+`
+    : `You are the moderator. The discussion has reached max rounds without consensus.
 
 Issue: ${discussion.issueTitle}
 Severity claimed: ${discussion.severity}
@@ -494,7 +516,7 @@ Review all rounds and make a final decision:
 - Reasoning
 
 Rounds:
-${rounds.map((r, i) => `Round ${i + 1}:\n${r.supporterResponses.map(s => `- ${s.supporterId}: ${s.stance} — ${s.response.substring(0, 200)}`).join('\n')}`).join('\n\n')}
+${roundsBlock}
 `;
 
   const response = await executeBackend({
@@ -719,15 +741,63 @@ function normalizeStance(raw: string): Stance {
 }
 
 /**
+ * Zod schema for the JSON-mode moderator verdict envelope (#465).
+ * Kept structurally compatible with the markdown-parser output.
+ */
+const ModeratorVerdictJsonSchema = z.object({
+  severity: z.enum(['HARSHLY_CRITICAL', 'CRITICAL', 'WARNING', 'SUGGESTION', 'DISMISSED']),
+  reasoning: z.string().min(1),
+});
+
+/** Extract a JSON payload from a possibly-wrapped response (whole-response only). */
+function extractModeratorJsonPayload(response: string): string | null {
+  const trimmed = response.trim();
+  const fullFence = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/i);
+  if (fullFence && fullFence[1]) return fullFence[1].trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return trimmed;
+  return null;
+}
+
+/**
+ * Parse a JSON-mode moderator verdict response. Returns null when the
+ * response is not recognizable as JSON (caller can fall back to the
+ * regex-based parser).
+ */
+export function parseForcedDecisionJson(
+  response: string,
+): { severity: Severity; reasoning: string } | null {
+  const payload = extractModeratorJsonPayload(response);
+  if (payload === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return null;
+  }
+  const result = ModeratorVerdictJsonSchema.safeParse(parsed);
+  if (!result.success) return null;
+  return {
+    severity: result.data.severity,
+    reasoning: result.data.reasoning,
+  };
+}
+
+/**
  * Parse moderator forced decision from LLM response.
  *
  * Priority:
+ * 0. JSON envelope (if outputFormat: 'json' — #465). Zod-validated.
  * 1. Structured patterns: "Severity: WARNING", "**Severity:** CRITICAL"
- * 2. JSON-like: "severity": "WARNING"
- * 3. Keyword scan on full response (most specific first)
+ * 2. JSON-like regex: "severity": "WARNING"
+ * 3. Keyword scan on first 10 lines (most specific first)
  * 4. Default: WARNING
  */
 export function parseForcedDecision(response: string): { severity: Severity; reasoning: string } {
+  // Phase 0: try JSON envelope first. Graceful fall-through to existing
+  // regex path on any failure — preserves legacy behavior for markdown-mode.
+  const jsonResult = parseForcedDecisionJson(response);
+  if (jsonResult !== null) return jsonResult;
+
   const SEVERITY_ORDER: Severity[] = [
     'HARSHLY_CRITICAL', 'CRITICAL', 'WARNING', 'SUGGESTION', 'DISMISSED',
   ];

--- a/packages/core/src/tests/moderator-json.test.ts
+++ b/packages/core/src/tests/moderator-json.test.ts
@@ -1,0 +1,115 @@
+/**
+ * L2 Moderator — JSON output mode (#465)
+ *
+ * Covers parseForcedDecisionJson and parseForcedDecision dispatch /
+ * fallback behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseForcedDecision,
+  parseForcedDecisionJson,
+} from '../l2/moderator.js';
+
+const VALID: string = JSON.stringify({
+  severity: 'CRITICAL',
+  reasoning: 'The unchecked input allows SQL injection via parameter concatenation.',
+});
+
+describe('parseForcedDecisionJson', () => {
+  it('parses a well-formed moderator verdict', () => {
+    const result = parseForcedDecisionJson(VALID)!;
+    expect(result.severity).toBe('CRITICAL');
+    expect(result.reasoning).toMatch(/SQL injection/);
+  });
+
+  it('accepts all SEVERITY enum values including DISMISSED', () => {
+    for (const s of ['HARSHLY_CRITICAL', 'CRITICAL', 'WARNING', 'SUGGESTION', 'DISMISSED']) {
+      const r = parseForcedDecisionJson(
+        JSON.stringify({ severity: s, reasoning: 'rationale text' }),
+      )!;
+      expect(r.severity).toBe(s);
+    }
+  });
+
+  it('unwraps ```json ... ``` fence', () => {
+    const fenced = '```json\n' + VALID + '\n```';
+    const result = parseForcedDecisionJson(fenced)!;
+    expect(result.severity).toBe('CRITICAL');
+  });
+
+  it('unwraps plain ``` fence (no language tag)', () => {
+    const fenced = '```\n' + VALID + '\n```';
+    const result = parseForcedDecisionJson(fenced)!;
+    expect(result.severity).toBe('CRITICAL');
+  });
+
+  it('returns null when severity enum value is invalid', () => {
+    expect(parseForcedDecisionJson(
+      JSON.stringify({ severity: 'NOT_A_SEVERITY', reasoning: 'x' }),
+    )).toBeNull();
+  });
+
+  it('returns null when reasoning is missing / empty', () => {
+    expect(parseForcedDecisionJson(
+      JSON.stringify({ severity: 'CRITICAL', reasoning: '' }),
+    )).toBeNull();
+    expect(parseForcedDecisionJson(
+      JSON.stringify({ severity: 'CRITICAL' }),
+    )).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseForcedDecisionJson('{severity:')).toBeNull();
+    expect(parseForcedDecisionJson('not json')).toBeNull();
+  });
+
+  it('returns null for markdown-shaped response (not JSON)', () => {
+    expect(parseForcedDecisionJson('Severity: CRITICAL\nThe diff contains...')).toBeNull();
+  });
+
+  it('does not pick up embedded code fences inside prose', () => {
+    const prose = `The moderator observed the following.
+
+\`\`\`json
+{"severity": "CRITICAL", "reasoning": "should not hit"}
+\`\`\`
+
+Severity: WARNING
+`;
+    // Response starts with prose, not JSON → strict matcher bails out
+    expect(parseForcedDecisionJson(prose)).toBeNull();
+  });
+});
+
+describe('parseForcedDecision — dispatch + fallback', () => {
+  it('uses JSON path when response is valid JSON', () => {
+    const result = parseForcedDecision(VALID);
+    expect(result.severity).toBe('CRITICAL');
+    expect(result.reasoning).toMatch(/SQL injection/);
+  });
+
+  it('falls back to regex parser for markdown "Severity: X" response', () => {
+    const md = 'Severity: HARSHLY_CRITICAL\nReasoning: Data loss potential.';
+    const result = parseForcedDecision(md);
+    expect(result.severity).toBe('HARSHLY_CRITICAL');
+  });
+
+  it('falls back to keyword-scan for free-form prose', () => {
+    const prose = 'After reviewing all rounds, this finding is a WARNING due to low exploitability.';
+    const result = parseForcedDecision(prose);
+    expect(result.severity).toBe('WARNING');
+  });
+
+  it('defaults to WARNING when no pattern matches', () => {
+    const result = parseForcedDecision('I have no opinion.');
+    expect(result.severity).toBe('WARNING');
+  });
+
+  it('respects JSON severity over markdown-style text when both are present', () => {
+    // If response starts with JSON, that wins — downstream regex doesn't run
+    const mixed = JSON.stringify({ severity: 'SUGGESTION', reasoning: 'Minor concern' });
+    const result = parseForcedDecision(mixed);
+    expect(result.severity).toBe('SUGGESTION');
+  });
+});

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -121,6 +121,14 @@ export const ModeratorConfigSchema = z.object({
   model: z.string(),
   provider: z.string().optional(),
   timeout: z.number().default(120),
+  /**
+   * Forced-decision output format. Default (undefined/'markdown') uses the
+   * existing regex-based parser (structured "severity:" field → JSON-like
+   * pattern → keyword scan). `'json'` switches the prompt to emit a JSON
+   * object matching the forced-decision schema, which cheap models follow
+   * more reliably than markdown keywords. See #465.
+   */
+  outputFormat: z.enum(['markdown', 'json']).optional(),
 });
 export type ModeratorConfig = z.infer<typeof ModeratorConfigSchema>;
 


### PR DESCRIPTION
Closes #465.

## Summary
L1 에 이어 L2 moderator 도 JSON 출력 지원. #463 에서 만든 패턴을 forced-decision 경로에 적용. Default off (BC), opt-in 시 Zod 검증 + regex fallback 체인 유지.

## Behavior
- \`config.moderator.outputFormat: 'json'\` → 프롬프트에 JSON schema 주입, 응답은 Zod 로 검증
- default (undefined / 'markdown') → 기존 regex 기반 파싱 경로 그대로
- JSON 파싱 실패 → 기존 regex chain 으로 graceful fallback (structured "Severity:" → "severity": pattern → keyword scan → default WARNING)

## Schema
\`\`\`json
{
  "severity": "HARSHLY_CRITICAL" | "CRITICAL" | "WARNING" | "SUGGESTION" | "DISMISSED",
  "reasoning": "string (1-3 sentences)"
}
\`\`\`

## Test plan
- [x] Parser 유닛 14 (envelope / fenced / enum 전체 / 실패 → fallback)
- [x] 기존 parseStance + 다른 moderator 테스트 regression 없음
- [x] 전체 suite 3286 → 3300 passed
- [x] typecheck + dist rebuild clean

## Breaking changes
- **없음**. \`outputFormat\` optional. 미설정 시 기존 경로 100% 유지.

## Follow-up
- Phase 2: Vercel AI SDK \`generateObject\` 로 provider-native strict schema
- #464 lite tier + #465 JSON 조합으로 cheap moderator 에 자동 권장 preset 구성

🤖 Generated with [Claude Code](https://claude.com/claude-code)