### PR TITLE
test: guard product surface reset

### DIFF
--- a/assets/AGENTS.md
+++ b/assets/AGENTS.md
@@ -4,20 +4,20 @@
 # assets
 
 ## Purpose
-Static assets including logos, icons, and visual brand materials used in documentation, web UI, and public-facing channels.
+Static assets including logos, icons, and visual brand materials used in documentation, the desktop app, and public-facing channels.
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
-| `logo.svg` | CodeAgora brand logo (SVG, 250x250) — dark navy blue (#191A51) geometric design; use in README, website, and releases |
+| `logo.svg` | CodeAgora brand logo (SVG, 250x250) — dark navy blue (#191A51) geometric design; use in README, desktop surfaces, and releases |
 
 ## For AI Agents
 
 ### Working In This Directory
 
 - **Asset format**: SVG (scalable, version-controllable); no raster images required
-- **Logo usage**: Include in documentation, web dashboard, and GitHub profile links with appropriate attribution
+- **Logo usage**: Include in documentation, desktop app surfaces, and GitHub profile links with appropriate attribution
 - **Adding assets**: Keep files organized and minimal; add new assets only when needed for UI/marketing
 - **SVG handling**: Assets are inline-capable; reference via `<img>` tags or CSS backgrounds
 - **Size guidelines**: Logo is 250x250; maintain aspect ratio and readability at smaller sizes
@@ -25,7 +25,7 @@ Static assets including logos, icons, and visual brand materials used in documen
 ### When Referencing Assets
 
 - In docs: use `![CodeAgora](../../assets/logo.svg)` for relative paths from docs/
-- In web UI: import/require SVG assets via build process (no manual CDN links)
+- In desktop UI: import SVG assets through the package build process (no manual CDN links)
 - In README: use `![](assets/logo.svg)` from repo root
 
 <!-- MANUAL: -->

--- a/packages/shared/src/utils/triage.ts
+++ b/packages/shared/src/utils/triage.ts
@@ -1,7 +1,7 @@
 /**
  * Triage Classification
  * Shared logic for classifying evidence documents into must-fix / verify / ignore.
- * Used by CLI output, GitHub PR comments, notifications, and MCP responses.
+ * Used by CLI output, GitHub PR comments, desktop summaries, and MCP responses.
  */
 
 import type { EvidenceDocument } from '../types/evidence.js';

--- a/packages/shared/src/utils/truncate.ts
+++ b/packages/shared/src/utils/truncate.ts
@@ -1,6 +1,6 @@
 /**
- * Text truncation helpers for previews in logs, notifications, and
- * GitHub review bodies where full content is too large.
+ * Text truncation helpers for previews in logs, GitHub review bodies,
+ * and MCP responses where full content is too large.
  */
 
 /**

--- a/src/tests/product-surface-reset.test.ts
+++ b/src/tests/product-surface-reset.test.ts
@@ -1,0 +1,81 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+
+const retiredSurfacePatterns = [
+  /@codeagora\/(?:web|tui|notifications)\b/,
+  /packages\/(?:web|tui|notifications)\b/,
+  /\bagora (?:dashboard|tui|notify)\b/,
+  /review --notify\b/,
+  /--notify\b/,
+];
+
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function listFiles(dir: string, predicate: (file: string) => boolean): string[] {
+  const absoluteDir = path.join(repoRoot, dir);
+  if (!fs.existsSync(absoluteDir)) return [];
+
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+    const absoluteEntry = path.join(absoluteDir, entry.name);
+    const relativeEntry = path.relative(repoRoot, absoluteEntry);
+
+    if (entry.isDirectory()) {
+      if (entry.name === 'dist' || entry.name === 'node_modules') continue;
+      files.push(...listFiles(relativeEntry, predicate));
+      continue;
+    }
+
+    if (entry.isFile() && predicate(relativeEntry)) {
+      files.push(relativeEntry);
+    }
+  }
+
+  return files;
+}
+
+function expectNoRetiredSurfaceReferences(relativePath: string): void {
+  const text = readText(relativePath);
+  for (const pattern of retiredSurfacePatterns) {
+    expect(text, `${relativePath} contains retired surface reference ${pattern}`).not.toMatch(pattern);
+  }
+}
+
+describe('product surface reset', () => {
+  it('does not keep retired workspace package directories', () => {
+    for (const dir of ['packages/web', 'packages/tui', 'packages/notifications']) {
+      expect(fs.existsSync(path.join(repoRoot, dir)), `${dir} should stay retired`).toBe(false);
+    }
+  });
+
+  it('does not advertise retired packages in active manifests and release config', () => {
+    const manifestFiles = [
+      'package.json',
+      'pnpm-workspace.yaml',
+      'tsconfig.json',
+      'vitest.config.ts',
+      'eslint.config.js',
+      'action.yml',
+      '.github/workflows/release.yml',
+      ...listFiles('packages', (file) => file.endsWith('package.json')),
+    ];
+
+    for (const file of manifestFiles) {
+      expectNoRetiredSurfaceReferences(file);
+    }
+  });
+
+  it('does not expose retired CLI commands or notification flags in active source', () => {
+    const sourceFiles = ['packages/cli/src', 'packages/core/src', 'packages/github/src', 'packages/mcp/src', 'packages/shared/src']
+      .flatMap((dir) => listFiles(dir, (file) => file.endsWith('.ts')));
+
+    for (const file of sourceFiles) {
+      expectNoRetiredSurfaceReferences(file);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- clean stale asset/shared comments that still described retired human surfaces as active
- add a product surface reset regression test for retired package dirs, manifests, release config, active source commands, and notification flags

## Verification
- pnpm test src/tests/product-surface-reset.test.ts
- pnpm typecheck
- pnpm test --no-file-parallelism