### PR TITLE
feat(filter): evidence quality scoring as hallucination check 6 (#468)

### DIFF
--- a/packages/core/src/pipeline/evidence-scorer.ts
+++ b/packages/core/src/pipeline/evidence-scorer.ts
@@ -1,0 +1,118 @@
+/**
+ * Evidence quality scorer (#468).
+ *
+ * Produces a 0–1 score describing how *specific* and *verifiable* a
+ * reviewer's evidence is. Used as hallucination-filter check 6 to
+ * dampen confidence on vague, pattern-match-style findings (the FP
+ * class the n=3 baseline exposed on `benchmarks/golden-bugs/fp-moderator-regex`).
+ *
+ * The scorer intentionally does not judge correctness — that is the
+ * other checks' job. It measures surface features only: list length,
+ * text length, and specificity-marker density.
+ *
+ * Three equally weighted sub-scores:
+ *
+ *   1. evidence list length (doc.evidence[]) — reviewers who can cite
+ *      multiple corroborating lines tend to be grounded in the diff.
+ *   2. problem text length — detailed failure narratives correlate
+ *      with real understanding; one-liner problems correlate with
+ *      template regurgitation.
+ *   3. specificity-marker density in `problem` — file:line citations,
+ *      backtick-wrapped identifiers, function/variable tokens. These
+ *      are the lexical footprint of someone reading the diff rather
+ *      than pattern-matching.
+ *
+ * Final score = (length + problemLength + specificity) / 3.
+ *
+ * Downstream multiplier (applied in hallucination-filter):
+ *     conf × (0.7 + 0.3 × score)
+ * giving a penalty range of [×0.7 (lowest quality), ×1.0 (highest)].
+ *
+ * Rule-based findings (`source === 'rule'`) should be excluded before
+ * this scorer runs — static analysis evidence lives in a different
+ * structural regime.
+ */
+
+import type { EvidenceDocument } from '../types/core.js';
+
+// Sub-score 1: evidence[] length.
+// 0 items → 0, 1 → 0.33, 2 → 0.67, ≥3 → 1.0
+function scoreEvidenceCount(doc: EvidenceDocument): number {
+  const n = doc.evidence?.length ?? 0;
+  if (n === 0) return 0;
+  if (n === 1) return 0.33;
+  if (n === 2) return 0.67;
+  return 1.0;
+}
+
+// Sub-score 2: problem text length.
+// Piecewise: <50ch → 0, <100 → 0.5, <300 → 0.8, ≥300 → 1.0
+function scoreProblemLength(doc: EvidenceDocument): number {
+  const len = doc.problem?.length ?? 0;
+  if (len < 50) return 0;
+  if (len < 100) return 0.5;
+  if (len < 300) return 0.8;
+  return 1.0;
+}
+
+/**
+ * Sub-score 3: specificity markers in the problem text.
+ *
+ * Each matcher contributes at most one hit (not multiple overlaps) to
+ * keep the scale bounded and insensitive to padding. Five markers map
+ * to five hit buckets: 0 → 0, 1 → 0.2, 2 → 0.5, 3 → 0.7, ≥4 → 1.0.
+ *
+ * Designed conservatively — markers must look like code or citations,
+ * not just any capitalised word. Generic English should score 0.
+ */
+const SPECIFICITY_MATCHERS: RegExp[] = [
+  // file:line or path:line citations, e.g. `moderator.ts:755`
+  /\b[\w./-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|cpp|c|h)\b(?::\d+)?/i,
+  // backtick-wrapped identifiers or code, e.g. `parseForcedDecisionJson`
+  /`[A-Za-z_$][\w$.]*(?:\([^)]*\))?`/,
+  // explicit line citation ("line 755" / "lines 12-18")
+  /\bline(?:s)?\s+\d+(?:\s*[-–]\s*\d+)?\b/i,
+  // camelCase or snake_case identifier (at least one separator)
+  /\b(?:[a-z]+[A-Z][A-Za-z0-9]+|[a-z]+_[a-z]+[\w_]*)\b/,
+  // function invocation pattern, e.g. `foo(bar)` outside backticks
+  /\b[A-Za-z_$][\w$]*\s*\(\s*[^)]{0,40}\)/,
+];
+
+function scoreSpecificity(doc: EvidenceDocument): number {
+  const text = doc.problem ?? '';
+  let hits = 0;
+  for (const rx of SPECIFICITY_MATCHERS) {
+    if (rx.test(text)) hits++;
+  }
+  if (hits === 0) return 0;
+  if (hits === 1) return 0.2;
+  if (hits === 2) return 0.5;
+  if (hits === 3) return 0.7;
+  return 1.0;
+}
+
+/**
+ * Compute the evidence quality score for a single document.
+ * Returns a value in [0, 1], rounded to three decimals for stable
+ * serialisation.
+ */
+export function scoreEvidence(doc: EvidenceDocument): number {
+  const a = scoreEvidenceCount(doc);
+  const b = scoreProblemLength(doc);
+  const c = scoreSpecificity(doc);
+  const raw = (a + b + c) / 3;
+  return Math.round(raw * 1000) / 1000;
+}
+
+/** Multiplier derived from the score: 0.7 + 0.3 × score. */
+export function evidenceMultiplier(score: number): number {
+  const clamped = Math.max(0, Math.min(1, score));
+  return 0.7 + 0.3 * clamped;
+}
+
+export const __internal = {
+  scoreEvidenceCount,
+  scoreProblemLength,
+  scoreSpecificity,
+  SPECIFICITY_MATCHERS,
+};

