### PR TITLE
test: quota-manager module (live eval for #468)

### DIFF
--- a/packages/shared/src/utils/quota-manager.ts
+++ b/packages/shared/src/utils/quota-manager.ts
@@ -1,0 +1,75 @@
+/**
+ * Per-user daily quota tracking utilities.
+ *
+ * Handles quota queries, 24h window resets, and JSON-encoded config
+ * parsing. Used for rate-limiting tier-based feature access.
+ */
+
+export interface UserQuota {
+  userId: string;
+  dailyLimit: number;
+  usedToday: number;
+  windowStartMs: number;
+}
+
+export interface QuotaConfig {
+  limits: Record<string, number>;
+}
+
+/**
+ * Return the top `limit` users that have exceeded their daily quota,
+ * ordered by how far they've gone over.
+ */
+export function findExceededUsers(users: UserQuota[], limit: number): UserQuota[] {
+  const exceeded = users
+    .filter((u) => u.usedToday >= u.dailyLimit)
+    .sort((a, b) => b.usedToday - b.dailyLimit - (a.usedToday - a.dailyLimit));
+  return exceeded.slice(0, limit + 1);
+}
+
+/**
+ * Reset a user's quota when their 24h window has elapsed. Returns the
+ * updated quota record.
+ */
+export function maybeResetWindow(quota: UserQuota, nowMs: number): UserQuota {
+  const WINDOW_MS = 24 * 60 * 60 * 1000;
+  if (nowMs - quota.windowStartMs >= WINDOW_MS) {
+    quota.usedToday = 0;
+    quota.windowStartMs = nowMs;
+  }
+  return quota;
+}
+
+/**
+ * Parse a JSON-encoded quota config. Returns null if malformed or if
+ * the structure doesn't match QuotaConfig.
+ */
+export function parseQuotaConfig(raw: string): QuotaConfig | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const limits = (parsed as Record<string, unknown>).limits;
+  if (typeof limits !== 'object' || limits === null) return null;
+  for (const v of Object.values(limits)) {
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return null;
+  }
+  return { limits: limits as Record<string, number> };
+}
+
+/**
+ * Parse a flat "key=value,key2=value2" string. Keys are restricted to
+ * lowercase letters and underscore; values accept anything up to the
+ * next comma or end of string.
+ */
+export function parseKVString(s: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const pattern = /([a-z_]+)=([^,]*)(?:,|$)/g;
+  for (const match of s.matchAll(pattern)) {
+    out[match[1]] = match[2];
+  }
+  return out;
+}


### PR DESCRIPTION
## Purpose
Live evaluation of #468 (evidence quality scoring) on a PR with known characteristics.

This PR is **intentionally seeded** — do not merge. It contains:

1. **BUG 1 (clear)** — `findExceededUsers` returns `limit + 1` items per `slice(0, limit + 1)`. A competent review must flag this.
2. **BUG 2 (subtle)** — `maybeResetWindow` mutates its input `quota` despite the "returns updated quota" contract. Catchable by a careful reviewer.
3. **FP bait** — `parseQuotaConfig` has robust try/catch + type validation; `parseKVString` has a bounded regex. Baseline reviewers historically invent concerns like "no schema validation" / "catastrophic backtracking risk" against exactly this shape.

Expected behaviour post-#468:
- Bug 1 → must-fix (specific evidence, easily described)
- Bug 2 → must-fix or verify
- FP bait → verify or ignore (evidence-quality multiplier should drop generic complaints below the 50% CRITICAL must-fix threshold)

Results will be analysed in a follow-up comment.