### PR TITLE
feat(bench): golden-bug FN measurement framework (#472)

### DIFF
--- a/.github/workflows/bench-fn.yml
+++ b/.github/workflows/bench-fn.yml
@@ -1,0 +1,91 @@
+name: Benchmark — golden-bug FN
+
+# Manual one-shot runner for the #472 FN measurement framework.
+# Does NOT run on push/PR — triggered on demand to capture a baseline or
+# measure the impact of a calibration change.
+
+on:
+  workflow_dispatch:
+    inputs:
+      fixtures:
+        description: 'Comma-separated fixture ids (default: all)'
+        required: false
+        default: ''
+      skip_head:
+        description: 'Skip L3 head verdict stage'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check API key
+        run: |
+          if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+            echo "::error::OPENROUTER_API_KEY secret is not configured"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run live pipeline on fixtures
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          set -e
+          ARGS="--results ${{ github.workspace }}/bench-out"
+          if [ -n "${{ inputs.fixtures }}" ]; then
+            ARGS="$ARGS --fixtures ${{ inputs.fixtures }}"
+          fi
+          if [ "${{ inputs.skip_head }}" = "true" ]; then
+            ARGS="$ARGS --skip-head"
+          fi
+          echo "bench-fn-run args: $ARGS"
+          pnpm bench:fn:run -- $ARGS
+
+      - name: Score results
+        id: score
+        run: |
+          set -e
+          pnpm bench:fn -- --results ${{ github.workspace }}/bench-out --json \
+            > ${{ github.workspace }}/bench-out/_report.json
+          pnpm bench:fn -- --results ${{ github.workspace }}/bench-out \
+            | tee ${{ github.workspace }}/bench-out/_report.txt
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## Golden-bug benchmark"
+            echo ""
+            echo '```'
+            if [ -f "${{ github.workspace }}/bench-out/_report.txt" ]; then
+              cat "${{ github.workspace }}/bench-out/_report.txt"
+            else
+              echo "(no report — earlier step failed)"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-out
+          path: bench-out/
+          retention-days: 14

--- a/.github/workflows/bench-fn.yml
+++ b/.github/workflows/bench-fn.yml
@@ -46,17 +46,22 @@ jobs:
       - name: Run live pipeline on fixtures
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          BENCH_FIXTURES: ${{ inputs.fixtures }}
+          BENCH_SKIP_HEAD: ${{ inputs.skip_head }}
+          BENCH_RESULTS: ${{ github.workspace }}/bench-out
         run: |
-          set -e
-          ARGS="--results ${{ github.workspace }}/bench-out"
-          if [ -n "${{ inputs.fixtures }}" ]; then
-            ARGS="$ARGS --fixtures ${{ inputs.fixtures }}"
+          set -euo pipefail
+          # Build args as an array to avoid word-splitting surprises from
+          # workflow_dispatch user input.
+          ARGS=(--results "$BENCH_RESULTS")
+          if [ -n "$BENCH_FIXTURES" ]; then
+            ARGS+=(--fixtures "$BENCH_FIXTURES")
           fi
-          if [ "${{ inputs.skip_head }}" = "true" ]; then
-            ARGS="$ARGS --skip-head"
+          if [ "$BENCH_SKIP_HEAD" = "true" ]; then
+            ARGS+=(--skip-head)
           fi
-          echo "bench-fn-run args: $ARGS"
-          pnpm bench:fn:run -- $ARGS
+          echo "bench-fn-run args: ${ARGS[*]}"
+          pnpm bench:fn:run -- "${ARGS[@]}"
 
       - name: Score results
         id: score

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,12 @@ reviews/
 # CodeAgora session data & config (local)
 .ca/
 packages/web/.ca/
+# Benchmark config is committed; runtime session data stays local.
+!benchmarks/.ca/
+benchmarks/.ca/sessions/
+benchmarks/.ca/logs/
+benchmarks/.ca/cache/
+benchmarks/.ca/model-quality.json
 
 # Storage
 .storage/

--- a/README.md
+++ b/README.md
@@ -234,18 +234,30 @@ pnpm cli review path/to/diff.patch
 
 Golden-bug fixtures under `benchmarks/golden-bugs/` drive the false-negative measurement framework (see #472).
 
+**Score pre-computed results** (fast, no API calls):
+
 ```bash
 pnpm bench:fn -- --validate-only                     # schema-check fixtures
 pnpm bench:fn -- --results path/to/results-dir       # score against pre-computed review output
 pnpm bench:fn -- --results path/to/results-dir --json  # CI-friendly JSON report
 ```
 
+**Run the live pipeline against every fixture** (produces the results dir above):
+
+```bash
+export OPENROUTER_API_KEY=...
+pnpm bench:fn:run -- --results ./bench-out
+pnpm bench:fn     -- --results ./bench-out
+```
+
+The driver uses `benchmarks/.ca/config.json` — a lean 3-reviewer OpenRouter setup. A full run over the 4 seed fixtures costs roughly $0.04–$0.10 depending on discussion rounds. Add `--fixtures id1,id2` to restrict, `--skip-head` to skip the L3 verdict stage.
+
 Two fixture kinds live side by side:
 
 - **Recall cases** (`expectedFindings` non-empty) — review must surface each listed bug. Misses count as FN.
 - **FP regression cases** (`expectedFindings` is `[]`) — review must report nothing. Any finding is a regression.
 
-Current seed fixtures: 3 recall cases (off-by-one, null-deref, SQL injection) + 1 FP regression (PR #490 moderator regex). Live-pipeline baseline recording is deferred to #472 Phase 2. See `benchmarks/golden-bugs/README.md` for fixture format.
+Current seed fixtures: 3 recall cases (off-by-one, null-deref, SQL injection) + 1 FP regression (PR #490 moderator regex). See `benchmarks/golden-bugs/README.md` for fixture format.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,25 @@ pnpm cli review path/to/diff.patch
 
 ---
 
+## Benchmarks
+
+Golden-bug fixtures under `benchmarks/golden-bugs/` drive the false-negative measurement framework (see #472).
+
+```bash
+pnpm bench:fn -- --validate-only                     # schema-check fixtures
+pnpm bench:fn -- --results path/to/results-dir       # score against pre-computed review output
+pnpm bench:fn -- --results path/to/results-dir --json  # CI-friendly JSON report
+```
+
+Two fixture kinds live side by side:
+
+- **Recall cases** (`expectedFindings` non-empty) — review must surface each listed bug. Misses count as FN.
+- **FP regression cases** (`expectedFindings` is `[]`) — review must report nothing. Any finding is a regression.
+
+Current seed fixtures: 3 recall cases (off-by-one, null-deref, SQL injection) + 1 FP regression (PR #490 moderator regex). Live-pipeline baseline recording is deferred to #472 Phase 2. See `benchmarks/golden-bugs/README.md` for fixture format.
+
+---
+
 ## License
 
 MIT

--- a/benchmarks/.ca/config.json
+++ b/benchmarks/.ca/config.json
@@ -1,0 +1,27 @@
+{
+  "mode": "pragmatic",
+  "language": "en",
+  "reviewers": [
+    { "id": "r1", "model": "x-ai/grok-code-fast-1", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    { "id": "r2", "model": "qwen/qwen3-coder",      "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    { "id": "r3", "model": "minimax/minimax-m2.5",  "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 }
+  ],
+  "supporters": {
+    "pool": [
+      { "id": "s1", "model": "qwen/qwen3.6-plus", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 }
+    ],
+    "pickCount": 1,
+    "pickStrategy": "random",
+    "devilsAdvocate": { "id": "da", "model": "deepseek/deepseek-r1", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
+    "personaAssignment": "random"
+  },
+  "moderator": { "model": "deepseek/deepseek-v3.2", "backend": "api", "provider": "openrouter" },
+  "discussion": {
+    "maxRounds": 2,
+    "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null },
+    "codeSnippetRange": 10
+  },
+  "head": { "backend": "api", "model": "openai/gpt-5.4-mini", "provider": "openrouter", "enabled": true },
+  "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
+}

--- a/benchmarks/golden-bugs/README.md
+++ b/benchmarks/golden-bugs/README.md
@@ -1,0 +1,21 @@
+# Golden-bug fixtures (#472)
+
+Each subdirectory is one fixture with two files:
+
+- `diff.patch` — unified diff the review runs against
+- `expected.json` — ground-truth findings (matches `GoldenBugFixtureSchema`)
+
+Two kinds of fixture:
+
+- **Recall case** — `expectedFindings` is non-empty. The review must catch every listed bug. Misses count as FN.
+- **FP regression case** — `expectedFindings` is empty. The review must report *nothing*. Any finding is a regression.
+
+See `scripts/bench-fn.mjs` for the runner and `packages/shared/src/utils/golden-bug-scorer.ts` for matching semantics.
+
+## Adding a fixture
+
+1. Pick a kebab-case id and create `benchmarks/golden-bugs/<id>/`.
+2. Write `diff.patch` — keep it minimal but realistic (one hunk per bug is fine).
+3. Write `expected.json` following the schema. Set `category` to one of `cve`, `hotfix`, `fp-regression`, or add a new category as needed.
+4. Use `lineRange` coordinates from the **post-patch** file (the `+` side), with `lineTolerance` if the exact line is uncertain.
+5. Run `pnpm bench:fn` to verify the fixture loads and scores as expected.

--- a/benchmarks/golden-bugs/README.md
+++ b/benchmarks/golden-bugs/README.md
@@ -10,7 +10,7 @@ Two kinds of fixture:
 - **Recall case** — `expectedFindings` is non-empty. The review must catch every listed bug. Misses count as FN.
 - **FP regression case** — `expectedFindings` is empty. The review must report *nothing*. Any finding is a regression.
 
-See `scripts/bench-fn.mjs` for the runner and `packages/shared/src/utils/golden-bug-scorer.ts` for matching semantics.
+See `scripts/bench-fn.ts` (scorer) and `scripts/bench-fn-run.ts` (live-pipeline driver). Matching semantics live in `packages/shared/src/utils/golden-bug-scorer.ts`.
 
 ## Adding a fixture
 
@@ -18,4 +18,5 @@ See `scripts/bench-fn.mjs` for the runner and `packages/shared/src/utils/golden-
 2. Write `diff.patch` — keep it minimal but realistic (one hunk per bug is fine).
 3. Write `expected.json` following the schema. Set `category` to one of `cve`, `hotfix`, `fp-regression`, or add a new category as needed.
 4. Use `lineRange` coordinates from the **post-patch** file (the `+` side), with `lineTolerance` if the exact line is uncertain.
-5. Run `pnpm bench:fn` to verify the fixture loads and scores as expected.
+5. Run `pnpm bench:fn -- --validate-only` to confirm the fixture parses.
+6. (optional) Run `pnpm bench:fn:run -- --results ./bench-out --fixtures <id>` to produce live review output, then `pnpm bench:fn -- --results ./bench-out` to score.

--- a/benchmarks/golden-bugs/fp-moderator-regex/diff.patch
+++ b/benchmarks/golden-bugs/fp-moderator-regex/diff.patch
@@ -1,0 +1,24 @@
+diff --git a/packages/core/src/l2/moderator.ts b/packages/core/src/l2/moderator.ts
+index 7777777..8888888 100644
+--- a/packages/core/src/l2/moderator.ts
++++ b/packages/core/src/l2/moderator.ts
+@@ -750,10 +750,16 @@ function extractModeratorJsonPayload(response: string): string | null {
+   const trimmed = response.trim();
+   if (trimmed.startsWith('{')) {
+     return trimmed;
+   }
+-  const match = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/i);
+-  if (match) {
+-    return match[1].trim();
++  const fenceMatch = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/i);
++  if (fenceMatch) {
++    return fenceMatch[1].trim();
+   }
+   return null;
+ }
++
++export function parseForcedDecisionJson(response: string) {
++  const payload = extractModeratorJsonPayload(response);
++  if (!payload) return null;
++  return ModeratorVerdictJsonSchema.safeParse(JSON.parse(payload)).data ?? null;
++}

--- a/benchmarks/golden-bugs/fp-moderator-regex/expected.json
+++ b/benchmarks/golden-bugs/fp-moderator-regex/expected.json
@@ -1,0 +1,8 @@
+{
+  "id": "fp-moderator-regex",
+  "title": "PR #490 moderator JSON fence regex — FP regression case",
+  "source": "CodeAgora PR #490 (merged 2026-04-20 with admin override)",
+  "category": "fp-regression",
+  "expectedFindings": [],
+  "notes": "Self-review on PR #490 falsely claimed the regex literal contained zero-width-space characters at 90–93% confidence, with 2/3 reviewer corroboration. Verification via `od -c` showed pure ASCII. A competent review of this diff must report no findings — any CRITICAL/HARSHLY_CRITICAL claim about invisible characters is a regression of the exact FP the calibration stack is meant to catch."
+}

--- a/benchmarks/golden-bugs/null-deref-early-access/diff.patch
+++ b/benchmarks/golden-bugs/null-deref-early-access/diff.patch
@@ -1,0 +1,22 @@
+diff --git a/src/user/profile.ts b/src/user/profile.ts
+index 3333333..4444444 100644
+--- a/src/user/profile.ts
++++ b/src/user/profile.ts
+@@ -1,10 +1,11 @@
+ import type { User } from './types.js';
+
+ export function getDisplayName(user: User | null): string {
+-  if (user === null) {
+-    return 'Anonymous';
+-  }
+-  return user.displayName ?? user.email;
++  const name = user.displayName ?? user.email;
++  if (user === null) {
++    return 'Anonymous';
++  }
++  return name;
+ }
+
+ export function isAdmin(user: User): boolean {
+   return user.role === 'admin';
+ }

--- a/benchmarks/golden-bugs/null-deref-early-access/expected.json
+++ b/benchmarks/golden-bugs/null-deref-early-access/expected.json
@@ -1,0 +1,17 @@
+{
+  "id": "null-deref-early-access",
+  "title": "getDisplayName dereferences user before null check",
+  "source": "synthetic — classic ordering bug",
+  "category": "hotfix",
+  "expectedFindings": [
+    {
+      "filePath": "src/user/profile.ts",
+      "lineRange": [4, 4],
+      "lineTolerance": 3,
+      "minSeverity": "CRITICAL",
+      "rationale": "user.displayName is read before the `user === null` check, so a null user crashes before reaching the Anonymous branch",
+      "keyword": "null"
+    }
+  ],
+  "notes": "Refactor moved the property read above its null guard. Review must raise CRITICAL — this is a reliable NPE."
+}

--- a/benchmarks/golden-bugs/off-by-one-slice/diff.patch
+++ b/benchmarks/golden-bugs/off-by-one-slice/diff.patch
@@ -1,0 +1,18 @@
+diff --git a/src/utils/pagination.ts b/src/utils/pagination.ts
+index 1111111..2222222 100644
+--- a/src/utils/pagination.ts
++++ b/src/utils/pagination.ts
+@@ -1,12 +1,12 @@
+ export function paginate<T>(items: T[], page: number, pageSize: number): T[] {
+   if (page < 1 || pageSize < 1) {
+     throw new RangeError('page and pageSize must be >= 1');
+   }
+   const start = (page - 1) * pageSize;
+-  const end = start + pageSize;
++  const end = start + pageSize + 1;
+   return items.slice(start, end);
+ }
+
+ export function pageCount(total: number, pageSize: number): number {
+   return Math.ceil(total / pageSize);
+ }

--- a/benchmarks/golden-bugs/off-by-one-slice/expected.json
+++ b/benchmarks/golden-bugs/off-by-one-slice/expected.json
@@ -1,0 +1,17 @@
+{
+  "id": "off-by-one-slice",
+  "title": "pagination.paginate returns pageSize+1 items",
+  "source": "synthetic — canonical off-by-one",
+  "category": "hotfix",
+  "expectedFindings": [
+    {
+      "filePath": "src/utils/pagination.ts",
+      "lineRange": [6, 6],
+      "lineTolerance": 2,
+      "minSeverity": "WARNING",
+      "rationale": "end index adds pageSize + 1 instead of pageSize — returns one extra item per page",
+      "keyword": "page"
+    }
+  ],
+  "notes": "Clear off-by-one. A competent review must flag that `end = start + pageSize + 1` produces pageSize+1 items per page."
+}

--- a/benchmarks/golden-bugs/sql-injection-concat/diff.patch
+++ b/benchmarks/golden-bugs/sql-injection-concat/diff.patch
@@ -1,0 +1,20 @@
+diff --git a/src/db/users.ts b/src/db/users.ts
+index 5555555..6666666 100644
+--- a/src/db/users.ts
++++ b/src/db/users.ts
+@@ -1,12 +1,12 @@
+ import { db } from './connection.js';
+
+ export async function findUserByEmail(email: string) {
+-  return db.query(
+-    'SELECT id, email, role FROM users WHERE email = $1',
+-    [email],
+-  );
++  const sql =
++    "SELECT id, email, role FROM users WHERE email = '" + email + "'";
++  return db.query(sql);
+ }
+
+ export async function countUsers() {
+   return db.query('SELECT COUNT(*) FROM users');
+ }

--- a/benchmarks/golden-bugs/sql-injection-concat/expected.json
+++ b/benchmarks/golden-bugs/sql-injection-concat/expected.json
@@ -1,0 +1,17 @@
+{
+  "id": "sql-injection-concat",
+  "title": "findUserByEmail concatenates email into SQL string",
+  "source": "synthetic — OWASP A03:2021 reproducer",
+  "category": "cve-shaped",
+  "expectedFindings": [
+    {
+      "filePath": "src/db/users.ts",
+      "lineRange": [5, 6],
+      "lineTolerance": 3,
+      "minSeverity": "CRITICAL",
+      "rationale": "email is concatenated into the SQL string instead of being bound as a parameter — classic SQL injection",
+      "keyword": "injection"
+    }
+  ],
+  "notes": "Patch replaces a parameterized query with string concatenation. Review must raise CRITICAL or HARSHLY_CRITICAL and mention SQL injection."
+}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "test:coverage": "vitest run --coverage",
     "dev": "pnpm --filter @codeagora/cli dev",
     "build:action": "node scripts/build-action.mjs",
-    "bench:fn": "tsx scripts/bench-fn.ts"
+    "bench:fn": "tsx scripts/bench-fn.ts",
+    "bench:fn:run": "tsx scripts/bench-fn-run.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "test:all": "vitest run && cd packages/web && vitest run",
     "test:coverage": "vitest run --coverage",
     "dev": "pnpm --filter @codeagora/cli dev",
-    "build:action": "node scripts/build-action.mjs"
+    "build:action": "node scripts/build-action.mjs",
+    "bench:fn": "tsx scripts/bench-fn.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",

--- a/packages/shared/src/tests/golden-bug-mapping.test.ts
+++ b/packages/shared/src/tests/golden-bug-mapping.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import type { EvidenceDocument } from '../types/evidence.js';
+import {
+  evidenceToActualFinding,
+  evidenceListToActualFindings,
+} from '../utils/golden-bug-mapping.js';
+
+function doc(over: Partial<EvidenceDocument> = {}): EvidenceDocument {
+  return {
+    issueTitle: 'title',
+    problem: 'problem',
+    evidence: ['foo'],
+    severity: 'CRITICAL',
+    suggestion: 's',
+    filePath: 'src/a.ts',
+    lineRange: [10, 10],
+    ...over,
+  };
+}
+
+describe('evidenceToActualFinding', () => {
+  it('prefers confidenceTrace.final', () => {
+    const result = evidenceToActualFinding(
+      doc({
+        confidence: 50,
+        confidenceTrace: { raw: 80, filtered: 80, corroborated: 95, verified: 95, final: 95 },
+      }),
+    );
+    expect(result.confidence).toBe(95);
+  });
+
+  it('falls back to doc.confidence when trace absent', () => {
+    const result = evidenceToActualFinding(doc({ confidence: 42 }));
+    expect(result.confidence).toBe(42);
+  });
+
+  it('omits confidence when neither trace nor doc.confidence is set', () => {
+    const result = evidenceToActualFinding(doc());
+    expect(result.confidence).toBeUndefined();
+    expect('confidence' in result).toBe(false);
+  });
+
+  it('carries filePath, lineRange, severity verbatim', () => {
+    const result = evidenceToActualFinding(
+      doc({
+        filePath: 'pkg/x.ts',
+        lineRange: [5, 9],
+        severity: 'HARSHLY_CRITICAL',
+      }),
+    );
+    expect(result.filePath).toBe('pkg/x.ts');
+    expect(result.lineRange).toEqual([5, 9]);
+    expect(result.severity).toBe('HARSHLY_CRITICAL');
+  });
+
+  it('does not include evidence[] or suggestion (scorer does not need them)', () => {
+    const result = evidenceToActualFinding(doc());
+    expect('evidence' in result).toBe(false);
+    expect('suggestion' in result).toBe(false);
+  });
+});
+
+describe('evidenceListToActualFindings', () => {
+  it('maps every entry preserving order', () => {
+    const input = [
+      doc({ issueTitle: 'A', filePath: 'a.ts' }),
+      doc({ issueTitle: 'B', filePath: 'b.ts' }),
+    ];
+    const result = evidenceListToActualFindings(input);
+    expect(result.map((r) => r.issueTitle)).toEqual(['A', 'B']);
+    expect(result.map((r) => r.filePath)).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(evidenceListToActualFindings([])).toEqual([]);
+  });
+});

--- a/packages/shared/src/tests/golden-bug-scorer.test.ts
+++ b/packages/shared/src/tests/golden-bug-scorer.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GoldenBugFixtureSchema,
+  type GoldenBugFixture,
+} from '../types/golden-bug.js';
+import {
+  scoreCase,
+  aggregate,
+  type ActualFinding,
+  __internal,
+} from '../utils/golden-bug-scorer.js';
+
+const { normalizePath, rangesOverlap, findingMatches } = __internal;
+
+function fixture(over: Partial<GoldenBugFixture> = {}): GoldenBugFixture {
+  return GoldenBugFixtureSchema.parse({
+    id: 'demo-bug',
+    title: 'Demo',
+    source: 'unit-test',
+    category: 'test',
+    expectedFindings: [
+      {
+        filePath: 'src/foo.ts',
+        lineRange: [10, 12],
+        minSeverity: 'WARNING',
+        rationale: 'off-by-one in loop',
+      },
+    ],
+    ...over,
+  });
+}
+
+function finding(over: Partial<ActualFinding> = {}): ActualFinding {
+  return {
+    issueTitle: 'title',
+    problem: 'problem',
+    severity: 'CRITICAL',
+    filePath: 'src/foo.ts',
+    lineRange: [11, 11],
+    confidence: 70,
+    ...over,
+  };
+}
+
+describe('GoldenBugFixtureSchema', () => {
+  it('rejects non-kebab-case id', () => {
+    expect(() =>
+      GoldenBugFixtureSchema.parse({
+        id: 'Bad_ID',
+        title: 't',
+        source: 's',
+        category: 'c',
+        expectedFindings: [],
+      }),
+    ).toThrow();
+  });
+
+  it('allows empty expectedFindings (FP regression case)', () => {
+    const fx = GoldenBugFixtureSchema.parse({
+      id: 'fp-case',
+      title: 't',
+      source: 's',
+      category: 'fp-regression',
+      expectedFindings: [],
+    });
+    expect(fx.expectedFindings).toEqual([]);
+  });
+});
+
+describe('matching primitives', () => {
+  it('normalizePath handles backslashes and leading ./', () => {
+    expect(normalizePath('.\\src\\foo.ts')).toBe('src/foo.ts');
+    expect(normalizePath('./src/foo.ts')).toBe('src/foo.ts');
+  });
+
+  it('rangesOverlap honors tolerance at edges', () => {
+    expect(rangesOverlap([20, 22], [10, 10], 10)).toBe(true);
+    expect(rangesOverlap([21, 21], [10, 10], 10)).toBe(false);
+  });
+
+  it('findingMatches rejects mismatched file', () => {
+    expect(
+      findingMatches(fixture().expectedFindings[0], finding({ filePath: 'src/bar.ts' })),
+    ).toBe(false);
+  });
+
+  it('findingMatches rejects below-threshold severity', () => {
+    const fx = fixture({
+      expectedFindings: [
+        {
+          filePath: 'src/foo.ts',
+          lineRange: [10, 12],
+          minSeverity: 'CRITICAL',
+          rationale: 'r',
+        },
+      ],
+    });
+    expect(findingMatches(fx.expectedFindings[0], finding({ severity: 'WARNING' }))).toBe(false);
+    expect(findingMatches(fx.expectedFindings[0], finding({ severity: 'CRITICAL' }))).toBe(true);
+    expect(
+      findingMatches(fx.expectedFindings[0], finding({ severity: 'HARSHLY_CRITICAL' })),
+    ).toBe(true);
+  });
+
+  it('findingMatches enforces keyword when present', () => {
+    const fx = fixture({
+      expectedFindings: [
+        {
+          filePath: 'src/foo.ts',
+          lineRange: [10, 12],
+          minSeverity: 'WARNING',
+          rationale: 'r',
+          keyword: 'off-by-one',
+        },
+      ],
+    });
+    expect(
+      findingMatches(fx.expectedFindings[0], finding({ issueTitle: 'unrelated', problem: 'unrelated' })),
+    ).toBe(false);
+    expect(
+      findingMatches(fx.expectedFindings[0], finding({ issueTitle: 'OFF-BY-ONE in loop', problem: 'p' })),
+    ).toBe(true);
+  });
+});
+
+describe('scoreCase — recall path', () => {
+  it('reports hit + recall=1 when a matching finding exists', () => {
+    const fx = fixture();
+    const result = scoreCase(fx, [finding()]);
+    expect(result.isFpRegression).toBe(false);
+    expect(result.matched).toHaveLength(1);
+    expect(result.missed).toHaveLength(0);
+    expect(result.recallAtK[3]).toBe(1);
+    expect(result.recallAtK[5]).toBe(1);
+  });
+
+  it('misses when no finding overlaps line range within tolerance', () => {
+    const fx = fixture();
+    const result = scoreCase(fx, [finding({ lineRange: [100, 101] })]);
+    expect(result.matched).toHaveLength(0);
+    expect(result.missed).toHaveLength(1);
+    expect(result.recallAtK[3]).toBe(0);
+  });
+
+  it('prefers high-severity findings when computing recall@k', () => {
+    const fx = fixture();
+    // 5 low-severity noise, plus one real match buried last
+    const noise: ActualFinding[] = Array.from({ length: 5 }, (_, i) =>
+      finding({
+        filePath: `src/unrelated-${i}.ts`,
+        severity: 'SUGGESTION',
+        confidence: 20,
+      }),
+    );
+    const real = finding({ severity: 'HARSHLY_CRITICAL', confidence: 90 });
+    const result = scoreCase(fx, [...noise, real]);
+    // Severity ranking lifts the real finding into top-1
+    expect(result.recallAtK[3]).toBe(1);
+  });
+
+  it('claims each actual finding to at most one expected', () => {
+    const fx = fixture({
+      expectedFindings: [
+        {
+          filePath: 'src/foo.ts',
+          lineRange: [10, 12],
+          minSeverity: 'WARNING',
+          rationale: 'bug A',
+        },
+        {
+          filePath: 'src/foo.ts',
+          lineRange: [11, 11],
+          minSeverity: 'WARNING',
+          rationale: 'bug B',
+        },
+      ],
+    });
+    // One actual finding. Should hit exactly one expected, not both.
+    const result = scoreCase(fx, [finding()]);
+    expect(result.matched).toHaveLength(1);
+    expect(result.missed).toHaveLength(1);
+    expect(result.recallAtK[3]).toBe(0.5);
+  });
+});
+
+describe('scoreCase — FP regression path', () => {
+  it('isFpRegression=true when expectedFindings empty', () => {
+    const fx = fixture({ expectedFindings: [] });
+    const result = scoreCase(fx, []);
+    expect(result.isFpRegression).toBe(true);
+    expect(result.falsePositives).toEqual([]);
+    expect(result.recallAtK[3]).toBeNull();
+  });
+
+  it('lists all actual findings as falsePositives', () => {
+    const fx = fixture({ expectedFindings: [] });
+    const result = scoreCase(fx, [finding(), finding({ filePath: 'src/other.ts' })]);
+    expect(result.falsePositives).toHaveLength(2);
+  });
+});
+
+describe('aggregate', () => {
+  it('averages recall across only recall cases', () => {
+    const recall = fixture();
+    const fp = fixture({ id: 'fp-case', expectedFindings: [], category: 'fp-regression' });
+
+    const results = [
+      scoreCase(recall, [finding()]),           // recall=1
+      scoreCase(recall, []),                    // recall=0
+      scoreCase(fp, [finding()]),               // FP triggered, no recall
+    ];
+    const report = aggregate(results);
+    expect(report.totalCases).toBe(3);
+    expect(report.recallCases).toBe(2);
+    expect(report.fpRegressionCases).toBe(1);
+    expect(report.meanRecallAtK[3]).toBe(0.5);
+    expect(report.fpRegressionsTriggered).toBe(1);
+  });
+
+  it('returns 0 mean recall when no recall cases exist', () => {
+    const fp = fixture({ id: 'fp-only', expectedFindings: [], category: 'fp-regression' });
+    const report = aggregate([scoreCase(fp, [])]);
+    expect(report.meanRecallAtK[3]).toBe(0);
+    expect(report.fpRegressionsTriggered).toBe(0);
+  });
+});

--- a/packages/shared/src/tests/golden-bug-scorer.test.ts
+++ b/packages/shared/src/tests/golden-bug-scorer.test.ts
@@ -65,6 +65,25 @@ describe('GoldenBugFixtureSchema', () => {
     });
     expect(fx.expectedFindings).toEqual([]);
   });
+
+  it('rejects inverted lineRange (start > end)', () => {
+    expect(() =>
+      GoldenBugFixtureSchema.parse({
+        id: 'inverted',
+        title: 't',
+        source: 's',
+        category: 'hotfix',
+        expectedFindings: [
+          {
+            filePath: 'a.ts',
+            lineRange: [12, 10],
+            minSeverity: 'WARNING',
+            rationale: 'r',
+          },
+        ],
+      }),
+    ).toThrow(/non-inverted/);
+  });
 });
 
 describe('matching primitives', () => {

--- a/packages/shared/src/types/golden-bug.ts
+++ b/packages/shared/src/types/golden-bug.ts
@@ -16,7 +16,11 @@ import { SeveritySchema } from './severity.js';
 
 export const ExpectedFindingSchema = z.object({
   filePath: z.string().min(1),
-  lineRange: z.tuple([z.number().int().min(1), z.number().int().min(1)]),
+  lineRange: z
+    .tuple([z.number().int().min(1), z.number().int().min(1)])
+    .refine(([start, end]) => start <= end, {
+      message: 'lineRange must be non-inverted (start <= end)',
+    }),
   /**
    * Allowed deviation (in lines) around `lineRange` when matching. Defaults
    * to 10 to stay consistent with the hallucination filter's ±10 window.

--- a/packages/shared/src/types/golden-bug.ts
+++ b/packages/shared/src/types/golden-bug.ts
@@ -1,0 +1,64 @@
+/**
+ * Golden bug fixture schema (#472)
+ *
+ * A golden-bug fixture describes a diff for which we know the ground-truth
+ * findings. It powers the FN measurement framework (`scripts/bench-fn.mjs`):
+ *
+ *   - `expectedFindings = []` → FP regression case (review should report nothing)
+ *   - `expectedFindings` populated → recall case (review should catch listed bugs)
+ *
+ * Fixtures live at `benchmarks/golden-bugs/<id>/{diff.patch, expected.json}`.
+ * The JSON file matches `GoldenBugFixtureSchema`.
+ */
+
+import { z } from 'zod';
+import { SeveritySchema } from './severity.js';
+
+export const ExpectedFindingSchema = z.object({
+  filePath: z.string().min(1),
+  lineRange: z.tuple([z.number().int().min(1), z.number().int().min(1)]),
+  /**
+   * Allowed deviation (in lines) around `lineRange` when matching. Defaults
+   * to 10 to stay consistent with the hallucination filter's ±10 window.
+   */
+  lineTolerance: z.number().int().min(0).max(100).optional(),
+  /** Minimum severity the review must raise to count as a hit. */
+  minSeverity: SeveritySchema,
+  /**
+   * Short phrase describing the bug. Not used for matching — purely for
+   * human readability when the runner prints misses.
+   */
+  rationale: z.string().min(1),
+  /**
+   * Optional keyword that must appear (case-insensitive) in the review's
+   * `issueTitle` or `problem`. Use sparingly — over-specific keywords make
+   * the benchmark brittle.
+   */
+  keyword: z.string().min(1).optional(),
+});
+export type ExpectedFinding = z.infer<typeof ExpectedFindingSchema>;
+
+export const GoldenBugFixtureSchema = z.object({
+  id: z.string().min(1).regex(/^[a-z0-9-]+$/, 'id must be kebab-case'),
+  title: z.string().min(1),
+  /**
+   * Where this fixture came from: CVE id, commit SHA + repo, or internal
+   * reference. Purely informational.
+   */
+  source: z.string().min(1),
+  /**
+   * Free-text category for grouping reports (e.g., "cve", "hotfix",
+   * "fp-regression"). Not enumerated so new categories can be added
+   * without a schema bump.
+   */
+  category: z.string().min(1),
+  /**
+   * Empty list means "review should report nothing" — FP regression case.
+   * Non-empty list means the review must surface each entry (recall case).
+   */
+  expectedFindings: z.array(ExpectedFindingSchema),
+  notes: z.string().optional(),
+});
+export type GoldenBugFixture = z.infer<typeof GoldenBugFixtureSchema>;
+
+export const DEFAULT_LINE_TOLERANCE = 10;

--- a/packages/shared/src/utils/golden-bug-mapping.ts
+++ b/packages/shared/src/utils/golden-bug-mapping.ts
@@ -1,0 +1,34 @@
+/**
+ * Evidence → ActualFinding mapper (#472 Phase 2).
+ *
+ * Isolates the tiny mapping layer between pipeline output and the
+ * benchmark scorer input so it can be unit-tested without spinning up a
+ * real pipeline run.
+ */
+
+import type { EvidenceDocument } from '../types/evidence.js';
+import type { ActualFinding } from './golden-bug-scorer.js';
+
+/**
+ * Convert a pipeline evidence document into the shape the golden-bug
+ * scorer expects. Prefers `confidenceTrace.final` (the canonical
+ * post-pipeline confidence) and falls back to the deprecated
+ * `doc.confidence` field for legacy traces.
+ */
+export function evidenceToActualFinding(doc: EvidenceDocument): ActualFinding {
+  const confidence = doc.confidenceTrace?.final ?? doc.confidence;
+  return {
+    issueTitle: doc.issueTitle,
+    problem: doc.problem,
+    severity: doc.severity,
+    filePath: doc.filePath,
+    lineRange: doc.lineRange,
+    ...(typeof confidence === 'number' ? { confidence } : {}),
+  };
+}
+
+export function evidenceListToActualFindings(
+  docs: readonly EvidenceDocument[],
+): ActualFinding[] {
+  return docs.map(evidenceToActualFinding);
+}

--- a/packages/shared/src/utils/golden-bug-scorer.ts
+++ b/packages/shared/src/utils/golden-bug-scorer.ts
@@ -14,7 +14,7 @@
  * regression — `falsePositives` contains the offending findings.
  */
 
-import { SEVERITY_ORDER, type Severity } from '../types/severity.js';
+import type { Severity } from '../types/severity.js';
 import {
   DEFAULT_LINE_TOLERANCE,
   type ExpectedFinding,

--- a/packages/shared/src/utils/golden-bug-scorer.ts
+++ b/packages/shared/src/utils/golden-bug-scorer.ts
@@ -1,0 +1,216 @@
+/**
+ * Golden-bug recall@k scorer (#472)
+ *
+ * Matches review findings against a golden-bug fixture and emits a structured
+ * result used by `scripts/bench-fn.mjs` to compute aggregate metrics.
+ *
+ * Matching rules (for recall cases, `fixture.expectedFindings` non-empty):
+ *   - filePath must match exactly (normalized to forward slashes)
+ *   - [actualStart, actualEnd] must overlap [expectedStart - tol, expectedEnd + tol]
+ *   - actual severity rank >= expected.minSeverity rank
+ *   - keyword (if set) must appear case-insensitively in issueTitle or problem
+ *
+ * FP regression cases (expectedFindings=[]) treat any actual finding as a
+ * regression — `falsePositives` contains the offending findings.
+ */
+
+import { SEVERITY_ORDER, type Severity } from '../types/severity.js';
+import {
+  DEFAULT_LINE_TOLERANCE,
+  type ExpectedFinding,
+  type GoldenBugFixture,
+} from '../types/golden-bug.js';
+
+export interface ActualFinding {
+  issueTitle: string;
+  problem: string;
+  severity: Severity;
+  filePath: string;
+  lineRange: [number, number];
+  confidence?: number;
+}
+
+export interface CaseMatch {
+  expected: ExpectedFinding;
+  actual: ActualFinding;
+}
+
+export interface CaseResult {
+  fixtureId: string;
+  category: string;
+  isFpRegression: boolean;
+  matched: CaseMatch[];
+  missed: ExpectedFinding[];
+  falsePositives: ActualFinding[];
+  /** recall@k for several k values. For FP cases, recall is undefined. */
+  recallAtK: Record<number, number | null>;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  HARSHLY_CRITICAL: 4,
+  CRITICAL: 3,
+  WARNING: 2,
+  SUGGESTION: 1,
+};
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function rangesOverlap(
+  a: [number, number],
+  b: [number, number],
+  tolerance: number,
+): boolean {
+  const [aStart, aEnd] = a;
+  const [bStart, bEnd] = b;
+  return aStart <= bEnd + tolerance && aEnd >= bStart - tolerance;
+}
+
+function findingMatches(
+  expected: ExpectedFinding,
+  actual: ActualFinding,
+): boolean {
+  if (normalizePath(expected.filePath) !== normalizePath(actual.filePath)) {
+    return false;
+  }
+
+  const tol = expected.lineTolerance ?? DEFAULT_LINE_TOLERANCE;
+  if (!rangesOverlap(actual.lineRange, expected.lineRange, tol)) {
+    return false;
+  }
+
+  if (SEVERITY_RANK[actual.severity] < SEVERITY_RANK[expected.minSeverity]) {
+    return false;
+  }
+
+  if (expected.keyword) {
+    const kw = expected.keyword.toLowerCase();
+    const haystack = `${actual.issueTitle}\n${actual.problem}`.toLowerCase();
+    if (!haystack.includes(kw)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Rank actual findings (highest priority first) so recall@k picks the
+ * review's own top candidates. Severity dominates; confidence breaks ties.
+ */
+function rankFindings(findings: ActualFinding[]): ActualFinding[] {
+  return [...findings].sort((a, b) => {
+    const sevDiff = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sevDiff !== 0) return sevDiff;
+    return (b.confidence ?? 0) - (a.confidence ?? 0);
+  });
+}
+
+export interface ScoreOptions {
+  /** k values to compute recall at. Defaults to [3, 5, 10]. */
+  kValues?: number[];
+}
+
+export function scoreCase(
+  fixture: GoldenBugFixture,
+  actual: ActualFinding[],
+  options: ScoreOptions = {},
+): CaseResult {
+  const kValues = options.kValues ?? [3, 5, 10];
+  const isFpRegression = fixture.expectedFindings.length === 0;
+
+  if (isFpRegression) {
+    return {
+      fixtureId: fixture.id,
+      category: fixture.category,
+      isFpRegression: true,
+      matched: [],
+      missed: [],
+      falsePositives: [...actual],
+      recallAtK: Object.fromEntries(kValues.map((k) => [k, null])),
+    };
+  }
+
+  const ranked = rankFindings(actual);
+  const matched: CaseMatch[] = [];
+  const claimedActualIdx = new Set<number>();
+
+  for (const expected of fixture.expectedFindings) {
+    for (let i = 0; i < ranked.length; i++) {
+      if (claimedActualIdx.has(i)) continue;
+      if (findingMatches(expected, ranked[i])) {
+        matched.push({ expected, actual: ranked[i] });
+        claimedActualIdx.add(i);
+        break;
+      }
+    }
+  }
+
+  const matchedExpected = new Set(matched.map((m) => m.expected));
+  const missed = fixture.expectedFindings.filter((e) => !matchedExpected.has(e));
+
+  const recallAtK: Record<number, number | null> = {};
+  for (const k of kValues) {
+    const topK = ranked.slice(0, k);
+    let hits = 0;
+    const claimedInK = new Set<number>();
+    for (const expected of fixture.expectedFindings) {
+      for (let i = 0; i < topK.length; i++) {
+        if (claimedInK.has(i)) continue;
+        if (findingMatches(expected, topK[i])) {
+          hits += 1;
+          claimedInK.add(i);
+          break;
+        }
+      }
+    }
+    recallAtK[k] = hits / fixture.expectedFindings.length;
+  }
+
+  return {
+    fixtureId: fixture.id,
+    category: fixture.category,
+    isFpRegression: false,
+    matched,
+    missed,
+    falsePositives: [],
+    recallAtK,
+  };
+}
+
+export interface AggregateReport {
+  totalCases: number;
+  recallCases: number;
+  fpRegressionCases: number;
+  meanRecallAtK: Record<number, number>;
+  fpRegressionsTriggered: number;
+  perCase: CaseResult[];
+}
+
+export function aggregate(
+  results: CaseResult[],
+  kValues: number[] = [3, 5, 10],
+): AggregateReport {
+  const recallCases = results.filter((r) => !r.isFpRegression);
+  const fpCases = results.filter((r) => r.isFpRegression);
+
+  const meanRecallAtK: Record<number, number> = {};
+  for (const k of kValues) {
+    if (recallCases.length === 0) {
+      meanRecallAtK[k] = 0;
+      continue;
+    }
+    const sum = recallCases.reduce((acc, r) => acc + (r.recallAtK[k] ?? 0), 0);
+    meanRecallAtK[k] = sum / recallCases.length;
+  }
+
+  return {
+    totalCases: results.length,
+    recallCases: recallCases.length,
+    fpRegressionCases: fpCases.length,
+    meanRecallAtK,
+    fpRegressionsTriggered: fpCases.filter((r) => r.falsePositives.length > 0).length,
+    perCase: results,
+  };
+}
+
+export const __internal = { SEVERITY_RANK, normalizePath, rangesOverlap, findingMatches };

--- a/scripts/bench-fn-run.ts
+++ b/scripts/bench-fn-run.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env -S tsx
+// Live-pipeline driver for the golden-bug benchmark (#472 Phase 2).
+//
+// For each fixture in benchmarks/golden-bugs/ this script runs the full
+// CodeAgora pipeline against `diff.patch` and emits an ActualFinding[]
+// JSON file at <results-dir>/<fixture-id>.json, which `pnpm bench:fn`
+// then scores.
+//
+// Usage:
+//   pnpm bench:fn:run -- --results <dir>                     # run all fixtures
+//   pnpm bench:fn:run -- --results <dir> --fixtures id1,id2  # subset
+//   pnpm bench:fn:run -- --results <dir> --skip-head         # skip L3 verdict
+//
+// Requirements:
+//   - OPENROUTER_API_KEY in env (matching the default benchmark config)
+//   - Run from repo root; the driver chdir's into benchmarks/ so the
+//     pipeline picks up benchmarks/.ca/config.json.
+//
+// Cost: roughly $0.04–$0.10 per full run across the seed fixtures with
+// the default cheap OpenRouter config. Scales with reviewer count and
+// discussion rounds.
+
+import { readFile, readdir, stat, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+import { GoldenBugFixtureSchema, type GoldenBugFixture } from '../packages/shared/src/types/golden-bug.js';
+import { evidenceListToActualFindings } from '../packages/shared/src/utils/golden-bug-mapping.js';
+import { runPipeline } from '../packages/core/src/pipeline/orchestrator.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const fixturesDir = path.join(repoRoot, 'benchmarks', 'golden-bugs');
+const benchmarkCwd = path.join(repoRoot, 'benchmarks');
+
+interface Args {
+  resultsDir: string | null;
+  fixtureFilter: Set<string> | null;
+  skipHead: boolean;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    resultsDir: null,
+    fixtureFilter: null,
+    skipHead: false,
+    dryRun: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--results') args.resultsDir = argv[++i] ?? null;
+    else if (a === '--fixtures') {
+      const list = argv[++i] ?? '';
+      args.fixtureFilter = new Set(list.split(',').map((s) => s.trim()).filter(Boolean));
+    } else if (a === '--skip-head') args.skipHead = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: pnpm bench:fn:run -- --results <dir> [--fixtures id1,id2] [--skip-head] [--dry-run]',
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+async function loadFixtures(filter: Set<string> | null): Promise<GoldenBugFixture[]> {
+  const entries = await readdir(fixturesDir, { withFileTypes: true });
+  const out: GoldenBugFixture[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (filter && !filter.has(entry.name)) continue;
+    const dir = path.join(fixturesDir, entry.name);
+    await stat(path.join(dir, 'diff.patch'));
+    const raw = await readFile(path.join(dir, 'expected.json'), 'utf8');
+    const parsed = GoldenBugFixtureSchema.parse(JSON.parse(raw));
+    out.push(parsed);
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+async function runOne(fixtureId: string, skipHead: boolean): Promise<unknown[]> {
+  const diffPath = path.join(fixturesDir, fixtureId, 'diff.patch');
+  const result = await runPipeline({ diffPath, skipHead });
+  if (result.status !== 'success') {
+    throw new Error(`pipeline error for ${fixtureId}: ${result.error ?? 'unknown'}`);
+  }
+  const docs = result.evidenceDocs ?? [];
+  return evidenceListToActualFindings(docs);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.resultsDir) {
+    console.error('bench-fn-run: --results <dir> is required');
+    process.exit(2);
+  }
+
+  const fixtures = await loadFixtures(args.fixtureFilter);
+  if (fixtures.length === 0) {
+    console.error('bench-fn-run: no fixtures matched');
+    process.exit(2);
+  }
+
+  const resultsDir = path.resolve(process.cwd(), args.resultsDir);
+  await mkdir(resultsDir, { recursive: true });
+
+  if (args.dryRun) {
+    console.log(`[dry-run] would run ${fixtures.length} fixture(s):`);
+    for (const f of fixtures) console.log(`  - ${f.id} → ${path.join(resultsDir, `${f.id}.json`)}`);
+    return;
+  }
+
+  // Pipeline reads config from process.cwd()/.ca/config.json — chdir into
+  // benchmarks/ so the committed benchmark config is picked up regardless
+  // of where the caller invoked the script from.
+  process.chdir(benchmarkCwd);
+
+  const summary: { id: string; findings: number; status: 'ok' | 'error'; error?: string }[] = [];
+  for (const fixture of fixtures) {
+    process.stderr.write(`[${fixture.id}] running... `);
+    const started = Date.now();
+    try {
+      const findings = await runOne(fixture.id, args.skipHead);
+      const outPath = path.join(resultsDir, `${fixture.id}.json`);
+      await writeFile(outPath, JSON.stringify(findings, null, 2) + '\n');
+      summary.push({ id: fixture.id, findings: findings.length, status: 'ok' });
+      process.stderr.write(`ok (${findings.length} finding(s), ${Math.round((Date.now() - started) / 1000)}s)\n`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      summary.push({ id: fixture.id, findings: 0, status: 'error', error: msg });
+      process.stderr.write(`ERROR: ${msg}\n`);
+    }
+  }
+
+  console.log('\n== bench-fn-run summary ==');
+  for (const s of summary) {
+    if (s.status === 'ok') console.log(`  ${s.id.padEnd(32)} ok     ${s.findings} finding(s)`);
+    else console.log(`  ${s.id.padEnd(32)} ERROR  ${s.error ?? ''}`);
+  }
+
+  const failures = summary.filter((s) => s.status === 'error').length;
+  if (failures > 0) process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`bench-fn-run: ${msg}`);
+  process.exit(2);
+});

--- a/scripts/bench-fn-run.ts
+++ b/scripts/bench-fn-run.ts
@@ -75,8 +75,20 @@ async function loadFixtures(filter: Set<string> | null): Promise<GoldenBugFixtur
     if (filter && !filter.has(entry.name)) continue;
     const dir = path.join(fixturesDir, entry.name);
     await stat(path.join(dir, 'diff.patch'));
-    const raw = await readFile(path.join(dir, 'expected.json'), 'utf8');
-    const parsed = GoldenBugFixtureSchema.parse(JSON.parse(raw));
+    const expectedPath = path.join(dir, 'expected.json');
+    let parsed: GoldenBugFixture;
+    try {
+      const raw = await readFile(expectedPath, 'utf8');
+      parsed = GoldenBugFixtureSchema.parse(JSON.parse(raw));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`fixture ${entry.name}: failed to load expected.json — ${msg}`);
+    }
+    if (parsed.id !== entry.name) {
+      throw new Error(
+        `fixture ${entry.name}: id "${parsed.id}" does not match directory name`,
+      );
+    }
     out.push(parsed);
   }
   return out.sort((a, b) => a.id.localeCompare(b.id));
@@ -117,23 +129,28 @@ async function main(): Promise<void> {
   // Pipeline reads config from process.cwd()/.ca/config.json — chdir into
   // benchmarks/ so the committed benchmark config is picked up regardless
   // of where the caller invoked the script from.
+  const originalCwd = process.cwd();
   process.chdir(benchmarkCwd);
 
   const summary: { id: string; findings: number; status: 'ok' | 'error'; error?: string }[] = [];
-  for (const fixture of fixtures) {
-    process.stderr.write(`[${fixture.id}] running... `);
-    const started = Date.now();
-    try {
-      const findings = await runOne(fixture.id, args.skipHead);
-      const outPath = path.join(resultsDir, `${fixture.id}.json`);
-      await writeFile(outPath, JSON.stringify(findings, null, 2) + '\n');
-      summary.push({ id: fixture.id, findings: findings.length, status: 'ok' });
-      process.stderr.write(`ok (${findings.length} finding(s), ${Math.round((Date.now() - started) / 1000)}s)\n`);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      summary.push({ id: fixture.id, findings: 0, status: 'error', error: msg });
-      process.stderr.write(`ERROR: ${msg}\n`);
+  try {
+    for (const fixture of fixtures) {
+      process.stderr.write(`[${fixture.id}] running... `);
+      const started = Date.now();
+      try {
+        const findings = await runOne(fixture.id, args.skipHead);
+        const outPath = path.join(resultsDir, `${fixture.id}.json`);
+        await writeFile(outPath, JSON.stringify(findings, null, 2) + '\n');
+        summary.push({ id: fixture.id, findings: findings.length, status: 'ok' });
+        process.stderr.write(`ok (${findings.length} finding(s), ${Math.round((Date.now() - started) / 1000)}s)\n`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        summary.push({ id: fixture.id, findings: 0, status: 'error', error: msg });
+        process.stderr.write(`ERROR: ${msg}\n`);
+      }
     }
+  } finally {
+    process.chdir(originalCwd);
   }
 
   console.log('\n== bench-fn-run summary ==');

--- a/scripts/bench-fn.ts
+++ b/scripts/bench-fn.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env -S tsx
+// Golden-bug FN benchmark runner (#472).
+//
+// Loads fixtures from benchmarks/golden-bugs/ and scores them against
+// precomputed review results.
+//
+// Usage:
+//   tsx scripts/bench-fn.ts --validate-only
+//       Load every fixture. Exit non-zero on any schema error.
+//
+//   tsx scripts/bench-fn.ts --results <dir>
+//       Score fixtures against pre-generated review results. Each file
+//       in <dir> must be named `<fixture-id>.json` and contain an array
+//       of ActualFinding objects.
+//
+//   tsx scripts/bench-fn.ts --results <dir> --json
+//       Same as above but emits a single JSON report on stdout.
+//
+// This runner does NOT invoke the CodeAgora pipeline. Driving the live
+// pipeline requires API keys and takes minutes per fixture — Phase 2 of
+// #472 will add a pipeline-driver that emits into --results.
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+import { GoldenBugFixtureSchema, type GoldenBugFixture } from '../packages/shared/src/types/golden-bug.js';
+import {
+  scoreCase,
+  aggregate,
+  type ActualFinding,
+  type AggregateReport,
+} from '../packages/shared/src/utils/golden-bug-scorer.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const fixturesDir = path.join(repoRoot, 'benchmarks', 'golden-bugs');
+
+interface Args {
+  validateOnly: boolean;
+  resultsDir: string | null;
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { validateOnly: false, resultsDir: null, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--validate-only') args.validateOnly = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--results') args.resultsDir = argv[++i] ?? null;
+    else if (a === '--help' || a === '-h') {
+      console.log('Usage: tsx scripts/bench-fn.ts [--validate-only] [--results <dir>] [--json]');
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+async function loadFixtures(): Promise<{ fixture: GoldenBugFixture; dir: string }[]> {
+  const entries = await readdir(fixturesDir, { withFileTypes: true });
+  const fixtures: { fixture: GoldenBugFixture; dir: string }[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(fixturesDir, entry.name);
+    const expectedPath = path.join(dir, 'expected.json');
+    const diffPath = path.join(dir, 'diff.patch');
+    try {
+      await stat(diffPath);
+    } catch {
+      throw new Error(`fixture ${entry.name}: missing diff.patch`);
+    }
+    const raw = await readFile(expectedPath, 'utf8');
+    const json = JSON.parse(raw);
+    const parsed = GoldenBugFixtureSchema.safeParse(json);
+    if (!parsed.success) {
+      const msg = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      throw new Error(`fixture ${entry.name}: schema error — ${msg}`);
+    }
+    if (parsed.data.id !== entry.name) {
+      throw new Error(`fixture ${entry.name}: id "${parsed.data.id}" does not match directory name`);
+    }
+    fixtures.push({ fixture: parsed.data, dir });
+  }
+  fixtures.sort((a, b) => a.fixture.id.localeCompare(b.fixture.id));
+  return fixtures;
+}
+
+async function loadResultsFor(fixtureId: string, resultsDir: string): Promise<ActualFinding[] | null> {
+  const resultsPath = path.join(resultsDir, `${fixtureId}.json`);
+  try {
+    const raw = await readFile(resultsPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) throw new Error(`results for ${fixtureId}: expected JSON array`);
+    return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+function pct(x: number | null | undefined): string {
+  if (x === null || x === undefined || Number.isNaN(x)) return '  n/a';
+  return `${(x * 100).toFixed(1).padStart(4)}%`;
+}
+
+function printHumanReport(report: AggregateReport, opts: { hadAnyResults: boolean }): void {
+  console.log('\n== Golden-bug benchmark ==\n');
+  console.log(
+    `total: ${report.totalCases} | recall: ${report.recallCases} | fp-regression: ${report.fpRegressionCases}`,
+  );
+  if (opts.hadAnyResults) {
+    console.log(
+      `mean recall@3: ${pct(report.meanRecallAtK[3])}  @5: ${pct(report.meanRecallAtK[5])}  @10: ${pct(report.meanRecallAtK[10])}`,
+    );
+    console.log(`FP regressions triggered: ${report.fpRegressionsTriggered}/${report.fpRegressionCases}`);
+  } else {
+    console.log('no --results supplied — fixture validation only');
+  }
+  console.log('\nper-fixture:');
+  for (const r of report.perCase) {
+    if (r.isFpRegression) {
+      const status = r.falsePositives.length === 0 ? 'PASS' : `FAIL (${r.falsePositives.length} FPs)`;
+      console.log(`  [fp ] ${r.fixtureId.padEnd(32)} ${status}`);
+    } else {
+      const hits = r.matched.length;
+      const total = r.matched.length + r.missed.length;
+      console.log(
+        `  [rec] ${r.fixtureId.padEnd(32)} ${hits}/${total}  r@3=${pct(r.recallAtK[3])} r@5=${pct(r.recallAtK[5])} r@10=${pct(r.recallAtK[10])}`,
+      );
+    }
+  }
+  console.log();
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const fixtures = await loadFixtures();
+
+  if (args.validateOnly) {
+    console.log(`OK: ${fixtures.length} fixture(s) validated`);
+    for (const { fixture } of fixtures) {
+      console.log(`  - ${fixture.id} (${fixture.category})`);
+    }
+    return;
+  }
+
+  const hadResultsDir = Boolean(args.resultsDir);
+  const results = [];
+  for (const { fixture } of fixtures) {
+    let actual: ActualFinding[] = [];
+    if (hadResultsDir && args.resultsDir) {
+      const loaded = await loadResultsFor(fixture.id, args.resultsDir);
+      if (loaded !== null) actual = loaded;
+    }
+    results.push(scoreCase(fixture, actual));
+  }
+
+  const report = aggregate(results);
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    return;
+  }
+
+  printHumanReport(report, { hadAnyResults: hadResultsDir });
+  if (report.fpRegressionsTriggered > 0) process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`bench-fn: ${msg}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
- Phase 1 infra for #472 — fixture schema, recall@k scorer, opt-in runner, 4 seed fixtures
- No pipeline changes; purely additive
- Closes the "FN 측정 infra 0" blind spot recorded in `project_calibration_stack.md`

## What's in
- `packages/shared/src/types/golden-bug.ts` — Zod schema (kebab-case id, line tolerance, keyword match, min severity)
- `packages/shared/src/utils/golden-bug-scorer.ts` — recall@k with severity+confidence ranking, FP regression branch, aggregate reporter
- `scripts/bench-fn.ts` + `pnpm bench:fn` — `--validate-only` / `--results <dir>` / `--json` modes. Does **not** drive the live pipeline (Phase 2).
- `benchmarks/golden-bugs/` — 4 seed fixtures:
  - `off-by-one-slice` (hotfix, WARNING+)
  - `null-deref-early-access` (hotfix, CRITICAL+)
  - `sql-injection-concat` (cve-shaped, CRITICAL+)
  - `fp-moderator-regex` — **PR #490 FP regression case** (expected findings = `[]`)

## Why it matters
모든 quality 논의가 FP 중심이었고 FN 측정 인프라는 0 이었음. A+B+C+D+E penalty 체인이 FP 를 줄였지만 FN 을 늘렸을 가능성 측정 불가. 이 PR 이 그 첫 계측기. PR #490 을 FP regression fixture 로 넣어서 현재 calibration stack 이 뚫렸던 케이스를 regression gate 로 바로 사용 가능.

## Out of scope (follow-up)
- **Phase 2**: live-pipeline driver (emits into `--results <dir>`), baseline recall@5 recording
- **Phase 3**: CI nightly + dashboard/alerts
- 20+ real CVE/hotfix 데이터셋 확장

## Test plan
- [x] `pnpm --filter @codeagora/shared test` — 15 new scorer tests pass (schema, primitives, recall path, FP path, aggregate)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 3315 passing (3300 → 3315 this PR)
- [x] `pnpm bench:fn -- --validate-only` — 4 fixtures validate
- [x] `pnpm bench:fn -- --results /tmp/demo` with sample results — correctly scores recall@k + FP regression branch
- [ ] Phase 2: run against live pipeline, record baseline recall@5

## Risks
- **Synthetic seed fixtures**: 3 recall cases are hand-crafted, not real CVE/hotfix diffs. Mitigation: Phase 2 expands to real data; current cases are still clear-cut bugs that any competent review must catch.
- **Matching subjectivity**: `lineTolerance` + `minSeverity` + optional `keyword` give enough knobs for brittleness. Mitigation: `lineTolerance` defaults to 10 (same as hallucination filter window); keyword is optional.
- **No live baseline yet**: README calls this out explicitly. Phase 2 PR will add numbers.