--- a/packages/core/src/pipeline/hallucination-filter.ts
+++ b/packages/core/src/pipeline/hallucination-filter.ts
@@ -2,19 +2,21 @@
  * Pre-Debate Hallucination Filter (#428)
  * Validates evidence documents against the actual diff before L2 debate.
  *
- * 5 checks (zero model cost):
+ * 6 checks (zero model cost):
  * 1. File existence — filePath must be in diff file list
  * 2. Line range — lineRange must overlap at least one diff hunk
  * 3. Code quote — inline code quotes must exist in diff content
  * 4. Self-contradiction — finding must not contradict observed change direction
  * 5. Speculative language — hedge markers in problem/suggestion dampen confidence
+ * 6. Evidence quality (#468) — vague/short evidence dampens confidence
  *
  * Findings that fail checks 1-2 are hard-removed.
- * Checks 3-5 apply confidence penalties (soft) and may flag as uncertain.
+ * Checks 3-6 apply confidence penalties (soft) and may flag as uncertain.
  */
 
 import type { EvidenceDocument } from '../types/core.js';
 import { extractFileListFromDiff, parseDiffFileRanges } from '@codeagora/shared/utils/diff.js';
+import { scoreEvidence, evidenceMultiplier } from './evidence-scorer.js';
 
 export interface FilterResult {
   filtered: EvidenceDocument[];
@@ -205,13 +207,25 @@ export function filterHallucinations(
       doc.confidence = penalized; // BC: legacy single-field confidence
     }
 
-    // ConfidenceTrace: record post-filter confidence (stage 2 of 5).
-    // Always set before routing so uncertain-bucket docs also carry the trace.
-    // Pass-through (no penalties applied) → filtered === raw.
+    // Check 6 (#468): Evidence quality penalty — vague/short evidence
+    // dampens confidence. The FP class exposed by the #472 baseline
+    // (short template-style problem text, no file:line citations, no
+    // backtick identifiers) scores low here and gets the full ×0.7.
+    const evScore = scoreEvidence(doc);
+    const evMultiplier = evidenceMultiplier(evScore);
+    if (evMultiplier < 1.0) {
+      const penalized = Math.round((doc.confidence ?? 50) * evMultiplier);
+      doc.confidence = penalized; // BC: legacy single-field confidence
+    }
+
+    // ConfidenceTrace: record post-filter confidence + evidence quality.
+    // Always set before routing so uncertain-bucket docs also carry the
+    // trace. Pass-through (no penalties) → filtered === raw.
     if (doc.confidence !== undefined) {
       doc.confidenceTrace = {
         ...(doc.confidenceTrace ?? {}),
         filtered: doc.confidence,
+        evidence: evScore,
       };
     }
 

--- a/packages/core/src/tests/evidence-scorer.test.ts
+++ b/packages/core/src/tests/evidence-scorer.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import type { EvidenceDocument } from '../types/core.js';
+import { scoreEvidence, evidenceMultiplier, __internal } from '../pipeline/evidence-scorer.js';
+
+const { scoreEvidenceCount, scoreProblemLength, scoreSpecificity } = __internal;
+
+function doc(over: Partial<EvidenceDocument> = {}): EvidenceDocument {
+  return {
+    issueTitle: 'title',
+    problem: 'problem',
+    evidence: ['e1'],
+    severity: 'WARNING',
+    suggestion: 's',
+    filePath: 'src/a.ts',
+    lineRange: [10, 10],
+    ...over,
+  };
+}
+
+describe('scoreEvidenceCount', () => {
+  it('0 items → 0', () => {
+    expect(scoreEvidenceCount(doc({ evidence: [] }))).toBe(0);
+  });
+  it('1 item → 0.33', () => {
+    expect(scoreEvidenceCount(doc({ evidence: ['a'] }))).toBe(0.33);
+  });
+  it('2 items → 0.67', () => {
+    expect(scoreEvidenceCount(doc({ evidence: ['a', 'b'] }))).toBe(0.67);
+  });
+  it('3+ items → 1.0', () => {
+    expect(scoreEvidenceCount(doc({ evidence: ['a', 'b', 'c'] }))).toBe(1.0);
+    expect(scoreEvidenceCount(doc({ evidence: new Array(10).fill('x') }))).toBe(1.0);
+  });
+});
+
+describe('scoreProblemLength', () => {
+  it('<50 chars → 0', () => {
+    expect(scoreProblemLength(doc({ problem: 'short problem' }))).toBe(0);
+  });
+  it('50–99 chars → 0.5', () => {
+    expect(scoreProblemLength(doc({ problem: 'x'.repeat(60) }))).toBe(0.5);
+    expect(scoreProblemLength(doc({ problem: 'x'.repeat(99) }))).toBe(0.5);
+  });
+  it('100–299 chars → 0.8', () => {
+    expect(scoreProblemLength(doc({ problem: 'x'.repeat(100) }))).toBe(0.8);
+    expect(scoreProblemLength(doc({ problem: 'x'.repeat(299) }))).toBe(0.8);
+  });
+  it('300+ chars → 1.0', () => {
+    expect(scoreProblemLength(doc({ problem: 'x'.repeat(300) }))).toBe(1.0);
+    expect(scoreProblemLength(doc({ problem: 'x'.repeat(1000) }))).toBe(1.0);
+  });
+});
+
+describe('scoreSpecificity', () => {
+  it('zero markers → 0', () => {
+    expect(scoreSpecificity(doc({ problem: 'This is generic English with no code citations.' }))).toBe(0);
+  });
+  it('file:line citation counts', () => {
+    expect(scoreSpecificity(doc({ problem: 'Bug at moderator.ts:755 inside that function.' }))).toBeGreaterThan(0);
+  });
+  it('backtick identifier counts', () => {
+    expect(scoreSpecificity(doc({ problem: 'The `parseForcedDecisionJson` call ignores errors.' }))).toBeGreaterThan(0);
+  });
+  it('combined markers stack to higher score', () => {
+    const weak = doc({ problem: 'Bug at foo.ts.' });
+    const strong = doc({
+      problem:
+        'Line 755 of `foo.ts`: `parseForcedDecisionJson(input)` invokes `JSON.parse(payload)` without guarding the parseJsonError.',
+    });
+    expect(scoreSpecificity(strong)).toBeGreaterThan(scoreSpecificity(weak));
+    expect(scoreSpecificity(strong)).toBe(1.0);
+  });
+  it('ignores generic capitalised words', () => {
+    expect(scoreSpecificity(doc({ problem: 'In Production Our System Sometimes Throws Exceptions.' }))).toBe(0);
+  });
+});
+
+describe('scoreEvidence (composite)', () => {
+  it('empty doc scores near zero', () => {
+    const s = scoreEvidence(doc({ evidence: [], problem: '' }));
+    expect(s).toBe(0);
+  });
+
+  it('low-quality FP template scores low', () => {
+    // Shape matches the "JSON.parse may throw" FP we observed in
+    // benchmark run #1: short evidence list, mid-length vague problem,
+    // no file:line citation, minimal specificity.
+    const fp = doc({
+      evidence: ['The function does not handle errors.'],
+      problem:
+        'The function may throw an uncaught exception if the input is malformed, which could crash the application.',
+    });
+    expect(scoreEvidence(fp)).toBeLessThan(0.6);
+  });
+
+  it('high-quality bug report scores high', () => {
+    const good = doc({
+      evidence: [
+        'packages/foo.ts:42 calls parseThing(input)',
+        'the return value is never null-checked before .length access',
+        'the caller path includes unauthenticated routes',
+      ],
+      problem:
+        'At `packages/foo.ts:42` the function `parseThing(input)` returns `null` when the input is malformed. The immediately following access `result.length` then dereferences null, producing a `TypeError: Cannot read properties of null`. This path is reachable via unauthenticated requests because `handleRequest()` does not validate the body before dispatch.',
+    });
+    expect(scoreEvidence(good)).toBeGreaterThan(0.8);
+  });
+
+  it('rounds to three decimals', () => {
+    const s = scoreEvidence(doc({ evidence: ['a'], problem: 'x'.repeat(60) }));
+    // (0.33 + 0.5 + specificity) / 3 — value must have at most 3 decimals
+    expect(s).toBe(Math.round(s * 1000) / 1000);
+  });
+});
+
+describe('evidenceMultiplier', () => {
+  it('score 0 → multiplier 0.7', () => {
+    expect(evidenceMultiplier(0)).toBeCloseTo(0.7, 5);
+  });
+  it('score 1 → multiplier 1.0', () => {
+    expect(evidenceMultiplier(1)).toBeCloseTo(1.0, 5);
+  });
+  it('score 0.5 → multiplier 0.85', () => {
+    expect(evidenceMultiplier(0.5)).toBeCloseTo(0.85, 5);
+  });
+  it('clamps out-of-range scores', () => {
+    expect(evidenceMultiplier(-0.5)).toBeCloseTo(0.7, 5);
+    expect(evidenceMultiplier(2)).toBeCloseTo(1.0, 5);
+  });
+});

--- a/packages/core/src/tests/hallucination-filter.test.ts
+++ b/packages/core/src/tests/hallucination-filter.test.ts
@@ -55,13 +55,52 @@ const REMOVALS_ONLY_DIFF = `diff --git a/src/deprecated.ts b/src/deprecated.ts
 // Helper
 // ============================================================================
 
+// Default doc values are intentionally rich so the #468 evidence-quality
+// check (check 6) scores 1.0 → multiplier 1.0 → no penalty. That lets
+// each `describe(Check N)` block exercise its specific check in
+// isolation.
+const DEFAULT_PROBLEM =
+  'At `src/utils.ts:10` the helper `computeValue(input)` is invoked without validating the `options.timeout` parameter. ' +
+  'The call site at line 12 forwards the raw user-provided value directly into `setTimeoutWrapper(input)`, bypassing ' +
+  'the sanitisation performed inside `normaliseTimeout()`. This allows unexpected NaN or negative values to propagate ' +
+  'through the scheduler and eventually land in `setTimeout(callback, value)` where the platform coerces them in ' +
+  'provider-specific ways.';
+const DEFAULT_EVIDENCE = [
+  'Line 10 of `src/utils.ts` introduces the unguarded call to `computeValue(input)`.',
+  'The subsequent call chain `setTimeoutWrapper(input)` → `setTimeout(callback, value)` never validates the argument.',
+  'Comparable helpers such as `normaliseTimeout()` already perform the sanity check but are not applied here.',
+];
+
+/**
+ * Wrap a short, check-specific problem snippet with enough surrounding
+ * context (length + specificity markers + file:line citation) to keep
+ * the #468 evidence-quality sub-scores at 1.0. Use when a test wants to
+ * exercise checks 3–5 against a minimal trigger string without also
+ * taking a check-6 multiplier.
+ *
+ * Padding deliberately avoids backticked code quotes ≥10 chars so it
+ * does not trip Check 3 (fabricated code quote) for diffs that don't
+ * contain those symbols. Specificity is carried by plain-text
+ * file:line citations, `line N` phrasing, and camelCase identifiers.
+ */
+function richProblem(snippet: string): string {
+  return (
+    `At src/utils.ts:10 inside the introduced call: ${snippet} ` +
+    'This bug was introduced on line 10 of src/utils.ts where the new ' +
+    'call site forwards the unvalidated argument into setTimeoutWrapper(input) ' +
+    'without running it through the normaliseTimeout() helper, which means ' +
+    'negative or NaN values can reach setTimeout(callback, value) and trigger ' +
+    'provider-specific coercion that the caller does not expect.'
+  );
+}
+
 function makeDoc(overrides: Partial<EvidenceDocument> = {}): EvidenceDocument {
   return {
     issueTitle: 'Test Issue',
-    problem: 'Some problem description',
-    evidence: ['evidence line'],
+    problem: DEFAULT_PROBLEM,
+    evidence: [...DEFAULT_EVIDENCE],
     severity: 'WARNING',
-    suggestion: 'Fix it',
+    suggestion: 'Add a null check for the timeout value before forwarding to setTimeoutWrapper.',
     filePath: 'src/utils.ts',
     lineRange: [10, 12] as [number, number],
     source: 'llm',
@@ -151,7 +190,7 @@ describe('Check 2: Line range overlap', () => {
 describe('Check 3: Code quote verification', () => {
   it('should penalize confidence for fabricated code quotes', () => {
     const docs = [makeDoc({
-      problem: 'The code `thisIsAFabricatedCodeSnippetThatDoesNotExist` is wrong',
+      problem: richProblem('The code `thisIsAFabricatedCodeSnippetThatDoesNotExist` is wrong'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -162,7 +201,7 @@ describe('Check 3: Code quote verification', () => {
 
   it('should not penalize confidence for real code quotes', () => {
     const docs = [makeDoc({
-      problem: 'The code `const b = computeValue()` is problematic',
+      problem: richProblem('The code `const b = computeValue()` is problematic'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -173,7 +212,7 @@ describe('Check 3: Code quote verification', () => {
 
   it('should ignore short code quotes (< 10 chars)', () => {
     const docs = [makeDoc({
-      problem: 'Variable `x` and `y` are bad',
+      problem: richProblem('Variable `x` and `y` are bad'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -183,7 +222,7 @@ describe('Check 3: Code quote verification', () => {
 
   it('should handle mixed real and fabricated quotes', () => {
     const docs = [makeDoc({
-      problem: 'The `const b = computeValue()` is fine but `totallyFakeCodeThatDoesNotExist` is bad',
+      problem: richProblem('The `const b = computeValue()` is fine but `totallyFakeCodeThatDoesNotExist` is bad'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -194,7 +233,7 @@ describe('Check 3: Code quote verification', () => {
 
   it('should penalize when majority of quotes are fabricated', () => {
     const docs = [makeDoc({
-      problem: '`fakeSnippetOne1234` and `fakeSnippetTwo5678` and `fakeSnippetThreeABC` are wrong',
+      problem: richProblem('`fakeSnippetOne1234` and `fakeSnippetTwo5678` and `fakeSnippetThreeABC` are wrong'),
       confidence: 60,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -203,7 +242,7 @@ describe('Check 3: Code quote verification', () => {
   });
 
   it('should not crash on problem text with no backticks', () => {
-    const docs = [makeDoc({ problem: 'No code quotes here at all', confidence: 80 })];
+    const docs = [makeDoc({ problem: richProblem('No code quotes here at all'), confidence: 80 })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
 
     expect(result.filtered[0].confidence).toBe(80);
@@ -219,7 +258,7 @@ describe('Check 4: Self-contradiction detection', () => {
     const docs = [makeDoc({
       filePath: 'src/deprecated.ts',
       lineRange: [1, 5],
-      problem: 'A new variable was added without type annotation',
+      problem: richProblem('A new variable was added without type annotation'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, REMOVALS_ONLY_DIFF);
@@ -231,7 +270,7 @@ describe('Check 4: Self-contradiction detection', () => {
     const docs = [makeDoc({
       filePath: 'src/new-feature.ts',
       lineRange: [1, 5],
-      problem: 'The function was removed without deprecation notice',
+      problem: richProblem('The function was removed without deprecation notice'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, ADDITIONS_ONLY_DIFF);
@@ -243,7 +282,7 @@ describe('Check 4: Self-contradiction detection', () => {
     const docs = [makeDoc({
       filePath: 'src/new-feature.ts',
       lineRange: [1, 5],
-      problem: 'A new function was added without error handling',
+      problem: richProblem('A new function was added without error handling'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, ADDITIONS_ONLY_DIFF);
@@ -255,7 +294,7 @@ describe('Check 4: Self-contradiction detection', () => {
     const docs = [makeDoc({
       filePath: 'src/new-feature.ts',
       lineRange: [1, 5],
-      problem: 'The function has a potential null reference',
+      problem: richProblem('The function has a potential null reference'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, ADDITIONS_ONLY_DIFF);
@@ -267,7 +306,7 @@ describe('Check 4: Self-contradiction detection', () => {
     const docs = [makeDoc({
       filePath: 'src/deprecated.ts',
       lineRange: [1, 5],
-      problem: 'The new import `totallyFakeCodeSnippetHere` was added incorrectly',
+      problem: richProblem('The new import `totallyFakeCodeSnippetHere` was added incorrectly'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, REMOVALS_ONLY_DIFF);
@@ -287,7 +326,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/utils.ts',
       lineRange: [10, 12],
-      problem: 'The helper may not exist in the target environment, causing runtime failure.',
+      problem: richProblem('The helper may not exist in the target environment, causing runtime failure.'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -299,7 +338,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/utils.ts',
       lineRange: [10, 12],
-      problem: 'Potentially unsupported API invocation for this provider.',
+      problem: richProblem('Potentially unsupported API invocation for this provider.'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -311,7 +350,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/utils.ts',
       lineRange: [10, 12],
-      problem: 'This computation could fail under high concurrency.',
+      problem: richProblem('This computation could fail under high concurrency.'),
       confidence: 90,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -324,13 +363,13 @@ describe('Check 5: Speculative language penalty', () => {
       makeDoc({
         filePath: 'src/utils.ts',
         lineRange: [10, 12],
-        problem: 'The function appears to handle null incorrectly.',
+        problem: richProblem('The function appears to handle null incorrectly.'),
         confidence: 80,
       }),
       makeDoc({
         filePath: 'src/utils.ts',
         lineRange: [10, 12],
-        problem: 'This seems to leak a file handle.',
+        problem: richProblem('This seems to leak a file handle.'),
         confidence: 80,
       }),
     ];
@@ -344,7 +383,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/utils.ts',
       lineRange: [10, 12],
-      problem: 'The helper returns an unchecked value.',
+      problem: richProblem('The helper returns an unchecked value.'),
       suggestion: 'Add a null check; the current code unclear about edge cases.',
       confidence: 80,
     })];
@@ -357,7 +396,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/utils.ts',
       lineRange: [10, 12],
-      problem: 'The helper returns without validating the input range.',
+      problem: richProblem('The helper returns without validating the input range.'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -370,7 +409,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/utils.ts',
       lineRange: [10, 12],
-      problem: 'The May 2026 release introduces a breaking change in this helper.',
+      problem: richProblem('The May 2026 release introduces a breaking change in this helper.'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -382,7 +421,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/deprecated.ts',
       lineRange: [1, 5],
-      problem: 'A new variable was added that may leak memory.',
+      problem: richProblem('A new variable was added that may leak memory.'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, REMOVALS_ONLY_DIFF);
@@ -396,7 +435,7 @@ describe('Check 5: Speculative language penalty', () => {
     const docs = [makeDoc({
       filePath: 'src/utils.ts',
       lineRange: [10, 12],
-      problem: 'The helper appears to mishandle null inputs.',
+      problem: richProblem('The helper appears to mishandle null inputs.'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -415,7 +454,7 @@ describe('Uncertainty routing', () => {
     const docs = [makeDoc({
       filePath: 'src/deprecated.ts',
       lineRange: [1, 5],
-      problem: 'A `totallyFakeCodeSnippetHere` was introduced that is wrong',
+      problem: richProblem('A `totallyFakeCodeSnippetHere` was introduced that is wrong'),
       confidence: 30, // After penalties: 30 * 0.5 (quote) * 0.5 (contradiction) = 8 < 20
     })];
     const result = filterHallucinations(docs, REMOVALS_ONLY_DIFF);
@@ -493,7 +532,7 @@ describe('Edge cases', () => {
 
   it('should handle doc with undefined confidence', () => {
     const docs = [makeDoc({
-      problem: 'The code `thisIsAFabricatedCodeSnippetThatDoesNotExist` is wrong',
+      problem: richProblem('The code `thisIsAFabricatedCodeSnippetThatDoesNotExist` is wrong'),
       confidence: undefined,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -511,7 +550,7 @@ describe('Edge cases', () => {
 describe('ConfidenceTrace: filtered stage', () => {
   it('should populate confidenceTrace.filtered after code-quote penalty', () => {
     const docs = [makeDoc({
-      problem: 'The code `thisIsAFabricatedCodeSnippetThatDoesNotExist` is wrong',
+      problem: richProblem('The code `thisIsAFabricatedCodeSnippetThatDoesNotExist` is wrong'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -523,7 +562,7 @@ describe('ConfidenceTrace: filtered stage', () => {
 
   it('should populate confidenceTrace.filtered as pass-through when no penalty applied', () => {
     const docs = [makeDoc({
-      problem: 'Plain problem description with no fabricated quotes',
+      problem: richProblem('Plain problem description with no fabricated quotes'),
       confidence: 75,
     })];
     const result = filterHallucinations(docs, SAMPLE_DIFF);
@@ -535,7 +574,7 @@ describe('ConfidenceTrace: filtered stage', () => {
     const docs = [makeDoc({
       filePath: 'src/deprecated.ts',
       lineRange: [1, 5],
-      problem: 'A `totallyFakeCodeSnippetHere` was introduced that is wrong',
+      problem: richProblem('A `totallyFakeCodeSnippetHere` was introduced that is wrong'),
       confidence: 30,
     })];
     const result = filterHallucinations(docs, REMOVALS_ONLY_DIFF);

--- a/packages/shared/src/types/confidence-trace.ts
+++ b/packages/shared/src/types/confidence-trace.ts
@@ -61,6 +61,17 @@ export const ConfidenceTraceSchema = z.object({
    * `verified ?? corroborated`.
    */
   final: z.number().min(0).max(100).optional(),
+
+  /**
+   * Evidence quality score (#468). Not a confidence stage — a 0–1 quality
+   * measure recorded by the hallucination filter (check 6) alongside the
+   * `filtered` confidence. Reflects three equally weighted sub-scores:
+   * evidence list length, problem text length, and specificity-marker
+   * density. The derived multiplier (0.7 + 0.3 × evidence) is folded
+   * into the `filtered` value — this field is kept for trace-viewer
+   * introspection and future calibration tuning.
+   */
+  evidence: z.number().min(0).max(1).optional(),
 });
 
 export type ConfidenceTrace = z.infer<typeof ConfidenceTraceSchema>;

--- a/packages/shared/src/utils/confidence-trace-formatter.ts
+++ b/packages/shared/src/utils/confidence-trace-formatter.ts
@@ -169,6 +169,18 @@ export function formatFindingTrace(doc: TraceableDoc, index: number): string[] {
     lines.push(`    ${label}  ${value}   ${row.note}`);
   }
 
+  // Evidence quality (#468) — 0–1 score recorded alongside the filtered
+  // stage. Rendered separately because it's a quality measure, not a
+  // confidence stage. The derived multiplier (0.7 + 0.3 × score) is
+  // already folded into `filtered`.
+  const evidence = doc.confidenceTrace?.evidence;
+  if (typeof evidence === 'number') {
+    const pct = `${Math.round(evidence * 100)}%`.padStart(4);
+    const mult = (0.7 + 0.3 * evidence).toFixed(2);
+    const label = 'evidence'.padEnd(labelWidth);
+    lines.push(`    ${label}  ${pct}   quality (×${mult} applied to filtered)`);
+  }
+
   const tab = classifyTriageTab(doc);
   lines.push(`    → ${tab} tab`);
   return lines;


### PR DESCRIPTION
## Summary
Dampen reviewer confidence based on evidence specificity. Closes the FP class the #472 n=3 baseline exposed.

- `packages/core/src/pipeline/evidence-scorer.ts` — pure `scoreEvidence(doc) → [0, 1]` from three equally weighted sub-scores: `evidence[]` length, `problem` text length, specificity-marker density (file:line, backtick identifiers, camelCase tokens, function calls).
- `packages/core/src/pipeline/hallucination-filter.ts` — check 6 applies `conf × (0.7 + 0.3 × score)` before the trace write. Rule-sourced docs still bypass the whole filter.
- `packages/shared/src/types/confidence-trace.ts` — new `evidence: number` field (0–1 quality, not a confidence stage).
- `packages/shared/src/utils/confidence-trace-formatter.ts` — trace viewer renders the quality score + derived multiplier.

## Why
Today's n=3 baseline run ([#491 → #493](https://github.com/bssm-oss/CodeAgora/pull/493)) triggered the FP branch on every run against the same diff:
- Run 1: CRITICAL×3 about unhandled `JSON.parse`
- Run 2: WARNING×2 about regex DoS + input size
- Run 3: WARNING + CRITICAL about unbounded string length + missing type import

Each claim was a plausible-sounding, code-level assertion backed by 1-line evidence and vague problem text. Check 6 targets exactly that surface.

## Penalty shape
Per issue spec, penalty caps at 30% (multiplier ∈ [0.7, 1.0]). A high-confidence CRITICAL with no specificity can only be knocked from 100 → 70. That's intentional — we don't want to crush real findings that happen to have short evidence.

Penalty strength tuning is the explicit follow-up. This PR delivers the measurement.

## Test plan
- [x] 21 new unit tests in `evidence-scorer.test.ts` — sub-score boundaries + composite + multiplier clamping
- [x] `hallucination-filter.test.ts` updated: rich default problem + `richProblem()` helper keeps checks 1–5 isolated from check 6
- [x] `pnpm test` — 3321 → 3344 passing
- [x] `pnpm typecheck` — clean
- [ ] Benchmark impact measured against n=3 baseline → PR body updated once [run #24668956475](https://github.com/bssm-oss/CodeAgora/actions/runs/24668956475) finishes

## BC
- `evidence` trace field is optional → old sessions still load.
- Filter integration is always-on for LLM-sourced docs. Rule-sourced docs unchanged.
- 23 existing filter tests' hardcoded values were NOT loosened — instead test fixtures were made richer so check 6 scores 1.0 and the assertions still hold. Tests remain strict equality.

## Risks
1. **Penalty too mild for observed FPs** — max 30% caps won't defeat a 100%-confidence FP. This PR is infrastructure + measurement. Tuning follow-up.
2. **Heuristic false negatives on terse real bugs** — a real 1-liner could be penalised. Mitigated by the bounded 0.7 floor and averaging across three signals.
3. **Specificity regex drift** — over-specific regexes might miss legitimate evidence patterns. Kept conservative, extensible via `SPECIFICITY_MATCHERS`.

Blocks: none. Unblocked by: #491, #492, #493.