### PR TITLE
fix(ci): provider-health workflow shouldn't fail on missing .ca/ (#487)

### DIFF
--- a/.github/workflows/provider-health.yml
+++ b/.github/workflows/provider-health.yml
@@ -24,6 +24,28 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
+      # doctor --live runs its base environment checks first (.ca/ dir,
+      # config file, API keys, CLIs). Those checks are meaningful for
+      # user environments but not in CI — the workspace is intentionally
+      # missing .ca/ (gitignored) and most CLIs. Write a minimal config
+      # so the env checks pass and the run's exit code reflects only the
+      # live provider pings we actually care about.
+      - name: Generate stub config for doctor
+        run: |
+          mkdir -p .ca
+          cat > .ca/config.json << 'CONF'
+          {
+            "mode": "pragmatic",
+            "language": "en",
+            "reviewers": [
+              { "id": "r1", "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 }
+            ],
+            "moderator": { "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq" },
+            "head": { "backend": "api", "model": "llama-3.3-70b-versatile", "provider": "groq", "enabled": true },
+            "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
+          }
+          CONF
+
       - name: Ping Tier 1 providers
         id: health
         continue-on-error: true


### PR DESCRIPTION
## Problem
Every weekly provider-health cron was creating a spurious \`Provider health check failed\` issue. Latest: #487 (2026-04-20).

Root cause: \`doctor --live\` runs its base environment checks first — including \`.ca/ directory\` and \`Config file\` — and treats missing state as failure. Those checks are correct for a user's local machine but wrong in CI: the workspace intentionally ships without \`.ca/\` (it's gitignored), so the run always fails regardless of actual provider availability.

## Fix
Workflow writes a minimal stub \`.ca/config.json\` before invoking \`doctor --live\`. Stub mirrors the Groq-based shape used by \`review.yml\`'s fallback branch — 1 reviewer + moderator + head.

Now the cron's exit code reflects only the live provider pings, which is what the check was supposed to measure in the first place.

## Alternatives considered
- New \`--providers-only\` flag on \`doctor\` that skips env checks — cleaner API but ~50 LOC change vs 15 LOC here, and CLI users never hit this path
- Delete the workflow — dubious signal anyway, but nice to keep a smoke test against real APIs

## Test plan
- [ ] Trigger once via \`workflow_dispatch\` after merge; verify exit 0 when Groq is healthy
- [ ] Close #487 once green run confirms no new spurious issue