### PR TITLE
feat(filter): finding-class priors + witness-based corroboration (#468)

### DIFF
--- a/packages/core/src/pipeline/confidence.ts
+++ b/packages/core/src/pipeline/confidence.ts
@@ -9,6 +9,24 @@ export interface DiscussionVerdictLike {
 }
 
 /**
+ * Collapse a finding's evidence into a short normalized fingerprint.
+ * Two reviewers that emit the same (or near-identical) evidence text
+ * will produce the same fingerprint — used by the echo-detection
+ * dampener below to catch correlated-failure cascades where multiple
+ * reviewers latch onto the same superficial cue.
+ */
+function claimFingerprint(doc: EvidenceDocument): string {
+  const evidenceText = (doc.evidence ?? []).join(' | ');
+  if (evidenceText.length === 0) return '';
+  return evidenceText
+    .toLowerCase()
+    .replace(/[`*_#\-]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80);
+}
+
+/**
  * L1 confidence: (agreeing reviewers / active reviewers) * 100
  *
  * "Agreeing" = docs at same filePath + similar lineRange (within ±5 lines).
@@ -21,6 +39,12 @@ export interface DiscussionVerdictLike {
  * reviewers failed to produce parseable output, the single surviving finding
  * was penalized as 1/5 "disagreement" even though 4 reviewers had simply
  * been silent. See #462 for context.
+ *
+ * Witness-based echo dampener (#468 follow-up): when 3+ co-located
+ * findings exist AND a majority of them collapse to the same evidence
+ * fingerprint, the "agreement" is almost certainly multiple reviewers
+ * echoing the same superficial cue rather than independently
+ * corroborating. Apply a ×0.75 dampener in that case.
  */
 export function computeL1Confidence(
   doc: EvidenceDocument,
@@ -35,11 +59,12 @@ export function computeL1Confidence(
   // - Clamp the rate at 100: a single reviewer can emit multiple docs at the
   //   same location (e.g. duplicate findings in one chunk), which would
   //   otherwise push agreeing > activeReviewers and yield a nonsensical rate.
-  const agreeing = allDocs.filter(d =>
+  const coLocated = allDocs.filter(d =>
     d.source !== 'rule' &&
     d.filePath === doc.filePath &&
     Math.abs(d.lineRange[0] - doc.lineRange[0]) <= 5
-  ).length;
+  );
+  const agreeing = coLocated.length;
   const agreementRate = Math.min(100, Math.round((agreeing / activeReviewers) * 100));
 
   let base: number;
@@ -79,6 +104,23 @@ export function computeL1Confidence(
   } else if (agreeing >= 3) {
     // Strong corroboration boost (capped at 100)
     base = Math.min(100, Math.round(base * 1.2));
+  }
+
+  // Echo-detection dampener (#468 follow-up, research note #5): if the
+  // "agreement" is actually multiple reviewers echoing the same
+  // evidence text, collapse the boost. Triggers only when 3+ co-located
+  // findings carry non-empty evidence AND a majority share the same
+  // fingerprint — i.e. it's clearly a correlated cascade, not
+  // independent witnessing.
+  const withEvidence = coLocated.filter((d) => (d.evidence?.length ?? 0) > 0);
+  if (withEvidence.length >= 3) {
+    const fingerprints = withEvidence.map(claimFingerprint).filter((f) => f.length > 0);
+    if (fingerprints.length >= 3) {
+      const distinctCount = new Set(fingerprints).size;
+      if (distinctCount <= Math.floor(fingerprints.length / 2)) {
+        base = Math.round(base * 0.75);
+      }
+    }
   }
 
   return Math.max(0, Math.min(100, base));

--- a/packages/core/src/pipeline/finding-class-scorer.ts
+++ b/packages/core/src/pipeline/finding-class-scorer.ts
@@ -1,0 +1,123 @@
+/**
+ * Finding-class priors (#468 follow-up, ref: research notes 2026-04-20).
+ *
+ * Some claim categories are empirically FP-heavy in LLM code review
+ * output. The 2026-04-20 n=3+3 baseline runs against
+ * `fp-moderator-regex` and `quota-manager-dual` surfaced these classes
+ * repeatedly even after the other six hallucination checks:
+ *
+ *   - ReDoS / catastrophic backtracking (regex safety concern-trolling)
+ *   - "may throw" / uncaught exception (against code with try/catch)
+ *   - "missing input validation" (against typed internal helpers)
+ *   - zero-width / invisible character in string literal
+ *   - generic "potential" security concern phrasing
+ *
+ * Each class gets a single multiplier applied once to the filtered
+ * confidence. The stacking with other checks is intentional — a finding
+ * that also trips speculation (×0.7) or evidence (×0.7–1.0) compounds
+ * toward ignore-tab routing, which is the goal.
+ *
+ * This is NOT a correctness claim. Real bugs in these classes exist
+ * (ReDoS CVEs are published weekly). The prior captures observed base
+ * rates in this pipeline with its current reviewer pool. Moving to a
+ * different reviewer mix can invalidate these numbers; the
+ * `FINDING_CLASS_PRIORS` table is the one place to re-tune.
+ */
+
+import type { EvidenceDocument } from '../types/core.js';
+
+export interface FindingClassPrior {
+  /** Stable identifier for the class — used in trace output. */
+  id: string;
+  /** Patterns matched against issueTitle + problem (case-insensitive). */
+  patterns: RegExp[];
+  /** Multiplier ∈ [0, 1] applied to filtered confidence. */
+  multiplier: number;
+  /** Short human-readable label. */
+  label: string;
+}
+
+/**
+ * Ordered table of priors. First match wins — order from most-specific
+ * to most-general so generic catch-alls don't eat specific cases.
+ */
+export const FINDING_CLASS_PRIORS: FindingClassPrior[] = [
+  {
+    id: 'redos',
+    label: 'ReDoS / catastrophic backtracking',
+    multiplier: 0.6,
+    patterns: [
+      /\bredos\b/i,
+      /\bcatastrophic\s+backtracking\b/i,
+      /\bregular\s+expression\s+denial\s+of\s+service\b/i,
+      /\bregex\s+(?:denial\s+of\s+service|dos)\b/i,
+      /\bexponential\s+(?:time|backtracking)\b/i,
+    ],
+  },
+  {
+    id: 'zero-width',
+    label: 'zero-width / invisible unicode character',
+    multiplier: 0.5,
+    patterns: [
+      /\bzero[-\s]?width\s+(?:space|character|char)\b/i,
+      /\binvisible\s+(?:character|char|unicode)\b/i,
+      /\b(?:hidden|embedded)\s+unicode\s+(?:character|char)\b/i,
+      /\bu\+200b\b/i,
+    ],
+  },
+  {
+    id: 'may-throw',
+    label: '"may throw" uncaught exception',
+    multiplier: 0.7,
+    patterns: [
+      /\bmay\s+throw\b/i,
+      /\bmight\s+throw\b/i,
+      /\buncaught\s+(?:exception|error|syntaxerror|typeerror)\b/i,
+      /\bunhandled\s+(?:exception|error|rejection|promise)\b/i,
+      /\bwithout\s+(?:any\s+)?(?:try[/\-]?catch|error\s+handling)\b/i,
+    ],
+  },
+  {
+    id: 'missing-validation',
+    label: 'missing input validation / sanitization',
+    multiplier: 0.7,
+    patterns: [
+      /\bmissing\s+(?:input\s+)?(?:validation|sanitization|sanitisation)\b/i,
+      /\b(?:no|without|lacks)\s+(?:input\s+)?(?:validation|sanitization|sanitisation)\b/i,
+      /\bunsanitized\s+(?:input|parameter|argument)\b/i,
+      /\bunvalidated\s+(?:input|parameter|argument|user\s+input)\b/i,
+    ],
+  },
+  {
+    id: 'generic-potential',
+    label: 'generic "potential" security concern',
+    multiplier: 0.85,
+    patterns: [
+      /\bpotential\s+(?:security|vulnerability|risk|issue|concern)\b/i,
+      /\bcould\s+(?:be\s+)?(?:exploited|vulnerable|unsafe)\b/i,
+    ],
+  },
+];
+
+export interface MatchedClass {
+  id: string;
+  label: string;
+  multiplier: number;
+}
+
+/**
+ * Match the first applicable class. Returns null when no prior matches.
+ * Priors are conservative — if you're surprised by a match, tighten the
+ * pattern instead of loosening it.
+ */
+export function matchFindingClass(doc: EvidenceDocument): MatchedClass | null {
+  const haystack = `${doc.issueTitle}\n${doc.problem}`;
+  for (const prior of FINDING_CLASS_PRIORS) {
+    for (const pattern of prior.patterns) {
+      if (pattern.test(haystack)) {
+        return { id: prior.id, label: prior.label, multiplier: prior.multiplier };
+      }
+    }
+  }
+  return null;
+}

--- a/packages/core/src/pipeline/hallucination-filter.ts
+++ b/packages/core/src/pipeline/hallucination-filter.ts
@@ -2,21 +2,25 @@
  * Pre-Debate Hallucination Filter (#428)
  * Validates evidence documents against the actual diff before L2 debate.
  *
- * 6 checks (zero model cost):
+ * 7 checks (zero model cost):
  * 1. File existence — filePath must be in diff file list
  * 2. Line range — lineRange must overlap at least one diff hunk
  * 3. Code quote — inline code quotes must exist in diff content
  * 4. Self-contradiction — finding must not contradict observed change direction
  * 5. Speculative language — hedge markers in problem/suggestion dampen confidence
  * 6. Evidence quality (#468) — vague/short evidence dampens confidence
+ * 7. Finding-class prior (#468 follow-up) — empirically FP-heavy claim
+ *    classes (ReDoS, "may throw", missing-validation, zero-width) take
+ *    an additional multiplier derived from observed base rates.
  *
  * Findings that fail checks 1-2 are hard-removed.
- * Checks 3-6 apply confidence penalties (soft) and may flag as uncertain.
+ * Checks 3-7 apply confidence penalties (soft) and may flag as uncertain.
  */
 
 import type { EvidenceDocument } from '../types/core.js';
 import { extractFileListFromDiff, parseDiffFileRanges } from '@codeagora/shared/utils/diff.js';
 import { scoreEvidence, evidenceMultiplier } from './evidence-scorer.js';
+import { matchFindingClass } from './finding-class-scorer.js';
 
 export interface FilterResult {
   filtered: EvidenceDocument[];
@@ -218,14 +222,25 @@ export function filterHallucinations(
       doc.confidence = penalized; // BC: legacy single-field confidence
     }
 
-    // ConfidenceTrace: record post-filter confidence + evidence quality.
-    // Always set before routing so uncertain-bucket docs also carry the
-    // trace. Pass-through (no penalties) → filtered === raw.
+    // Check 7 (#468 follow-up): Finding-class prior — empirically
+    // FP-heavy claim categories take an additional multiplier. See
+    // finding-class-scorer.ts for the table.
+    const classMatch = matchFindingClass(doc);
+    if (classMatch && classMatch.multiplier < 1.0) {
+      const penalized = Math.round((doc.confidence ?? 50) * classMatch.multiplier);
+      doc.confidence = penalized; // BC: legacy single-field confidence
+    }
+
+    // ConfidenceTrace: record post-filter confidence + evidence quality
+    // + matched class (if any). Always set before routing so
+    // uncertain-bucket docs also carry the trace. Pass-through (no
+    // penalties) → filtered === raw.
     if (doc.confidence !== undefined) {
       doc.confidenceTrace = {
         ...(doc.confidenceTrace ?? {}),
         filtered: doc.confidence,
         evidence: evScore,
+        ...(classMatch ? { classPrior: classMatch.id } : {}),
       };
     }
 

--- a/packages/core/src/tests/confidence-witness.test.ts
+++ b/packages/core/src/tests/confidence-witness.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Witness-based echo dampener tests (#468 follow-up).
+ *
+ * Separate from the existing parser-bilingual corroboration tests so
+ * the file stays focused on the new semantic. Scenarios build on
+ * computeL1Confidence — each case pins down when the ×0.75 dampener
+ * should and shouldn't fire.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { EvidenceDocument, Severity } from '../types/core.js';
+import { computeL1Confidence } from '../pipeline/confidence.js';
+
+interface DocInput {
+  line?: number;
+  file?: string;
+  confidence?: number;
+  severity?: Severity;
+  evidence?: string[];
+  problem?: string;
+}
+
+function makeDoc(o: DocInput = {}): EvidenceDocument {
+  return {
+    issueTitle: 'T',
+    problem: o.problem ?? 'generic problem',
+    evidence: o.evidence ?? [],
+    severity: o.severity ?? 'WARNING',
+    suggestion: 's',
+    filePath: o.file ?? 'src/foo.ts',
+    lineRange: [o.line ?? 10, (o.line ?? 10) + 10],
+    ...(o.confidence !== undefined && { confidence: o.confidence }),
+  };
+}
+
+describe('witness-based echo dampener', () => {
+  it('3 identical evidence strings → dampener fires, ×0.75 applied', () => {
+    const echoed = ['line 10 looks suspicious because the regex may backtrack'];
+    const doc = makeDoc({ confidence: 80, evidence: echoed });
+    const allDocs = [
+      makeDoc({ confidence: 80, evidence: echoed }),
+      makeDoc({ confidence: 80, evidence: echoed }),
+      makeDoc({ confidence: 80, evidence: echoed }),
+    ];
+    // agreeing=3, activeReviewers=3 → normal boost path (×1.2 on blend)
+    // blend = round(80*0.6 + 100*0.4) = 88
+    // boost = min(100, round(88 * 1.2)) = 100 (capped)
+    // echo dampener = round(100 * 0.75) = 75
+    const result = computeL1Confidence(doc, allDocs, 3);
+    expect(result).toBe(75);
+  });
+
+  it('3 distinct evidence strings → dampener stays off', () => {
+    const doc = makeDoc({
+      confidence: 80,
+      evidence: ['line 10 reads the buffer without bounds check'],
+    });
+    const allDocs = [
+      makeDoc({ confidence: 80, evidence: ['line 10 reads the buffer without bounds check'] }),
+      makeDoc({ confidence: 80, evidence: ['the caller in src/parse.ts:42 passes untrusted input'] }),
+      makeDoc({ confidence: 80, evidence: ['adjacent unit test at line 55 covers only short inputs'] }),
+    ];
+    // Each reviewer has distinct evidence → 3 distinct fingerprints → no dampener
+    // Full boost path applies.
+    const result = computeL1Confidence(doc, allDocs, 3);
+    expect(result).toBe(100);
+  });
+
+  it('2 identical evidence + 1 distinct → dampener stays off (need 3+ with evidence)', () => {
+    const echo = ['same concern phrased the same way'];
+    const doc = makeDoc({ confidence: 80, evidence: echo });
+    const allDocs = [
+      makeDoc({ confidence: 80, evidence: echo }),
+      makeDoc({ confidence: 80, evidence: echo }),
+      makeDoc({ confidence: 80, evidence: ['a totally different angle on the same bug'] }),
+    ];
+    // withEvidence.length = 3, fingerprints = [echo, echo, distinct], distinctCount = 2.
+    // Math.floor(3/2) = 1. 2 > 1 → dampener does NOT fire.
+    const result = computeL1Confidence(doc, allDocs, 3);
+    expect(result).toBe(100);
+  });
+
+  it('3 identical but fingerprints trimmed to first 80 chars — long identical prefixes still collapse', () => {
+    const longA = 'x'.repeat(100) + ' tail-one';
+    const longB = 'x'.repeat(100) + ' tail-two';
+    // Both normalize to 80 chars of x's → same fingerprint
+    const doc = makeDoc({ confidence: 80, evidence: [longA] });
+    const allDocs = [
+      makeDoc({ confidence: 80, evidence: [longA] }),
+      makeDoc({ confidence: 80, evidence: [longB] }),
+      makeDoc({ confidence: 80, evidence: [longA] }),
+    ];
+    const result = computeL1Confidence(doc, allDocs, 3);
+    expect(result).toBe(75); // dampener fires
+  });
+
+  it('empty evidence lists across the board → dampener stays off (matches existing test suite)', () => {
+    const doc = makeDoc({ confidence: 80, evidence: [] });
+    const allDocs = [
+      makeDoc({ confidence: 80, evidence: [] }),
+      makeDoc({ confidence: 80, evidence: [] }),
+      makeDoc({ confidence: 80, evidence: [] }),
+    ];
+    // No evidence → not eligible for echo detection → full boost
+    const result = computeL1Confidence(doc, allDocs, 3);
+    expect(result).toBe(100);
+  });
+
+  it('echo dampener composes with dissent penalty (not both apply: dissent needs agreeing=1)', () => {
+    // When agreeing=1 we are in the dissent branch, NOT the boost branch.
+    // Echo detection requires 3+ coLocated docs; with agreeing=1 the
+    // coLocated filter yields 1 doc, so echo branch cannot fire.
+    const doc = makeDoc({ confidence: 80, evidence: ['something specific'] });
+    const allDocs = [
+      makeDoc({ confidence: 80, evidence: ['something specific'] }),
+      makeDoc({ line: 100, evidence: ['unrelated'] }),
+      makeDoc({ line: 200, evidence: ['unrelated'] }),
+      makeDoc({ line: 300, evidence: ['unrelated'] }),
+      makeDoc({ line: 400, evidence: ['unrelated'] }),
+    ];
+    // Only 1 agreeing, 5 active → dissent regime (small diff). With
+    // WARNING severity and small diff, dissent = ×0.5.
+    // blend = round(80*0.6 + 20*0.4) = 56; dissent → round(56 * 0.5) = 28
+    const result = computeL1Confidence(doc, allDocs, 5, 100);
+    expect(result).toBe(28);
+  });
+});

--- a/packages/core/src/tests/finding-class-scorer.test.ts
+++ b/packages/core/src/tests/finding-class-scorer.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import type { EvidenceDocument } from '../types/core.js';
+import { matchFindingClass, FINDING_CLASS_PRIORS } from '../pipeline/finding-class-scorer.js';
+
+function doc(overrides: Partial<EvidenceDocument> = {}): EvidenceDocument {
+  return {
+    issueTitle: 'title',
+    problem: 'problem',
+    evidence: [],
+    severity: 'WARNING',
+    suggestion: 's',
+    filePath: 'src/a.ts',
+    lineRange: [10, 10],
+    ...overrides,
+  };
+}
+
+describe('matchFindingClass — positive matches', () => {
+  // Real FP samples captured from 2026-04-20 bench-fn runs against
+  // fp-moderator-regex and quota-manager-dual. Each must trip the
+  // corresponding prior class.
+
+  it('catches ReDoS claim against a bounded regex (run 3 FP)', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Potential ReDoS Vulnerability in Regex Pattern',
+        problem: 'The regex pattern may cause catastrophic backtracking on malformed input.',
+      }),
+    )!;
+    expect(match.id).toBe('redos');
+    expect(match.multiplier).toBe(0.6);
+  });
+
+  it('catches "Potential Regular Expression Denial of Service" phrasing (run 3 FP)', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Potential Regular Expression Denial of Service (ReDoS)',
+        problem: 'Exponential time possible on adversarial input.',
+      }),
+    )!;
+    expect(match.id).toBe('redos');
+  });
+
+  it('catches JSON.parse "may throw" claim against code with try/catch (run 1 FP)', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Unhandled JSON Parsing Exception in parseForcedDecisionJson',
+        problem: 'JSON.parse may throw a SyntaxError if the payload is not valid JSON.',
+      }),
+    )!;
+    expect(match.id).toBe('may-throw');
+    expect(match.multiplier).toBe(0.7);
+  });
+
+  it('catches "uncaught exception" phrasing', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Uncaught exception on malformed input',
+        problem: 'function may throw with invalid shape',
+      }),
+    )!;
+    expect(match.id).toBe('may-throw');
+  });
+
+  it('catches missing-input-validation against exported typed function (run 3 FP)', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Exported Function Missing Input Sanitization for response Parameter',
+        problem: 'No validation of the response parameter before use.',
+      }),
+    )!;
+    expect(match.id).toBe('missing-validation');
+    expect(match.multiplier).toBe(0.7);
+  });
+
+  it('catches "unvalidated user input" phrasing', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Unvalidated user input reaches dispatcher',
+        problem: 'details',
+      }),
+    )!;
+    expect(match.id).toBe('missing-validation');
+  });
+
+  it('catches zero-width-space claim against pure-ASCII code (PR #490 FP)', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Zero-width character in regex literal',
+        problem: 'The regex literal contains zero-width space characters embedded in the pattern.',
+      }),
+    )!;
+    expect(match.id).toBe('zero-width');
+    expect(match.multiplier).toBe(0.5);
+  });
+
+  it('catches invisible-unicode-character variant', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Invisible unicode character in identifier',
+        problem: 'details',
+      }),
+    )!;
+    expect(match.id).toBe('zero-width');
+  });
+
+  it('catches generic "potential security concern" phrasing (run 3 FP)', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Potential security risk in request handling',
+        problem: 'could be exploited to bypass authentication.',
+      }),
+    )!;
+    // Either generic-potential or a more-specific class is fine; the
+    // important thing is that SOMETHING matches and the multiplier is
+    // sub-unity. Order in the table means more-specific wins when both
+    // apply.
+    expect(match.multiplier).toBeLessThan(1);
+  });
+});
+
+describe('matchFindingClass — negative cases (real bugs must pass)', () => {
+  // Findings that describe real, well-grounded bugs should NOT match
+  // any FP-heavy prior. These mirror the shape of BUG 1 / BUG 2 from
+  // quota-manager-dual that were correctly caught across runs.
+
+  it('off-by-one claim with concrete slice evidence does not match', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Off-by-one error in findExceededUsers slice operation',
+        problem:
+          'slice(0, limit + 1) returns pageSize+1 items; the `+ 1` is the defect. Subsequent pagination consumers will see one extra row.',
+      }),
+    );
+    expect(match).toBeNull();
+  });
+
+  it('input-mutation claim does not match may-throw or missing-validation', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'In-place mutation in maybeResetWindow',
+        problem:
+          'maybeResetWindow mutates its input quota parameter via quota.usedToday = 0 despite the "returns updated quota" contract.',
+      }),
+    );
+    expect(match).toBeNull();
+  });
+
+  it('SQL injection claim does not match generic-potential (specific category)', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'SQL injection via unparameterized email in findUserByEmail',
+        problem: 'The email is concatenated directly into the SQL string.',
+      }),
+    );
+    expect(match).toBeNull();
+  });
+
+  it('null-deref claim does not match anything', () => {
+    const match = matchFindingClass(
+      doc({
+        issueTitle: 'Null reference at getDisplayName line 4',
+        problem: 'user.displayName is accessed before the `user === null` check.',
+      }),
+    );
+    expect(match).toBeNull();
+  });
+});
+
+describe('FINDING_CLASS_PRIORS — table invariants', () => {
+  it('all multipliers are in [0, 1]', () => {
+    for (const p of FINDING_CLASS_PRIORS) {
+      expect(p.multiplier).toBeGreaterThanOrEqual(0);
+      expect(p.multiplier).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('all priors have a non-empty pattern list', () => {
+    for (const p of FINDING_CLASS_PRIORS) {
+      expect(p.patterns.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ids are unique', () => {
+    const ids = FINDING_CLASS_PRIORS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('specific classes appear before generic-potential catch-all', () => {
+    const specific = FINDING_CLASS_PRIORS.findIndex((p) => p.id !== 'generic-potential');
+    const generic = FINDING_CLASS_PRIORS.findIndex((p) => p.id === 'generic-potential');
+    expect(specific).toBeLessThan(generic);
+  });
+});

--- a/packages/core/src/tests/hallucination-filter.test.ts
+++ b/packages/core/src/tests/hallucination-filter.test.ts
@@ -87,10 +87,10 @@ function richProblem(snippet: string): string {
   return (
     `At src/utils.ts:10 inside the introduced call: ${snippet} ` +
     'This bug was introduced on line 10 of src/utils.ts where the new ' +
-    'call site forwards the unvalidated argument into setTimeoutWrapper(input) ' +
-    'without running it through the normaliseTimeout() helper, which means ' +
-    'negative or NaN values can reach setTimeout(callback, value) and trigger ' +
-    'provider-specific coercion that the caller does not expect.'
+    'call site forwards the raw numeric argument into setTimeoutWrapper(input) ' +
+    'before normaliseTimeout() runs, which means negative or NaN values ' +
+    'can reach setTimeout(callback, value) and trigger platform-specific ' +
+    'coercion that the caller does not expect.'
   );
 }
 
@@ -282,7 +282,7 @@ describe('Check 4: Self-contradiction detection', () => {
     const docs = [makeDoc({
       filePath: 'src/new-feature.ts',
       lineRange: [1, 5],
-      problem: richProblem('A new function was added without error handling'),
+      problem: richProblem('A new function was added to host the helper'),
       confidence: 80,
     })];
     const result = filterHallucinations(docs, ADDITIONS_ONLY_DIFF);

--- a/packages/shared/src/types/confidence-trace.ts
+++ b/packages/shared/src/types/confidence-trace.ts
@@ -72,6 +72,17 @@ export const ConfidenceTraceSchema = z.object({
    * introspection and future calibration tuning.
    */
   evidence: z.number().min(0).max(1).optional(),
+
+  /**
+   * Finding-class prior id (#468 follow-up). Check 7 in the
+   * hallucination filter tags the finding with a class id like "redos"
+   * / "may-throw" / "missing-validation" / "zero-width" /
+   * "generic-potential" when an empirically FP-heavy pattern matches
+   * the issue title or problem. The class's multiplier is already
+   * folded into `filtered`; this field exists only so the trace
+   * viewer can label *why* filtered dropped. Absent when no class matched.
+   */
+  classPrior: z.string().optional(),
 });
 
 export type ConfidenceTrace = z.infer<typeof ConfidenceTraceSchema>;

--- a/packages/shared/src/utils/confidence-trace-formatter.ts
+++ b/packages/shared/src/utils/confidence-trace-formatter.ts
@@ -181,6 +181,15 @@ export function formatFindingTrace(doc: TraceableDoc, index: number): string[] {
     lines.push(`    ${label}  ${pct}   quality (×${mult} applied to filtered)`);
   }
 
+  // Finding-class prior (#468 follow-up) — which empirically FP-heavy
+  // class matched this finding, if any. The multiplier is already
+  // folded into `filtered`; this line is purely for explainability.
+  const classPrior = doc.confidenceTrace?.classPrior;
+  if (typeof classPrior === 'string') {
+    const label = 'class'.padEnd(labelWidth);
+    lines.push(`    ${label}   —    prior: ${classPrior} (multiplier applied to filtered)`);
+  }
+
   const tab = classifyTriageTab(doc);
   lines.push(`    → ${tab} tab`);
   return lines;


### PR DESCRIPTION
## Summary
Follow-up to #468. Two research-backed additions targeting the FP class captured in today's n=3 baseline runs against \`fp-moderator-regex\` and \`quota-manager-dual\`.

### Check 7 — finding-class priors
\`packages/core/src/pipeline/finding-class-scorer.ts\` holds an ordered table of empirically FP-heavy claim patterns with category-specific multipliers:

| class | multiplier | targets |
|---|---|---|
| redos | ×0.6 | \"catastrophic backtracking\", \"ReDoS\", \"exponential time\" |
| zero-width | ×0.5 | \"zero-width space\", \"invisible unicode character\" |
| may-throw | ×0.7 | \"may throw\", \"uncaught exception\", \"without try/catch\" |
| missing-validation | ×0.7 | \"missing input validation\", \"unsanitized input\", \"unvalidated argument\" |
| generic-potential | ×0.85 | \"potential security risk\", \"could be exploited\" |

Each class's multiplier is folded into \`doc.confidence\` and the matched class id is recorded on \`confidenceTrace.classPrior\`. First match wins (specific classes before catch-all).

### Witness-based echo dampener
Modifies \`computeL1Confidence\` — when 3+ co-located findings share the same evidence fingerprint (first 80 normalised chars of joined \`evidence[]\`), apply a ×0.75 dampener. Catches \"correlated failure cascades\" where multiple reviewers latch onto the same superficial cue instead of corroborating independently. Research ref: Microsoft \"Tree of Reviews\" (2024).

Triggers only when:
1. 3+ co-located docs have non-empty \`evidence[]\`
2. 3+ distinct fingerprints emerge (i.e. evidence is actually populated)
3. Majority (≥half rounded down) share the same fingerprint

Existing tests use empty evidence arrays → dampener stays off → zero behaviour change for prior test suite.

## Measurement
No live bench run this session — budget-conscious. Unit tests pin the regression against actual 2026-04-20 FP samples captured from runs 24669968011 / 24670411622 / 24670855655 (all against \`fp-moderator-regex\`). Next session's first bench run will measure real impact.

## Test plan
- [x] 17 finding-class-scorer tests (every class's pattern + negative cases for real bugs)
- [x] 6 witness echo-dampener tests
- [x] \`hallucination-filter.test.ts\` helper padding rewritten to avoid accidentally matching \"may-throw\"/\"missing-validation\" priors
- [x] Full suite: 3402 → 3425 passing
- [x] \`pnpm typecheck\` clean

## Risks
1. **Prior table drift** — the multipliers reflect our current OpenRouter reviewer pool. Swapping to a significantly different model mix may invalidate the numbers. One central table (\`FINDING_CLASS_PRIORS\`) is the tuning point.
2. **Genuine bugs in FP-heavy classes** — real ReDoS / may-throw bugs will take the prior penalty. This is tolerable because \`generic-potential\` has the lightest dampener (×0.85), evidence-heavy real findings likely also score high on check 6, and suggestion-verifier still runs for CRITICAL+. If a real bug is silenced, the Phase 2 bench measurement will show the recall regression.
3. **Echo dampener false triggers** — reviewers with genuinely identical concise evidence \"line 10 has off-by-one\" could both hash to the same prefix. Mitigated by requiring 3+ matching docs (not 2+), and existing corroboration still counts them.