### PR TITLE
test(bench): quota-manager-dual golden-bug fixture (#472)

### DIFF
--- a/benchmarks/golden-bugs/quota-manager-dual/diff.patch
+++ b/benchmarks/golden-bugs/quota-manager-dual/diff.patch
@@ -1,0 +1,81 @@
+diff --git a/packages/shared/src/utils/quota-manager.ts b/packages/shared/src/utils/quota-manager.ts
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/packages/shared/src/utils/quota-manager.ts
+@@ -0,0 +1,75 @@
++/**
++ * Per-user daily quota tracking utilities.
++ *
++ * Handles quota queries, 24h window resets, and JSON-encoded config
++ * parsing. Used for rate-limiting tier-based feature access.
++ */
++
++export interface UserQuota {
++  userId: string;
++  dailyLimit: number;
++  usedToday: number;
++  windowStartMs: number;
++}
++
++export interface QuotaConfig {
++  limits: Record<string, number>;
++}
++
++/**
++ * Return the top `limit` users that have exceeded their daily quota,
++ * ordered by how far they've gone over.
++ */
++export function findExceededUsers(users: UserQuota[], limit: number): UserQuota[] {
++  const exceeded = users
++    .filter((u) => u.usedToday >= u.dailyLimit)
++    .sort((a, b) => b.usedToday - b.dailyLimit - (a.usedToday - a.dailyLimit));
++  return exceeded.slice(0, limit + 1);
++}
++
++/**
++ * Reset a user's quota when their 24h window has elapsed. Returns the
++ * updated quota record.
++ */
++export function maybeResetWindow(quota: UserQuota, nowMs: number): UserQuota {
++  const WINDOW_MS = 24 * 60 * 60 * 1000;
++  if (nowMs - quota.windowStartMs >= WINDOW_MS) {
++    quota.usedToday = 0;
++    quota.windowStartMs = nowMs;
++  }
++  return quota;
++}
++
++/**
++ * Parse a JSON-encoded quota config. Returns null if malformed or if
++ * the structure doesn't match QuotaConfig.
++ */
++export function parseQuotaConfig(raw: string): QuotaConfig | null {
++  let parsed: unknown;
++  try {
++    parsed = JSON.parse(raw);
++  } catch {
++    return null;
++  }
++  if (typeof parsed !== 'object' || parsed === null) return null;
++  const limits = (parsed as Record<string, unknown>).limits;
++  if (typeof limits !== 'object' || limits === null) return null;
++  for (const v of Object.values(limits)) {
++    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return null;
++  }
++  return { limits: limits as Record<string, number> };
++}
++
++/**
++ * Parse a flat "key=value,key2=value2" string. Keys are restricted to
++ * lowercase letters and underscore; values accept anything up to the
++ * next comma or end of string.
++ */
++export function parseKVString(s: string): Record<string, string> {
++  const out: Record<string, string> = {};
++  const pattern = /([a-z_]+)=([^,]*)(?:,|$)/g;
++  for (const match of s.matchAll(pattern)) {
++    out[match[1]] = match[2];
++  }
++  return out;
++}

--- a/benchmarks/golden-bugs/quota-manager-dual/expected.json
+++ b/benchmarks/golden-bugs/quota-manager-dual/expected.json
@@ -1,0 +1,25 @@
+{
+  "id": "quota-manager-dual",
+  "title": "quota-manager: off-by-one slice + input mutation",
+  "source": "CodeAgora PR #495 (live-eval harness for #468, not merged)",
+  "category": "hotfix",
+  "expectedFindings": [
+    {
+      "filePath": "packages/shared/src/utils/quota-manager.ts",
+      "lineRange": [27, 27],
+      "lineTolerance": 3,
+      "minSeverity": "WARNING",
+      "rationale": "findExceededUsers returns limit+1 items per page: slice(0, limit + 1). A competent review must flag the off-by-one.",
+      "keyword": "off-by-one"
+    },
+    {
+      "filePath": "packages/shared/src/utils/quota-manager.ts",
+      "lineRange": [34, 36],
+      "lineTolerance": 3,
+      "minSeverity": "WARNING",
+      "rationale": "maybeResetWindow mutates its input quota parameter (quota.usedToday = 0; quota.windowStartMs = nowMs) despite a 'returns updated quota' contract. Breaks purity expectations for callers who share the object.",
+      "keyword": "mutat"
+    }
+  ],
+  "notes": "Recall case derived from the PR #495 live evaluation run for #468. Expected findings correspond to the two real bugs planted in the diff. Also serves as an implicit FP-suppression check: parseQuotaConfig and parseKVString are correct code; any CRITICAL finding against them is evidence that the calibration stack is still generating phantom complaints about generic patterns (JSON.parse / regex DoS / type assertion / missing validation). Generic complaints against these functions should land in verify or suggestion tier, not must-fix."
+}


### PR DESCRIPTION
## Summary
Freeze the PR #495 live-eval diff as a permanent golden-bug fixture. Part of the #472 dataset.

## What it measures
`benchmarks/golden-bugs/quota-manager-dual/` — recall fixture with two expected findings:

| line | severity | bug |
|---|---|---|
| 27 | WARNING+ | off-by-one in `findExceededUsers` (`slice(0, limit + 1)`) |
| 34 | WARNING+ | input mutation in `maybeResetWindow` |

`parseQuotaConfig` and `parseKVString` in the same diff are intentionally correct — they test whether the generic-complaint FP class (JSON.parse / regex / type assertion / missing validation) re-emerges in future calibration changes. The scorer only checks the recall cases; the FP-suppression expectation is documented in `notes` for manual inspection.

## Why
PR #495 was a one-off live test of #468. That run showed:
- BUG 1 → suggestion (under-graded but caught)
- BUG 2 → must-fix × 1 + verify × 3 (correctly identified)
- FP bait → suggestion × 2 (successfully demoted)

Freezing the diff means future calibration tuning (#468 v2, #469, etc.) can measure *its own* impact against this identical input rather than relying on ad-hoc live runs. PR #495 will be closed — the diff lives here now.

## Test plan
- [x] `pnpm bench:fn -- --validate-only` — 5 fixtures validate (was 4)
- [ ] Follow-up PR (#468 v2) can `pnpm bench:fn:run -- --results bench-out --fixtures quota-manager-dual` to directly score the change
- [ ] Recall should stay 2/2 (off-by-one + mutation) on subsequent runs; any run that loses BUG 1 or BUG 2 is a regression