### PR TITLE
feat: harden benchmark contract and desktop MVP

### DIFF
--- a/.reviewignore
+++ b/.reviewignore
@@ -1,0 +1,2 @@
+# Generated benchmark fixtures contain intentionally vulnerable diffs.
+benchmarks/golden-bugs/**

--- a/benchmarks/golden-bugs/async-stale-profile-cache/diff.patch
+++ b/benchmarks/golden-bugs/async-stale-profile-cache/diff.patch
@@ -1,0 +1,30 @@
+diff --git a/src/profile/cache.ts b/src/profile/cache.ts
+index 3333333..4444444 100644
+--- a/src/profile/cache.ts
++++ b/src/profile/cache.ts
+@@ -1,19 +1,18 @@
+ interface Profile {
+   id: string;
+   displayName: string;
+   updatedAt: number;
+ }
+
+ const cache = new Map<string, Profile>();
+
+ export async function refreshProfile(id: string, load: () => Promise<Profile>): Promise<Profile> {
+-  const fresh = await load();
+-  const current = cache.get(id);
+-  if (!current || fresh.updatedAt >= current.updatedAt) {
+-    cache.set(id, fresh);
+-  }
+-  return fresh;
++  const current = cache.get(id);
++  load().then((fresh) => {
++    cache.set(id, fresh);
++  });
++  return current ?? await load();
+ }
+
+ export function getCachedProfile(id: string): Profile | undefined {
+   return cache.get(id);
+ }

--- a/benchmarks/golden-bugs/async-stale-profile-cache/expected.json
+++ b/benchmarks/golden-bugs/async-stale-profile-cache/expected.json
@@ -1,0 +1,17 @@
+{
+  "id": "async-stale-profile-cache",
+  "title": "refreshProfile can overwrite fresh cache entries with stale async results",
+  "source": "synthetic — async race/stale state",
+  "category": "hotfix",
+  "expectedFindings": [
+    {
+      "filePath": "src/profile/cache.ts",
+      "lineRange": [11, 13],
+      "lineTolerance": 4,
+      "minSeverity": "WARNING",
+      "rationale": "The fire-and-forget load writes to cache without checking updatedAt, so a slower older request can overwrite a newer profile.",
+      "keyword": "cache"
+    }
+  ],
+  "notes": "Recall fixture for async race/stale state. The removed timestamp guard is the key bug."
+}

--- a/benchmarks/golden-bugs/authz-admin-bypass/diff.patch
+++ b/benchmarks/golden-bugs/authz-admin-bypass/diff.patch
@@ -1,0 +1,26 @@
+diff --git a/src/api/admin.ts b/src/api/admin.ts
+index 1111111..2222222 100644
+--- a/src/api/admin.ts
++++ b/src/api/admin.ts
+@@ -1,18 +1,17 @@
+ import { getUser, requireAdmin } from '../auth/session.js';
+ import { deleteUserAccount } from '../users/delete.js';
+
+ export async function deleteAccountHandler(req: Request): Promise<Response> {
+   const actor = await getUser(req);
+   if (!actor) {
+     return new Response('Unauthorized', { status: 401 });
+   }
+-  if (!requireAdmin(actor)) {
+-    return new Response('Forbidden', { status: 403 });
+-  }
+
+   const body = await req.json() as { userId?: string };
+   if (!body.userId) {
+     return new Response('Missing userId', { status: 400 });
+   }
+
++  // Admin UI already hides this action for regular users.
+   await deleteUserAccount(body.userId, actor.id);
+   return new Response(null, { status: 204 });
+ }

--- a/benchmarks/golden-bugs/authz-admin-bypass/expected.json
+++ b/benchmarks/golden-bugs/authz-admin-bypass/expected.json
@@ -1,0 +1,17 @@
+{
+  "id": "authz-admin-bypass",
+  "title": "deleteAccountHandler drops server-side admin authorization",
+  "source": "synthetic — authorization guard removal",
+  "category": "hotfix",
+  "expectedFindings": [
+    {
+      "filePath": "src/api/admin.ts",
+      "lineRange": [15, 15],
+      "lineTolerance": 6,
+      "minSeverity": "CRITICAL",
+      "rationale": "The server no longer calls requireAdmin before deleting another account, so any authenticated user can invoke the handler directly.",
+      "keyword": "admin"
+    }
+  ],
+  "notes": "Recall fixture for auth/authorization: UI gating is not a substitute for server-side access control."
+}

--- a/benchmarks/golden-bugs/env-secret-fallback/diff.patch
+++ b/benchmarks/golden-bugs/env-secret-fallback/diff.patch
@@ -1,0 +1,22 @@
+diff --git a/src/config/auth.ts b/src/config/auth.ts
+index 7777777..8888888 100644
+--- a/src/config/auth.ts
++++ b/src/config/auth.ts
+@@ -1,15 +1,13 @@
+ export interface AuthConfig {
+   issuer: string;
+   jwtSecret: string;
+ }
+
+ export function loadAuthConfig(env: NodeJS.ProcessEnv): AuthConfig {
+-  const jwtSecret = env.JWT_SECRET;
+-  if (!jwtSecret) {
+-    throw new Error('JWT_SECRET is required');
+-  }
++  const jwtSecret = env.JWT_SECRET ?? 'dev-secret';
+
+   return {
+     issuer: env.AUTH_ISSUER ?? 'codeagora',
+     jwtSecret,
+   };
+ }

--- a/benchmarks/golden-bugs/env-secret-fallback/expected.json
+++ b/benchmarks/golden-bugs/env-secret-fallback/expected.json
@@ -1,0 +1,17 @@
+{
+  "id": "env-secret-fallback",
+  "title": "loadAuthConfig silently falls back to a hard-coded JWT secret",
+  "source": "synthetic — API contract/config/env regression",
+  "category": "hotfix",
+  "expectedFindings": [
+    {
+      "filePath": "src/config/auth.ts",
+      "lineRange": [7, 7],
+      "lineTolerance": 3,
+      "minSeverity": "CRITICAL",
+      "rationale": "Missing JWT_SECRET no longer fails closed; production can sign tokens with a public hard-coded secret.",
+      "keyword": "secret"
+    }
+  ],
+  "notes": "Recall fixture for config/env contract regressions where fail-closed validation is replaced with an unsafe default."
+}

--- a/benchmarks/golden-bugs/fp-docs-only-runbook/diff.patch
+++ b/benchmarks/golden-bugs/fp-docs-only-runbook/diff.patch
@@ -1,0 +1,22 @@
+diff --git a/docs/release-runbook.md b/docs/release-runbook.md
+index 9999999..aaaaaaa 100644
+--- a/docs/release-runbook.md
++++ b/docs/release-runbook.md
+@@ -1,10 +1,17 @@
+ # Release runbook
+
+ ## Before publishing
+
+ - Confirm CI is green.
+ - Confirm the changelog has a section for the release.
+ - Confirm the package version was bumped.
+
++## After publishing
++
++- Tag the release commit.
++- Verify the GitHub Action uses the published package.
++- Announce the release in the maintainer channel.
++
+ ## Rollback
+
+ Restore the previous package version and publish a patch release if needed.

--- a/benchmarks/golden-bugs/fp-docs-only-runbook/expected.json
+++ b/benchmarks/golden-bugs/fp-docs-only-runbook/expected.json
@@ -1,0 +1,8 @@
+{
+  "id": "fp-docs-only-runbook",
+  "title": "docs-only release runbook update",
+  "source": "synthetic — docs-only diff",
+  "category": "fp-regression",
+  "expectedFindings": [],
+  "notes": "FP regression fixture: documentation-only changes should not be reported as code defects."
+}

--- a/benchmarks/golden-bugs/fp-stable-sorting-refactor/diff.patch
+++ b/benchmarks/golden-bugs/fp-stable-sorting-refactor/diff.patch
@@ -1,0 +1,23 @@
+diff --git a/src/search/sort.ts b/src/search/sort.ts
+index ddddddd..eeeeeee 100644
+--- a/src/search/sort.ts
++++ b/src/search/sort.ts
+@@ -1,12 +1,16 @@
+ export interface SearchResult {
+   id: string;
+   title: string;
+   score: number;
+ }
+
+ export function sortResults(results: readonly SearchResult[]): SearchResult[] {
+-  return [...results].sort((a, b) => b.score - a.score);
++  return [...results].sort((a, b) => {
++    const scoreOrder = b.score - a.score;
++    if (scoreOrder !== 0) return scoreOrder;
++    return a.title.localeCompare(b.title);
++  });
+ }
+
+ export function topResult(results: readonly SearchResult[]): SearchResult | undefined {
+   return sortResults(results)[0];
+ }

--- a/benchmarks/golden-bugs/fp-stable-sorting-refactor/expected.json
+++ b/benchmarks/golden-bugs/fp-stable-sorting-refactor/expected.json
@@ -1,0 +1,8 @@
+{
+  "id": "fp-stable-sorting-refactor",
+  "title": "deterministic tie-breaker added to search result sorting",
+  "source": "synthetic — sorting false-positive guard",
+  "category": "fp-regression",
+  "expectedFindings": [],
+  "notes": "FP regression fixture: the sort still orders by descending score and only adds a deterministic title tie-breaker."
+}

--- a/benchmarks/golden-bugs/fp-type-only-import-refactor/diff.patch
+++ b/benchmarks/golden-bugs/fp-type-only-import-refactor/diff.patch
@@ -1,0 +1,19 @@
+diff --git a/src/session/serializer.ts b/src/session/serializer.ts
+index bbbbbbb..ccccccc 100644
+--- a/src/session/serializer.ts
++++ b/src/session/serializer.ts
+@@ -1,12 +1,12 @@
+-import { type Session, type SessionPayload } from './types.js';
++import type { Session, SessionPayload } from './types.js';
+
+ export function serializeSession(session: Session): SessionPayload {
+   return {
+     id: session.id,
+     userId: session.userId,
+     expiresAt: session.expiresAt.toISOString(),
+   };
+ }
+
+ export function isExpired(session: Session, now = new Date()): boolean {
+   return session.expiresAt <= now;
+ }

--- a/benchmarks/golden-bugs/fp-type-only-import-refactor/expected.json
+++ b/benchmarks/golden-bugs/fp-type-only-import-refactor/expected.json
@@ -1,0 +1,8 @@
+{
+  "id": "fp-type-only-import-refactor",
+  "title": "type-only import style refactor",
+  "source": "synthetic — import/type false-positive guard",
+  "category": "fp-regression",
+  "expectedFindings": [],
+  "notes": "FP regression fixture: changing inline type imports to an import type declaration is behavior-preserving."
+}

--- a/docs/AGENT_CONTRACT.md
+++ b/docs/AGENT_CONTRACT.md
@@ -66,6 +66,7 @@ Consumers should branch first on `schemaVersion`, then `status`, then `summary.d
 ## NDJSON Stream
 
 `agora review --json-stream` writes newline-delimited JSON only. It does not also print the normal text formatter.
+Each line is one complete JSON object with a `type` discriminator. Consumers should ignore unknown fields and continue reading until a `type: "result"` event arrives.
 
 Progress event:
 
@@ -91,6 +92,7 @@ Progress event fields:
 | `timestamp` | Unix epoch milliseconds |
 
 Result event fields are the same as JSON Result plus `type: "result"`.
+The final result event is always the last contract event emitted by the CLI command.
 
 ## Exit Codes
 
@@ -150,6 +152,20 @@ Session JSON is intentionally smaller than review JSON, but uses the same contra
 ## MCP Alignment
 
 MCP review tools default to compact output to preserve agent context.
+
+Default compact response shape:
+
+```json
+{
+  "decision": "ACCEPT",
+  "reasoning": "No blocking issues.",
+  "issues": [],
+  "summary": "No issues found.",
+  "sessionId": "2026-04-27/001"
+}
+```
+
+For compact MCP output, `decision` is `ACCEPT`, `REJECT`, `NEEDS_HUMAN`, or `ERROR`; `issues` is an array of compact finding objects; `summary` is a short string; and `sessionId` is the review session identifier when available.
 
 When a caller requests `output_format: "json"`, MCP delegates to the same CLI JSON formatter and therefore includes `schemaVersion: "codeagora.review.v1"`.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -38,9 +38,16 @@ agora review --post-review --pr 123          # Post back to PR
 | `--quiet` | Suppress progress output | — |
 | `--verbose` | Show detailed info | — |
 
-**Exit codes:** `0` = command completed and no failure gate tripped, `1` = `--fail-on-reject` or `--fail-on-severity` tripped, `2` = setup/input/config error, `3` = runtime or pipeline failure.
+**Exit codes:**
 
-`--output json` and `--json-stream` use the stable agent contract documented in [Agent Contract](AGENT_CONTRACT.md). JSON objects include `schemaVersion: "codeagora.review.v1"`.
+| Code | Meaning |
+|------|---------|
+| `0` | Review completed and no requested failure gate tripped |
+| `1` | Review completed, but `--fail-on-reject` or `--fail-on-severity` tripped |
+| `2` | Setup, input, or config error |
+| `3` | Runtime or pipeline failure, including `status: "error"` JSON results |
+
+`--output json` and `--json-stream` use the stable agent contract documented in [Agent Contract](AGENT_CONTRACT.md). JSON result objects include `schemaVersion: "codeagora.review.v1"`; NDJSON stream lines include a `type` discriminator (`progress` or `result`).
 
 ## `agora init`
 

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -22,7 +22,7 @@ import { formatOutput, type OutputFormat } from '../formatters/review-output.js'
 import { parseReviewerOption, readStdin } from '../options/review-options.js';
 import { classifyCliErrorExitCode, formatError } from '../utils/errors.js';
 import { dim } from '../utils/colors.js';
-import { formatProgressNdjsonEvent, formatResultNdjsonEvent } from '../utils/agent-contract.js';
+import { formatProgressNdjsonEvent, formatResultNdjsonEvent, getAgentReviewExitCode } from '../utils/agent-contract.js';
 
 // ============================================================================
 // Types
@@ -391,26 +391,12 @@ async function reviewAction(diffPath: string | undefined, options: ReviewOptions
       if (!options.quiet) console.error(t('cli.info.reviewPosted', { url: postResult.reviewUrl }));
     }
 
-    if (result.summary?.decision === 'REJECT' && options.failOnReject) {
-      process.exit(1);
-    }
-
-    // --fail-on-severity: exit 1 if any issue at or above the threshold
-    if (options.failOnSeverity && result.summary?.severityCounts) {
-      const order = ['SUGGESTION', 'WARNING', 'CRITICAL', 'HARSHLY_CRITICAL'];
-      const threshold = order.indexOf(options.failOnSeverity.toUpperCase());
-      if (threshold >= 0) {
-        const hasIssueAtOrAbove = order.slice(threshold).some(
-          (sev) => (result.summary!.severityCounts[sev as keyof typeof result.summary.severityCounts] ?? 0) > 0
-        );
-        if (hasIssueAtOrAbove) {
-          process.exit(1);
-        }
-      }
-    }
-
-    if (result.status !== 'success') {
-      process.exit(3);
+    const exitCode = getAgentReviewExitCode(result, {
+      failOnReject: options.failOnReject,
+      failOnSeverity: options.failOnSeverity,
+    });
+    if (exitCode !== 0) {
+      process.exit(exitCode);
     }
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/cli/src/tests/agent-contract.test.ts
+++ b/packages/cli/src/tests/agent-contract.test.ts
@@ -6,6 +6,8 @@ import {
   formatAgentJson,
   formatProgressNdjsonEvent,
   formatResultNdjsonEvent,
+  getAgentReviewExitCode,
+  shouldFailOnSeverity,
   withAgentContract,
 } from '../utils/agent-contract.js';
 import { classifyCliErrorExitCode } from '../utils/errors.js';
@@ -44,6 +46,23 @@ describe('agent contract helpers', () => {
     const parsed = JSON.parse(formatAgentJson(makeResult())) as Record<string, unknown>;
     expect(parsed['schemaVersion']).toBe('codeagora.review.v1');
     expect(parsed['sessionId']).toBe('001');
+    expect(parsed['type']).toBeUndefined();
+  });
+
+  it('keeps the required JSON result fields at the top level', () => {
+    const parsed = JSON.parse(formatAgentJson(makeResult())) as Record<string, unknown>;
+    expect(parsed).toEqual(expect.objectContaining({
+      schemaVersion: 'codeagora.review.v1',
+      status: 'success',
+      date: '2026-04-27',
+      sessionId: '001',
+      summary: expect.objectContaining({
+        decision: 'ACCEPT',
+        reasoning: 'No blocking issues.',
+      }),
+      evidenceDocs: [],
+      discussions: [],
+    }));
   });
 
   it('formats progress NDJSON events with type=progress', () => {
@@ -59,6 +78,9 @@ describe('agent contract helpers', () => {
     expect(parsed['schemaVersion']).toBe('codeagora.review.v1');
     expect(parsed['type']).toBe('progress');
     expect(parsed['stage']).toBe('review');
+    expect(parsed['event']).toBe('stage-update');
+    expect(parsed['timestamp']).toBe(1777248000000);
+    expect(formatProgressNdjsonEvent(event)).not.toContain('\n');
   });
 
   it('formats result NDJSON events with type=result', () => {
@@ -66,6 +88,7 @@ describe('agent contract helpers', () => {
     expect(parsed['schemaVersion']).toBe('codeagora.review.v1');
     expect(parsed['type']).toBe('result');
     expect(parsed['sessionId']).toBe('001');
+    expect(formatResultNdjsonEvent(makeResult())).not.toContain('\n');
   });
 });
 
@@ -79,5 +102,52 @@ describe('CLI exit code classification', () => {
   it('classifies runtime errors as exit code 3', () => {
     expect(classifyCliErrorExitCode(new Error('Groq rate limit exceeded'))).toBe(3);
     expect(classifyCliErrorExitCode(new Error('Reviewer timed out'))).toBe(3);
+  });
+
+  it('keeps successful reviews at exit code 0 without failure gates', () => {
+    expect(getAgentReviewExitCode(makeResult({
+      summary: {
+        ...makeResult().summary!,
+        decision: 'REJECT',
+      },
+    }))).toBe(0);
+  });
+
+  it('returns exit code 1 when fail-on-reject trips', () => {
+    expect(getAgentReviewExitCode(makeResult({
+      summary: {
+        ...makeResult().summary!,
+        decision: 'REJECT',
+      },
+    }), { failOnReject: true })).toBe(1);
+  });
+
+  it('returns exit code 1 when fail-on-severity trips', () => {
+    expect(shouldFailOnSeverity({
+      SUGGESTION: 2,
+      WARNING: 0,
+      CRITICAL: 1,
+      HARSHLY_CRITICAL: 0,
+    }, 'CRITICAL')).toBe(true);
+
+    expect(getAgentReviewExitCode(makeResult({
+      summary: {
+        ...makeResult().summary!,
+        severityCounts: {
+          SUGGESTION: 2,
+          WARNING: 0,
+          CRITICAL: 1,
+          HARSHLY_CRITICAL: 0,
+        },
+      },
+    }), { failOnSeverity: 'CRITICAL' })).toBe(1);
+  });
+
+  it('returns exit code 3 for pipeline error results', () => {
+    expect(getAgentReviewExitCode(makeResult({
+      status: 'error',
+      error: 'Pipeline failed',
+      summary: undefined,
+    }))).toBe(3);
   });
 });

--- a/packages/cli/src/utils/agent-contract.ts
+++ b/packages/cli/src/utils/agent-contract.ts
@@ -8,6 +8,7 @@ import type { ProgressEvent } from '@codeagora/core/pipeline/progress.js';
 export const AGENT_CONTRACT_VERSION = 'codeagora.review.v1' as const;
 
 export type AgentContractVersion = typeof AGENT_CONTRACT_VERSION;
+export type AgentReviewExitCode = 0 | 1 | 3;
 
 export type AgentJsonResult = PipelineResult & {
   schemaVersion: AgentContractVersion;
@@ -21,6 +22,18 @@ export type AgentProgressNdjsonEvent = ProgressEvent & {
 export type AgentResultNdjsonEvent = AgentJsonResult & {
   type: 'result';
 };
+
+export interface AgentReviewExitOptions {
+  failOnReject?: boolean;
+  failOnSeverity?: string;
+}
+
+export const REVIEW_SEVERITY_ORDER = [
+  'SUGGESTION',
+  'WARNING',
+  'CRITICAL',
+  'HARSHLY_CRITICAL',
+] as const;
 
 export function withAgentContract(result: PipelineResult): AgentJsonResult {
   return {
@@ -46,4 +59,37 @@ export function formatResultNdjsonEvent(result: PipelineResult): string {
     type: 'result',
     ...withAgentContract(result),
   } satisfies AgentResultNdjsonEvent);
+}
+
+export function shouldFailOnSeverity(
+  severityCounts: Record<string, number> | undefined,
+  thresholdSeverity: string | undefined,
+): boolean {
+  if (!severityCounts || !thresholdSeverity) return false;
+
+  const threshold = REVIEW_SEVERITY_ORDER.indexOf(
+    thresholdSeverity.toUpperCase() as typeof REVIEW_SEVERITY_ORDER[number],
+  );
+  if (threshold < 0) return false;
+
+  return REVIEW_SEVERITY_ORDER.slice(threshold).some(
+    (severity) => (severityCounts[severity] ?? 0) > 0,
+  );
+}
+
+export function getAgentReviewExitCode(
+  result: PipelineResult,
+  options: AgentReviewExitOptions = {},
+): AgentReviewExitCode {
+  if (result.status !== 'success') return 3;
+
+  if (options.failOnReject && result.summary?.decision === 'REJECT') {
+    return 1;
+  }
+
+  if (shouldFailOnSeverity(result.summary?.severityCounts, options.failOnSeverity)) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/packages/core/src/l2/deduplication.ts
+++ b/packages/core/src/l2/deduplication.ts
@@ -90,6 +90,10 @@ function areDuplicates(d1: Discussion, d2: Discussion): boolean {
     return false;
   }
 
+  if (hasSameRootCauseSignal(d1, d2)) {
+    return true;
+  }
+
   // Check issue title similarity with adaptive threshold (L-17)
   const similarity = calculateTitleSimilarity(d1.issueTitle, d2.issueTitle);
   return similarity > similarityThreshold(d1.issueTitle, d2.issueTitle);
@@ -116,6 +120,106 @@ function calculateTitleSimilarity(title1: string, title2: string): number {
 
   if (union.size === 0) return 0;
   return intersection.size / union.size;
+}
+
+const ROOT_CAUSE_CLASSES: Array<[string, RegExp]> = [
+  ['authz', /\b(authz|authori[sz]ation|permission|privilege|role|rbac|admin|access control|bypass)\b/i],
+  ['authn', /\b(authn|authentication|login|session|token|jwt|cookie|credential)\b/i],
+  ['secret', /\b(secret|api[_ -]?key|private[_ -]?key|credential|password|env|fallback)\b/i],
+  ['injection', /\b(sql|command|shell|template|ldap|xpath|injection|sanitize|escape)\b/i],
+  ['xss', /\b(xss|cross-site|html injection|innerhtml|script)\b/i],
+  ['race', /\b(race|concurren|stale|cache|async|await|promise|timing)\b/i],
+  ['null', /\b(null|undefined|nil|none|optional|dereference)\b/i],
+  ['path', /\b(path traversal|directory traversal|\.\.\/|filepath|filename)\b/i],
+  ['crypto', /\b(crypto|encrypt|decrypt|hash|random|nonce|iv|cipher)\b/i],
+  ['resource', /\b(leak|resource|close|dispose|connection|handle)\b/i],
+];
+
+const GENERIC_REVIEW_WORDS = new Set([
+  'bug',
+  'issue',
+  'problem',
+  'risk',
+  'missing',
+  'possible',
+  'potential',
+  'critical',
+  'warning',
+  'suggestion',
+  'allows',
+  'allow',
+  'could',
+  'should',
+  'may',
+  'review',
+  'code',
+]);
+
+function discussionText(discussion: Discussion): string {
+  return [
+    discussionIssueText(discussion),
+    discussion.codeSnippet,
+  ].join(' ');
+}
+
+function discussionIssueText(discussion: Discussion): string {
+  const evidenceText = discussion.evidenceContent
+    ?.flatMap((doc) => [
+      doc.issueTitle,
+      doc.problem,
+      doc.suggestion,
+      ...doc.evidence,
+    ])
+    .join(' ') ?? '';
+
+  return [
+    discussion.issueTitle,
+    evidenceText,
+  ].join(' ');
+}
+
+function rootCauseClasses(discussion: Discussion): Set<string> {
+  const text = discussionIssueText(discussion);
+  return new Set(
+    ROOT_CAUSE_CLASSES
+      .filter(([, pattern]) => pattern.test(text))
+      .map(([name]) => name)
+  );
+}
+
+function normalizedSignalTokens(discussion: Discussion): Set<string> {
+  const tokens = discussionText(discussion)
+    .toLowerCase()
+    .match(/[a-z0-9_$]{3,}/g) ?? [];
+
+  return new Set(
+    tokens.filter((token) => !GENERIC_REVIEW_WORDS.has(token))
+  );
+}
+
+function tokenOverlapScore(a: Set<string>, b: Set<string>): number {
+  const smaller = a.size <= b.size ? a : b;
+  const larger = a.size <= b.size ? b : a;
+  if (smaller.size === 0) return 0;
+
+  let overlap = 0;
+  for (const token of smaller) {
+    if (larger.has(token)) overlap++;
+  }
+  return overlap / smaller.size;
+}
+
+function hasSameRootCauseSignal(d1: Discussion, d2: Discussion): boolean {
+  const classes1 = rootCauseClasses(d1);
+  const classes2 = rootCauseClasses(d2);
+  const sharedClass = [...classes1].some((className) => classes2.has(className));
+  if (!sharedClass) {
+    return false;
+  }
+
+  const tokens1 = normalizedSignalTokens(d1);
+  const tokens2 = normalizedSignalTokens(d2);
+  return tokenOverlapScore(tokens1, tokens2) >= 0.35;
 }
 
 /**

--- a/packages/core/src/l3/grouping.ts
+++ b/packages/core/src/l3/grouping.ts
@@ -58,7 +58,7 @@ export function groupDiff(diffContent: string): FileGroup[] {
  */
 function splitDiffByFile(diff: string): Map<string, string> {
   const result = new Map<string, string>();
-  const sections = diff.split(/(?=diff --git)/);
+  const sections = diff.split(/(?=^diff --git )/m);
 
   for (const section of sections) {
     const match = section.match(/diff --git a\/(.+?) b\/(.+)/);

--- a/packages/core/src/pipeline/analyzers/diff-classifier.ts
+++ b/packages/core/src/pipeline/analyzers/diff-classifier.ts
@@ -189,7 +189,7 @@ export function classifyDiffFiles(
   const result = new Map<string, FileClassification>();
   if (!diffContent.trim()) return result;
 
-  const sections = diffContent.split(/(?=diff --git )/);
+  const sections = diffContent.split(/(?=^diff --git )/m);
 
   for (const section of sections) {
     const trimmed = section.trim();

--- a/packages/core/src/pipeline/chunker.ts
+++ b/packages/core/src/pipeline/chunker.ts
@@ -53,7 +53,7 @@ export function estimateTokens(text: string): number {
 export function parseDiffFiles(diff: string): ParsedDiffFile[] {
   if (!diff.trim()) return [];
 
-  const sections = diff.split(/(?=diff --git )/);
+  const sections = diff.split(/(?=^diff --git )/m);
   const files: ParsedDiffFile[] = [];
 
   for (const section of sections) {

--- a/packages/core/src/rules/matcher.ts
+++ b/packages/core/src/rules/matcher.ts
@@ -26,7 +26,7 @@ interface DiffFile {
 function parseDiffFiles(diffContent: string): DiffFile[] {
   const files: DiffFile[] = [];
   // Split on file headers
-  const sections = diffContent.split(/(?=diff --git )/);
+  const sections = diffContent.split(/(?=^diff --git )/m);
 
   for (const section of sections) {
     if (!section.trim()) continue;

--- a/packages/core/src/tests/l2-dedup.test.ts
+++ b/packages/core/src/tests/l2-dedup.test.ts
@@ -87,6 +87,27 @@ describe('findDuplicates', () => {
     expect(map.get('d001')).toContain('d002');
     expect(map.get('d001')).toContain('d003');
   });
+
+  it('groups same root-cause security findings with different wording', () => {
+    const d1 = makeDiscussion({
+      id: 'd001',
+      filePath: 'src/admin.ts',
+      lineRange: [42, 48],
+      issueTitle: 'Admin endpoint bypasses authorization',
+      codeSnippet: '42 | router.post("/admin", async (req) => deleteUser(req.body.id));',
+    });
+    const d2 = makeDiscussion({
+      id: 'd002',
+      filePath: 'src/admin.ts',
+      lineRange: [43, 47],
+      issueTitle: 'Missing permission check before destructive route',
+      codeSnippet: '43 | router.post("/admin", async (req) => deleteUser(req.body.id));',
+    });
+
+    const map = findDuplicates([d1, d2]);
+
+    expect(map.get('d001')).toContain('d002');
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/tests/pipeline-chunker.test.ts
+++ b/packages/core/src/tests/pipeline-chunker.test.ts
@@ -76,6 +76,26 @@ diff --git a/src/b.ts b/src/b.ts
     expect(files).toHaveLength(2);
     expect(files.map((f) => f.filePath)).toEqual(['src/a.ts', 'src/b.ts']);
   });
+
+  it('does not split on diff headers embedded in added file content', () => {
+    const diff = `diff --git a/benchmarks/golden-bugs/example/diff.patch b/benchmarks/golden-bugs/example/diff.patch
+new file mode 100644
+--- /dev/null
++++ b/benchmarks/golden-bugs/example/diff.patch
+@@ -0,0 +1,7 @@
++diff --git a/src/admin.ts b/src/admin.ts
++--- a/src/admin.ts
+++++ b/src/admin.ts
++@@ -1,3 +1,2 @@
++ const user = getUser(req);
++-requireAdmin(user);
++ deleteAccount(user.id);
+`;
+    const files = parseDiffFiles(diff);
+    expect(files).toHaveLength(1);
+    expect(files[0].filePath).toBe('benchmarks/golden-bugs/example/diff.patch');
+    expect(files[0].content).toContain('+diff --git a/src/admin.ts b/src/admin.ts');
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/tests/pre-analysis.test.ts
+++ b/packages/core/src/tests/pre-analysis.test.ts
@@ -192,6 +192,23 @@ diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
     expect(result.get('README.md')).toBe('docs');
     expect(result.get('pnpm-lock.yaml')).toBe('dependency');
   });
+
+  it('should not classify embedded diff headers as separate files', () => {
+    const diff = `diff --git a/benchmarks/golden-bugs/example/diff.patch b/benchmarks/golden-bugs/example/diff.patch
+--- a/benchmarks/golden-bugs/example/diff.patch
++++ b/benchmarks/golden-bugs/example/diff.patch
+@@ -1,2 +1,5 @@
++diff --git a/src/admin.ts b/src/admin.ts
++--- a/src/admin.ts
++++ b/src/admin.ts
+++export function adminOnly(user) { return true; }
+`;
+
+    const result = classifyDiffFiles(diff);
+
+    expect([...result.keys()]).toEqual(['benchmarks/golden-bugs/example/diff.patch']);
+    expect(result.get('benchmarks/golden-bugs/example/diff.patch')).toBe('logic');
+  });
 });
 
 // ============================================================================

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -36,7 +36,13 @@ fn read_json(path: &Path) -> Option<Value> {
 }
 
 fn read_optional_text(path: &Path) -> Option<String> {
-    fs::read_to_string(path).ok().filter(|raw| !raw.trim().is_empty())
+    fs::read_to_string(path)
+        .ok()
+        .filter(|raw| !raw.trim().is_empty())
+}
+
+fn read_session_verdict(dir: &Path) -> Option<Value> {
+    read_json(&dir.join("head-verdict.json")).or_else(|| read_json(&dir.join("result.json")))
 }
 
 fn session_parts(id: &str) -> Result<(&str, &str), String> {
@@ -44,8 +50,12 @@ fn session_parts(id: &str) -> Result<(&str, &str), String> {
     let date = parts.next().unwrap_or_default();
     let session_id = parts.next().unwrap_or_default();
     if parts.next().is_some()
-        || !date.chars().all(|char| char.is_ascii_digit() || char == '-')
-        || !session_id.chars().all(|char| char.is_ascii_alphanumeric() || char == '-' || char == '_')
+        || !date
+            .chars()
+            .all(|char| char.is_ascii_digit() || char == '-')
+        || !session_id
+            .chars()
+            .all(|char| char.is_ascii_alphanumeric() || char == '-' || char == '_')
         || date.is_empty()
         || session_id.is_empty()
     {
@@ -73,9 +83,20 @@ fn status_from_metadata(metadata: Option<&Value>) -> String {
 
 fn updated_at_from_metadata(metadata: Option<&Value>) -> Option<String> {
     let millis = metadata
-        .and_then(|value| value.get("completedAt").or_else(|| value.get("startedAt")).or_else(|| value.get("timestamp")))
+        .and_then(|value| {
+            value
+                .get("completedAt")
+                .or_else(|| value.get("startedAt"))
+                .or_else(|| value.get("timestamp"))
+        })
         .and_then(Value::as_i64)?;
     Some(millis.to_string())
+}
+
+fn summary_object(verdict: Option<&Value>) -> Option<&serde_json::Map<String, Value>> {
+    verdict
+        .and_then(|value| value.get("summary"))
+        .and_then(Value::as_object)
 }
 
 fn issue_objects(verdict: Option<&Value>) -> Vec<Value> {
@@ -85,11 +106,25 @@ fn issue_objects(verdict: Option<&Value>) -> Vec<Value> {
     ["issues", "findings", "items"]
         .iter()
         .find_map(|key| verdict.get(key).and_then(Value::as_array))
+        .or_else(|| {
+            verdict
+                .get("summary")
+                .and_then(|summary| summary.get("topIssues"))
+                .and_then(Value::as_array)
+        })
+        .or_else(|| verdict.get("evidenceDocs").and_then(Value::as_array))
         .cloned()
         .unwrap_or_default()
 }
 
-fn severity_counts(issues: &[Value]) -> Value {
+fn severity_counts(verdict: Option<&Value>, issues: &[Value]) -> Value {
+    if let Some(counts) = summary_object(verdict)
+        .and_then(|summary| summary.get("severityCounts"))
+        .and_then(Value::as_object)
+    {
+        return Value::Object(counts.clone());
+    }
+
     let mut counts = serde_json::Map::new();
     for issue in issues {
         let severity = issue
@@ -102,8 +137,40 @@ fn severity_counts(issues: &[Value]) -> Value {
     Value::Object(counts)
 }
 
-fn top_issues(issues: &[Value]) -> Vec<Value> {
-    issues
+fn text_field<'a>(value: Option<&'a Value>, keys: &[&str]) -> Option<&'a str> {
+    let value = value?;
+    for key in keys {
+        if let Some(found) = value.get(*key).and_then(Value::as_str) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn verdict_decision(verdict: Option<&Value>) -> Option<&str> {
+    text_field(verdict, &["decision", "verdict"]).or_else(|| {
+        summary_object(verdict)
+            .and_then(|summary| summary.get("decision"))
+            .and_then(Value::as_str)
+    })
+}
+
+fn verdict_reasoning(verdict: Option<&Value>) -> Option<&str> {
+    text_field(verdict, &["reasoning", "summary"]).or_else(|| {
+        summary_object(verdict)
+            .and_then(|summary| summary.get("reasoning"))
+            .and_then(Value::as_str)
+    })
+}
+
+fn top_issues(verdict: Option<&Value>, issues: &[Value]) -> Vec<Value> {
+    let source = summary_object(verdict)
+        .and_then(|summary| summary.get("topIssues"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_else(|| issues.to_vec());
+
+    source
         .iter()
         .take(5)
         .map(|issue| {
@@ -140,7 +207,13 @@ fn top_issues(issues: &[Value]) -> Vec<Value> {
         .collect()
 }
 
-fn session_entry(date: &str, session_id: &str, dir: &Path, metadata: Option<&Value>, verdict: Option<&Value>) -> Value {
+fn session_entry(
+    date: &str,
+    session_id: &str,
+    dir: &Path,
+    metadata: Option<&Value>,
+    verdict: Option<&Value>,
+) -> Value {
     let id = format!("{date}/{session_id}");
     let issues = issue_objects(verdict);
     json!({
@@ -149,14 +222,10 @@ fn session_entry(date: &str, session_id: &str, dir: &Path, metadata: Option<&Val
         "sessionId": session_id,
         "status": status_from_metadata(metadata),
         "dirPath": dir.display().to_string(),
-        "decision": verdict
-            .and_then(|value| value.get("decision").or_else(|| value.get("verdict")))
-            .and_then(Value::as_str),
-        "reasoning": verdict
-            .and_then(|value| value.get("reasoning").or_else(|| value.get("summary")))
-            .and_then(Value::as_str),
-        "severityCounts": severity_counts(&issues),
-        "topIssues": top_issues(&issues),
+        "decision": verdict_decision(verdict),
+        "reasoning": verdict_reasoning(verdict),
+        "severityCounts": severity_counts(verdict, &issues),
+        "topIssues": top_issues(verdict, &issues),
         "updatedAt": updated_at_from_metadata(metadata),
     })
 }
@@ -169,12 +238,16 @@ fn session_detail_value(id: &str) -> Result<Value, String> {
 
     let (date, session_id) = session_parts(id)?;
     let metadata = read_json(&dir.join("metadata.json"));
-    let verdict = read_json(&dir.join("head-verdict.json"));
+    let verdict = read_session_verdict(&dir);
     let markdown = read_optional_text(&dir.join("report.md"))
         .or_else(|| read_optional_text(&dir.join("result.md")))
         .or_else(|| read_optional_text(&dir.join("suggestions.md")));
-    let evidence_count = fs::read_dir(dir.join("reviews")).map(|entries| entries.count()).unwrap_or(0);
-    let discussions_count = fs::read_dir(dir.join("discussions")).map(|entries| entries.count()).unwrap_or(0);
+    let evidence_count = fs::read_dir(dir.join("reviews"))
+        .map(|entries| entries.count())
+        .unwrap_or(0);
+    let discussions_count = fs::read_dir(dir.join("discussions"))
+        .map(|entries| entries.count())
+        .unwrap_or(0);
 
     Ok(json!({
         "entry": session_entry(date, session_id, &dir, metadata.as_ref(), verdict.as_ref()),
@@ -240,7 +313,10 @@ fn list_sessions() -> Result<Value, String> {
 
     for date_entry in date_dirs {
         let date = date_entry.file_name().to_string_lossy().to_string();
-        if !date.chars().all(|char| char.is_ascii_digit() || char == '-') {
+        if !date
+            .chars()
+            .all(|char| char.is_ascii_digit() || char == '-')
+        {
             continue;
         }
         let mut session_dirs = fs::read_dir(date_entry.path())
@@ -255,8 +331,14 @@ fn list_sessions() -> Result<Value, String> {
             let session_id = session_entry_dir.file_name().to_string_lossy().to_string();
             let dir = session_entry_dir.path();
             let metadata = read_json(&dir.join("metadata.json"));
-            let verdict = read_json(&dir.join("head-verdict.json"));
-            sessions.push(session_entry(&date, &session_id, &dir, metadata.as_ref(), verdict.as_ref()));
+            let verdict = read_session_verdict(&dir);
+            sessions.push(session_entry(
+                &date,
+                &session_id,
+                &dir,
+                metadata.as_ref(),
+                verdict.as_ref(),
+            ));
             if sessions.len() >= 25 {
                 return Ok(json!({ "schemaVersion": "codeagora.review.v1", "sessions": sessions }));
             }
@@ -282,9 +364,12 @@ fn run_review(app: tauri::AppHandle, staged: bool) -> Result<CommandResult, Stri
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let session_id = stdout.lines().rev().find_map(|line| {
-        serde_json::from_str::<Value>(line)
-            .ok()
-            .and_then(|value| value.get("sessionId").and_then(|id| id.as_str()).map(str::to_owned))
+        serde_json::from_str::<Value>(line).ok().and_then(|value| {
+            value
+                .get("sessionId")
+                .and_then(|id| id.as_str())
+                .map(str::to_owned)
+        })
     });
 
     let result = CommandResult {
@@ -305,7 +390,8 @@ fn run_review(app: tauri::AppHandle, staged: bool) -> Result<CommandResult, Stri
 #[tauri::command]
 fn read_config() -> Result<DesktopConfig, String> {
     let path = repo_root()?.join(".ca").join("config.json");
-    let raw = fs::read_to_string(&path).unwrap_or_else(|_| "{\n  \"language\": \"en\",\n  \"reviewers\": []\n}\n".to_string());
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|_| "{\n  \"language\": \"en\",\n  \"reviewers\": []\n}\n".to_string());
     Ok(DesktopConfig {
         raw,
         path: path.display().to_string(),

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
+use serde_json::{json, Value};
 use std::fs;
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri_plugin_notification::NotificationExt;
 
@@ -18,8 +20,183 @@ struct DesktopConfig {
     path: String,
 }
 
+#[derive(Serialize)]
+struct RepoInfo {
+    path: String,
+}
+
 fn repo_root() -> Result<PathBuf, String> {
     std::env::current_dir().map_err(|error| error.to_string())
+}
+
+fn read_json(path: &Path) -> Option<Value> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+}
+
+fn read_optional_text(path: &Path) -> Option<String> {
+    fs::read_to_string(path).ok().filter(|raw| !raw.trim().is_empty())
+}
+
+fn session_parts(id: &str) -> Result<(&str, &str), String> {
+    let mut parts = id.split('/');
+    let date = parts.next().unwrap_or_default();
+    let session_id = parts.next().unwrap_or_default();
+    if parts.next().is_some()
+        || !date.chars().all(|char| char.is_ascii_digit() || char == '-')
+        || !session_id.chars().all(|char| char.is_ascii_alphanumeric() || char == '-' || char == '_')
+        || date.is_empty()
+        || session_id.is_empty()
+    {
+        return Err(format!("Invalid session id: {id}"));
+    }
+    Ok((date, session_id))
+}
+
+fn sessions_root() -> Result<PathBuf, String> {
+    Ok(repo_root()?.join(".ca").join("sessions"))
+}
+
+fn session_dir(id: &str) -> Result<PathBuf, String> {
+    let (date, session_id) = session_parts(id)?;
+    Ok(sessions_root()?.join(date).join(session_id))
+}
+
+fn status_from_metadata(metadata: Option<&Value>) -> String {
+    metadata
+        .and_then(|value| value.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn updated_at_from_metadata(metadata: Option<&Value>) -> Option<String> {
+    let millis = metadata
+        .and_then(|value| value.get("completedAt").or_else(|| value.get("startedAt")).or_else(|| value.get("timestamp")))
+        .and_then(Value::as_i64)?;
+    Some(millis.to_string())
+}
+
+fn issue_objects(verdict: Option<&Value>) -> Vec<Value> {
+    let Some(verdict) = verdict else {
+        return Vec::new();
+    };
+    ["issues", "findings", "items"]
+        .iter()
+        .find_map(|key| verdict.get(key).and_then(Value::as_array))
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn severity_counts(issues: &[Value]) -> Value {
+    let mut counts = serde_json::Map::new();
+    for issue in issues {
+        let severity = issue
+            .get("severity")
+            .and_then(Value::as_str)
+            .unwrap_or("SUGGESTION");
+        let current = counts.get(severity).and_then(Value::as_u64).unwrap_or(0);
+        counts.insert(severity.to_string(), json!(current + 1));
+    }
+    Value::Object(counts)
+}
+
+fn top_issues(issues: &[Value]) -> Vec<Value> {
+    issues
+        .iter()
+        .take(5)
+        .map(|issue| {
+            let line = issue
+                .get("line")
+                .and_then(Value::as_i64)
+                .or_else(|| issue.get("lineNumber").and_then(Value::as_i64))
+                .unwrap_or(0);
+            let line_range = issue
+                .get("lineRange")
+                .and_then(Value::as_array)
+                .and_then(|range| {
+                    let start = range.first().and_then(Value::as_i64)?;
+                    let end = range.get(1).and_then(Value::as_i64).unwrap_or(start);
+                    Some(json!([start, end]))
+                })
+                .unwrap_or_else(|| json!([line, line]));
+            json!({
+                "severity": issue.get("severity").and_then(Value::as_str).unwrap_or("SUGGESTION"),
+                "filePath": issue.get("filePath")
+                    .or_else(|| issue.get("file"))
+                    .or_else(|| issue.get("path"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown"),
+                "lineRange": line_range,
+                "title": issue.get("title")
+                    .or_else(|| issue.get("description"))
+                    .or_else(|| issue.get("message"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("Untitled finding"),
+                "confidence": issue.get("confidence").cloned().unwrap_or(Value::Null)
+            })
+        })
+        .collect()
+}
+
+fn session_entry(date: &str, session_id: &str, dir: &Path, metadata: Option<&Value>, verdict: Option<&Value>) -> Value {
+    let id = format!("{date}/{session_id}");
+    let issues = issue_objects(verdict);
+    json!({
+        "id": id,
+        "date": date,
+        "sessionId": session_id,
+        "status": status_from_metadata(metadata),
+        "dirPath": dir.display().to_string(),
+        "decision": verdict
+            .and_then(|value| value.get("decision").or_else(|| value.get("verdict")))
+            .and_then(Value::as_str),
+        "reasoning": verdict
+            .and_then(|value| value.get("reasoning").or_else(|| value.get("summary")))
+            .and_then(Value::as_str),
+        "severityCounts": severity_counts(&issues),
+        "topIssues": top_issues(&issues),
+        "updatedAt": updated_at_from_metadata(metadata),
+    })
+}
+
+fn session_detail_value(id: &str) -> Result<Value, String> {
+    let dir = session_dir(id)?;
+    if !dir.is_dir() {
+        return Err(format!("Session not found: {id}"));
+    }
+
+    let (date, session_id) = session_parts(id)?;
+    let metadata = read_json(&dir.join("metadata.json"));
+    let verdict = read_json(&dir.join("head-verdict.json"));
+    let markdown = read_optional_text(&dir.join("report.md"))
+        .or_else(|| read_optional_text(&dir.join("result.md")))
+        .or_else(|| read_optional_text(&dir.join("suggestions.md")));
+    let evidence_count = fs::read_dir(dir.join("reviews")).map(|entries| entries.count()).unwrap_or(0);
+    let discussions_count = fs::read_dir(dir.join("discussions")).map(|entries| entries.count()).unwrap_or(0);
+
+    Ok(json!({
+        "entry": session_entry(date, session_id, &dir, metadata.as_ref(), verdict.as_ref()),
+        "metadata": metadata,
+        "verdict": verdict,
+        "markdown": markdown,
+        "evidenceCount": evidence_count,
+        "discussionsCount": discussions_count,
+    }))
+}
+
+fn run_agora(args: &[&str]) -> io::Result<std::process::Output> {
+    let root = repo_root().map_err(io::Error::other)?;
+    match Command::new("agora").args(args).current_dir(&root).output() {
+        Ok(output) => Ok(output),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Command::new("pnpm")
+            .args(["exec", "agora"])
+            .args(args)
+            .current_dir(root)
+            .output(),
+        Err(error) => Err(error),
+    }
 }
 
 fn notify_review_finished(app: &tauri::AppHandle, result: &CommandResult) {
@@ -39,33 +216,59 @@ fn notify_review_finished(app: &tauri::AppHandle, result: &CommandResult) {
 }
 
 #[tauri::command]
-fn list_sessions() -> Result<serde_json::Value, String> {
-    let output = Command::new("agora")
-        .args(["sessions", "list", "--json"])
-        .current_dir(repo_root()?)
-        .output()
-        .map_err(|error| error.to_string())?;
-
-    if !output.status.success() {
-        return Err(String::from_utf8_lossy(&output.stderr).to_string());
-    }
-
-    serde_json::from_slice(&output.stdout).map_err(|error| error.to_string())
+fn get_repo_info() -> Result<RepoInfo, String> {
+    Ok(RepoInfo {
+        path: repo_root()?.display().to_string(),
+    })
 }
 
 #[tauri::command]
-fn get_session_detail(id: String) -> Result<serde_json::Value, String> {
-    let output = Command::new("agora")
-        .args(["sessions", "show", &id, "--json"])
-        .current_dir(repo_root()?)
-        .output()
-        .map_err(|error| error.to_string())?;
-
-    if !output.status.success() {
-        return Err(String::from_utf8_lossy(&output.stderr).to_string());
+fn list_sessions() -> Result<Value, String> {
+    let root = sessions_root()?;
+    if !root.exists() {
+        return Ok(json!({ "schemaVersion": "codeagora.review.v1", "sessions": [] }));
     }
 
-    serde_json::from_slice(&output.stdout).map_err(|error| error.to_string())
+    let mut sessions = Vec::new();
+    let mut date_dirs = fs::read_dir(&root)
+        .map_err(|error| error.to_string())?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .collect::<Vec<_>>();
+    date_dirs.sort_by_key(|entry| entry.file_name());
+    date_dirs.reverse();
+
+    for date_entry in date_dirs {
+        let date = date_entry.file_name().to_string_lossy().to_string();
+        if !date.chars().all(|char| char.is_ascii_digit() || char == '-') {
+            continue;
+        }
+        let mut session_dirs = fs::read_dir(date_entry.path())
+            .map_err(|error| error.to_string())?
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().is_dir())
+            .collect::<Vec<_>>();
+        session_dirs.sort_by_key(|entry| entry.file_name());
+        session_dirs.reverse();
+
+        for session_entry_dir in session_dirs {
+            let session_id = session_entry_dir.file_name().to_string_lossy().to_string();
+            let dir = session_entry_dir.path();
+            let metadata = read_json(&dir.join("metadata.json"));
+            let verdict = read_json(&dir.join("head-verdict.json"));
+            sessions.push(session_entry(&date, &session_id, &dir, metadata.as_ref(), verdict.as_ref()));
+            if sessions.len() >= 25 {
+                return Ok(json!({ "schemaVersion": "codeagora.review.v1", "sessions": sessions }));
+            }
+        }
+    }
+
+    Ok(json!({ "schemaVersion": "codeagora.review.v1", "sessions": sessions }))
+}
+
+#[tauri::command]
+fn get_session_detail(id: String) -> Result<Value, String> {
+    session_detail_value(&id)
 }
 
 #[tauri::command]
@@ -75,17 +278,14 @@ fn run_review(app: tauri::AppHandle, staged: bool) -> Result<CommandResult, Stri
         args.push("--staged");
     }
 
-    let output = Command::new("agora")
-        .args(args)
-        .current_dir(repo_root()?)
-        .output()
-        .map_err(|error| error.to_string())?;
+    let output = run_agora(&args).map_err(|error| error.to_string())?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let last_line = stdout.lines().last().unwrap_or("");
-    let session_id = serde_json::from_str::<serde_json::Value>(last_line)
-        .ok()
-        .and_then(|value| value.get("sessionId").and_then(|id| id.as_str()).map(str::to_owned));
+    let session_id = stdout.lines().rev().find_map(|line| {
+        serde_json::from_str::<Value>(line)
+            .ok()
+            .and_then(|value| value.get("sessionId").and_then(|id| id.as_str()).map(str::to_owned))
+    });
 
     let result = CommandResult {
         ok: output.status.success(),
@@ -105,7 +305,7 @@ fn run_review(app: tauri::AppHandle, staged: bool) -> Result<CommandResult, Stri
 #[tauri::command]
 fn read_config() -> Result<DesktopConfig, String> {
     let path = repo_root()?.join(".ca").join("config.json");
-    let raw = fs::read_to_string(&path).map_err(|error| error.to_string())?;
+    let raw = fs::read_to_string(&path).unwrap_or_else(|_| "{\n  \"language\": \"en\",\n  \"reviewers\": []\n}\n".to_string());
     Ok(DesktopConfig {
         raw,
         path: path.display().to_string(),
@@ -116,6 +316,9 @@ fn read_config() -> Result<DesktopConfig, String> {
 fn write_config(raw: String) -> Result<DesktopConfig, String> {
     serde_json::from_str::<serde_json::Value>(&raw).map_err(|error| error.to_string())?;
     let path = repo_root()?.join(".ca").join("config.json");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
     fs::write(&path, &raw).map_err(|error| error.to_string())?;
     Ok(DesktopConfig {
         raw,
@@ -131,7 +334,8 @@ fn main() {
             get_session_detail,
             run_review,
             read_config,
-            write_config
+            write_config,
+            get_repo_info
         ])
         .run(tauri::generate_context!())
         .expect("failed to run CodeAgora desktop app");

--- a/packages/desktop/src/api/desktop-bridge.ts
+++ b/packages/desktop/src/api/desktop-bridge.ts
@@ -20,6 +20,7 @@ export interface SessionSummary {
   date: string;
   sessionId: string;
   status: 'completed' | 'failed' | 'interrupted' | 'in_progress' | 'unknown';
+  dirPath?: string;
   decision?: ReviewDecision;
   reasoning?: string;
   severityCounts?: SeverityCounts;
@@ -44,6 +45,10 @@ export interface DesktopConfig {
   path: string;
 }
 
+export interface RepoInfo {
+  path: string;
+}
+
 type TauriInvoke = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
 type JsonObject = Record<string, unknown>;
 
@@ -56,12 +61,21 @@ interface CliSessionEntry {
   date?: unknown;
   sessionId?: unknown;
   status?: unknown;
+  dirPath?: unknown;
+  decision?: unknown;
+  reasoning?: unknown;
+  severityCounts?: unknown;
+  topIssues?: unknown;
+  updatedAt?: unknown;
 }
 
 interface CliSessionDetail {
   entry?: CliSessionEntry;
   metadata?: JsonObject;
   verdict?: JsonObject;
+  markdown?: unknown;
+  evidenceCount?: unknown;
+  discussionsCount?: unknown;
 }
 
 declare global {
@@ -120,6 +134,14 @@ function asString(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback;
 }
 
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asObject(value: unknown): JsonObject | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as JsonObject : undefined;
+}
+
 function severityCountsFromVerdict(verdict?: JsonObject): SeverityCounts {
   const counts: SeverityCounts = {};
   for (const issue of extractIssues(verdict)) {
@@ -138,15 +160,64 @@ function extractIssues(verdict?: JsonObject): JsonObject[] {
   return [];
 }
 
+function severityCountsFromValue(value: unknown, verdict?: JsonObject): SeverityCounts {
+  const raw = asObject(value);
+  if (!raw) return severityCountsFromVerdict(verdict);
+  const counts: SeverityCounts = {};
+  for (const key of ['HARSHLY_CRITICAL', 'CRITICAL', 'WARNING', 'SUGGESTION'] as const) {
+    const count = raw[key];
+    if (typeof count === 'number') counts[key] = count;
+  }
+  return counts;
+}
+
+function normalizeIssue(issue: JsonObject): TopIssue {
+  return {
+    severity: asString(issue['severity'], 'SUGGESTION'),
+    filePath: asString(issue['filePath'] ?? issue['file'] ?? issue['path'], 'unknown'),
+    lineRange: Array.isArray(issue['lineRange'])
+      ? [Number(issue['lineRange'][0] ?? 0), Number(issue['lineRange'][1] ?? issue['lineRange'][0] ?? 0)]
+      : [Number(issue['line'] ?? issue['lineNumber'] ?? 0), Number(issue['line'] ?? issue['lineNumber'] ?? 0)],
+    title: asString(issue['title'] ?? issue['description'] ?? issue['message'], JSON.stringify(issue)),
+    confidence: asNumber(issue['confidence']),
+  };
+}
+
+function normalizeTopIssues(value: unknown, verdict?: JsonObject): TopIssue[] {
+  const issues = Array.isArray(value)
+    ? value.filter((item): item is JsonObject => typeof item === 'object' && item !== null)
+    : extractIssues(verdict).slice(0, 5);
+  return issues.map(normalizeIssue);
+}
+
+function timestampFromValue(raw: unknown): string | undefined {
+  if (typeof raw === 'number') return new Date(raw).toISOString();
+  if (typeof raw === 'string' && /^\d+$/.test(raw)) return new Date(Number(raw)).toISOString();
+  return typeof raw === 'string' ? raw : undefined;
+}
+
+function timestampFromMetadata(metadata?: JsonObject): string | undefined {
+  const raw = metadata?.['completedAt'] ?? metadata?.['startedAt'] ?? metadata?.['timestamp'];
+  return timestampFromValue(raw);
+}
+
 function normalizeEntry(entry: CliSessionEntry): SessionSummary {
   const date = asString(entry.date);
   const sessionId = asString(entry.sessionId);
   const id = asString(entry.id, date && sessionId ? `${date}/${sessionId}` : 'unknown');
+  const verdict = asObject((entry as JsonObject)['verdict']);
+  const decision = asString(entry.decision ?? verdict?.['decision'] ?? verdict?.['verdict']) as ReviewDecision | '';
   return {
     id,
     date,
     sessionId,
     status: asString(entry.status, 'unknown') as SessionSummary['status'],
+    dirPath: asString(entry.dirPath) || undefined,
+    decision: decision || undefined,
+    reasoning: asString(entry.reasoning ?? verdict?.['reasoning'] ?? verdict?.['summary']) || undefined,
+    severityCounts: severityCountsFromValue(entry.severityCounts, verdict),
+    topIssues: normalizeTopIssues(entry.topIssues, verdict),
+    updatedAt: timestampFromValue(entry.updatedAt),
   };
 }
 
@@ -155,30 +226,18 @@ function normalizeDetail(detail: CliSessionDetail): SessionDetail {
   const verdict = detail.verdict;
   const metadata = detail.metadata;
   const issues = extractIssues(verdict);
-  const decision = asString(verdict?.['decision'] ?? verdict?.['verdict']) as ReviewDecision | '';
-  const reasoning = asString(verdict?.['reasoning'] ?? verdict?.['summary']);
+  const decision = asString(entry.decision ?? verdict?.['decision'] ?? verdict?.['verdict']) as ReviewDecision | '';
+  const reasoning = asString(entry.reasoning ?? verdict?.['reasoning'] ?? verdict?.['summary']);
   return {
     ...entry,
     decision: decision || undefined,
     reasoning,
-    severityCounts: severityCountsFromVerdict(verdict),
-    topIssues: issues.slice(0, 5).map((issue) => ({
-      severity: asString(issue['severity'], 'SUGGESTION'),
-      filePath: asString(issue['filePath'] ?? issue['file'] ?? issue['path'], 'unknown'),
-      lineRange: Array.isArray(issue['lineRange'])
-        ? [Number(issue['lineRange'][0] ?? 0), Number(issue['lineRange'][1] ?? issue['lineRange'][0] ?? 0)]
-        : [Number(issue['line'] ?? 0), Number(issue['line'] ?? 0)],
-      title: asString(issue['title'] ?? issue['description'] ?? issue['message'], JSON.stringify(issue)),
-      confidence: typeof issue['confidence'] === 'number' ? issue['confidence'] : undefined,
-    })),
-    updatedAt: typeof metadata?.['completedAt'] === 'number'
-      ? new Date(metadata['completedAt']).toISOString()
-      : typeof metadata?.['timestamp'] === 'number'
-        ? new Date(metadata['timestamp']).toISOString()
-        : undefined,
-    evidenceCount: issues.length,
-    discussionsCount: Array.isArray(verdict?.['discussions']) ? verdict['discussions'].length : undefined,
-    markdown: [
+    severityCounts: entry.severityCounts ?? severityCountsFromVerdict(verdict),
+    topIssues: entry.topIssues?.length ? entry.topIssues : normalizeTopIssues(undefined, verdict),
+    updatedAt: entry.updatedAt ?? timestampFromMetadata(metadata),
+    evidenceCount: asNumber(detail.evidenceCount) ?? issues.length,
+    discussionsCount: asNumber(detail.discussionsCount) ?? (Array.isArray(verdict?.['discussions']) ? verdict['discussions'].length : undefined),
+    markdown: asString(detail.markdown) || [
       `# Review ${entry.id}`,
       '',
       `Decision: ${decision || entry.status}`,
@@ -243,4 +302,10 @@ export async function writeConfig(raw: string): Promise<DesktopConfig> {
   if (invoke) return invoke<DesktopConfig>('write_config', { raw });
   window.localStorage.setItem('codeagora.desktop.config', raw);
   return { path: '.ca/config.json', raw };
+}
+
+export async function getRepoInfo(): Promise<RepoInfo> {
+  const invoke = getInvoke();
+  if (invoke) return invoke<RepoInfo>('get_repo_info');
+  return { path: window.location.pathname.includes('/packages/desktop/') ? 'browser preview' : window.location.pathname };
 }

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import {
+  getRepoInfo,
   getSessionDetail,
   listSessions,
   readConfig,
@@ -14,6 +15,9 @@ interface AppState {
   view: View;
   sessions: SessionSummary[];
   selected?: SessionDetail;
+  repoPath: string;
+  sessionSearch: string;
+  sessionStatus: 'all' | SessionSummary['status'];
   configRaw: string;
   configPath: string;
   notice?: string;
@@ -23,6 +27,9 @@ interface AppState {
 const state: AppState = {
   view: 'sessions',
   sessions: [],
+  repoPath: '',
+  sessionSearch: '',
+  sessionStatus: 'all',
   configRaw: '',
   configPath: '.ca/config.json',
   busy: false,
@@ -35,6 +42,23 @@ const appRoot = app;
 function severityTotal(session: SessionSummary): number {
   const counts = session.severityCounts ?? {};
   return Object.values(counts).reduce((sum, value) => sum + (value ?? 0), 0);
+}
+
+function filteredSessions(): SessionSummary[] {
+  const query = state.sessionSearch.trim().toLowerCase();
+  return state.sessions.filter((session) => {
+    if (state.sessionStatus !== 'all' && session.status !== state.sessionStatus) return false;
+    if (!query) return true;
+    const haystack = [
+      session.id,
+      session.status,
+      session.decision,
+      session.reasoning,
+      session.dirPath,
+      ...(session.topIssues ?? []).flatMap((issue) => [issue.title, issue.filePath, issue.severity]),
+    ].filter(Boolean).join(' ').toLowerCase();
+    return haystack.includes(query);
+  });
 }
 
 function decisionClass(decision?: string): string {
@@ -58,6 +82,7 @@ function el<K extends keyof HTMLElementTagNameMap>(
 function button(label: string, onClick: () => void, className = 'button'): HTMLButtonElement {
   const node = el('button', className, label);
   node.type = 'button';
+  node.disabled = state.busy;
   node.addEventListener('click', onClick);
   return node;
 }
@@ -81,6 +106,15 @@ async function refreshSessions(selectFirst = false): Promise<void> {
     state.busy = false;
     render();
   }
+}
+
+async function loadRepoInfo(): Promise<void> {
+  try {
+    state.repoPath = (await getRepoInfo()).path;
+  } catch (error) {
+    state.repoPath = error instanceof Error ? error.message : String(error);
+  }
+  render();
 }
 
 async function selectSession(id: string): Promise<void> {
@@ -180,7 +214,7 @@ function renderToolbar(): HTMLElement {
   const toolbar = el('header', 'toolbar');
   const title = el('div');
   title.append(el('h1', '', state.view === 'sessions' ? 'Review Sessions' : state.view === 'run' ? 'Run Review' : 'Configuration'));
-  title.append(el('p', '', 'Local UI for CodeAgora reviews, backed by CLI/core session data.'));
+  title.append(el('p', '', state.repoPath || 'Loading repository...'));
   toolbar.append(title);
 
   const actions = el('div', 'toolbar-actions');
@@ -210,22 +244,57 @@ function renderContent(): HTMLElement {
 
 function renderSessions(): HTMLElement {
   const layout = el('div', 'sessions-layout');
-  const list = el('div', 'session-list');
-  if (state.sessions.length === 0) {
-    list.append(el('p', 'empty', 'No sessions found yet.'));
+  const listPanel = el('div', 'session-list');
+  const controls = el('div', 'session-controls');
+  const search = el('input', 'filter-input') as HTMLInputElement;
+  search.type = 'search';
+  search.placeholder = 'Filter sessions';
+  search.value = state.sessionSearch;
+  search.addEventListener('input', () => {
+    state.sessionSearch = search.value;
+    render();
+  });
+  const status = el('select', 'filter-select') as HTMLSelectElement;
+  for (const option of ['all', 'completed', 'failed', 'interrupted', 'in_progress', 'unknown'] as const) {
+    const node = el('option') as HTMLOptionElement;
+    node.value = option;
+    node.textContent = option === 'all' ? 'All statuses' : option.replace('_', ' ');
+    node.selected = state.sessionStatus === option;
+    status.append(node);
   }
-  for (const session of state.sessions) {
+  status.addEventListener('change', () => {
+    state.sessionStatus = status.value as AppState['sessionStatus'];
+    render();
+  });
+  controls.append(search, status);
+  listPanel.append(controls);
+
+  const sessions = filteredSessions();
+  const summary = el('div', 'list-summary', `${sessions.length} of ${state.sessions.length} sessions`);
+  listPanel.append(summary);
+  if (state.sessions.length === 0) {
+    listPanel.append(el('p', 'empty padded', 'No sessions found yet.'));
+  } else if (sessions.length === 0) {
+    listPanel.append(el('p', 'empty padded', 'No sessions match the current filter.'));
+  }
+  for (const session of sessions) {
     const item = button('', () => void selectSession(session.id), state.selected?.id === session.id ? 'session-row selected' : 'session-row');
     const top = el('div', 'session-row-top');
     top.append(el('strong', '', session.id));
     top.append(el('span', decisionClass(session.decision), session.decision ?? session.status));
     item.append(top);
-    item.append(el('span', 'session-meta', `${severityTotal(session)} issues · ${session.updatedAt ?? 'no timestamp'}`));
-    list.append(item);
+    item.append(el('span', 'session-meta', `${severityTotal(session)} issues · ${formatTimestamp(session.updatedAt)}`));
+    listPanel.append(item);
   }
-  layout.append(list);
+  layout.append(listPanel);
   layout.append(renderSessionDetail());
   return layout;
+}
+
+function formatTimestamp(value?: string): string {
+  if (!value) return 'no timestamp';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 
 function renderSessionDetail(): HTMLElement {
@@ -240,6 +309,12 @@ function renderSessionDetail(): HTMLElement {
   head.append(el('div', decisionClass(selected.decision), selected.decision ?? selected.status));
   head.append(el('h2', '', selected.id));
   detail.append(head);
+  const meta = el('div', 'detail-meta');
+  meta.append(el('span', '', selected.dirPath ?? '.ca/sessions'));
+  meta.append(el('span', '', `Updated ${formatTimestamp(selected.updatedAt)}`));
+  meta.append(el('span', '', `${selected.evidenceCount ?? 0} evidence docs`));
+  meta.append(el('span', '', `${selected.discussionsCount ?? 0} discussion files`));
+  detail.append(meta);
   detail.append(el('p', 'reasoning', selected.reasoning ?? 'No reasoning recorded.'));
 
   const counts = selected.severityCounts ?? {};
@@ -260,7 +335,8 @@ function renderSessionDetail(): HTMLElement {
     for (const issue of selected.topIssues) {
       const row = el('div', 'issue-row');
       row.append(el('strong', '', issue.title));
-      row.append(el('span', '', `${issue.severity} · ${issue.filePath}:${issue.lineRange[0]}`));
+      const confidence = issue.confidence === undefined ? '' : ` · ${Math.round(issue.confidence)}%`;
+      row.append(el('span', '', `${issue.severity} · ${issue.filePath}:${issue.lineRange[0]}${confidence}`));
       issues.append(row);
     }
   }
@@ -277,7 +353,7 @@ function renderSessionDetail(): HTMLElement {
 function renderRunReview(): HTMLElement {
   const panel = el('div', 'run-panel');
   panel.append(el('h2', '', 'Start a Local Review'));
-  panel.append(el('p', '', 'The desktop shell calls the CLI bridge so review behavior stays identical to terminal and agent workflows.'));
+  panel.append(el('p', '', state.repoPath || 'Current repository'));
   const actions = el('div', 'run-actions');
   actions.append(button('Review Staged Changes', () => void startReview(true), 'button primary'));
   actions.append(button('Review Working Tree', () => void startReview(false)));
@@ -288,6 +364,7 @@ function renderRunReview(): HTMLElement {
 function renderConfig(): HTMLElement {
   const panel = el('div', 'config-panel');
   panel.append(el('h2', '', state.configPath));
+  panel.append(renderConfigFacts());
   const textarea = el('textarea', 'config-editor') as HTMLTextAreaElement;
   textarea.value = state.configRaw;
   panel.append(textarea);
@@ -295,8 +372,27 @@ function renderConfig(): HTMLElement {
   return panel;
 }
 
+function renderConfigFacts(): HTMLElement {
+  const facts = el('div', 'config-facts');
+  let parsed: Record<string, unknown> | undefined;
+  try {
+    parsed = JSON.parse(state.configRaw) as Record<string, unknown>;
+  } catch {
+    facts.append(el('span', 'fact warn', 'Invalid JSON'));
+    return facts;
+  }
+  const language = typeof parsed.language === 'string' ? parsed.language : 'unset';
+  const reviewers = Array.isArray(parsed.reviewers) ? parsed.reviewers.length : 0;
+  const providers = Array.isArray(parsed.providers) ? parsed.providers.length : 0;
+  facts.append(el('span', 'fact', `Language ${language}`));
+  facts.append(el('span', 'fact', `${reviewers} reviewers`));
+  facts.append(el('span', 'fact', `${providers} providers`));
+  return facts;
+}
+
 function render(): void {
   appRoot.replaceChildren(renderShell());
 }
 
 void refreshSessions(true);
+void loadRepoInfo();

--- a/packages/desktop/src/styles.css
+++ b/packages/desktop/src/styles.css
@@ -17,7 +17,9 @@ body {
 }
 
 button,
-textarea {
+textarea,
+input,
+select {
   font: inherit;
 }
 
@@ -69,6 +71,11 @@ textarea {
 .session-row {
   border: 0;
   cursor: pointer;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.64;
 }
 
 .nav-button {
@@ -126,6 +133,13 @@ h3 {
 .reasoning,
 .empty {
   color: #64747b;
+}
+
+.toolbar p {
+  max-width: 72ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .toolbar-actions,
@@ -197,6 +211,40 @@ h3 {
   overflow: hidden;
 }
 
+.session-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 132px;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid #e6ecef;
+}
+
+.filter-input,
+.filter-select {
+  width: 100%;
+  min-width: 0;
+  min-height: 34px;
+  padding: 7px 9px;
+  border: 1px solid #cbd6da;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #172026;
+}
+
+.list-summary {
+  padding: 8px 14px;
+  color: #64747b;
+  background: #f8fbfb;
+  border-bottom: 1px solid #e6ecef;
+  font-size: 12px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.padded {
+  padding: 14px;
+}
+
 .session-row {
   display: grid;
   gap: 4px;
@@ -221,7 +269,8 @@ h3 {
 }
 
 .session-meta,
-.issue-row span {
+.issue-row span,
+.detail-meta {
   color: #64747b;
   font-size: 13px;
 }
@@ -259,6 +308,28 @@ h3 {
   display: grid;
   gap: 16px;
   padding: 18px;
+}
+
+.detail-meta,
+.config-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.detail-meta span,
+.fact {
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px solid #dbe3e6;
+  border-radius: 999px;
+  background: #f8fbfb;
+}
+
+.fact.warn {
+  border-color: #f1c44e;
+  background: #fff8e1;
+  color: #92400e;
 }
 
 .count-grid {

--- a/packages/mcp/src/tests/tool-handlers.test.ts
+++ b/packages/mcp/src/tests/tool-handlers.test.ts
@@ -372,6 +372,22 @@ describe('review_full handler', () => {
     expect(formatReviewResult).toHaveBeenCalledWith(expect.anything(), 'md');
   });
 
+  it('routes output_format=json through the versioned review formatter', async () => {
+    const { runReviewRaw } = await import('../helpers.js');
+    const { formatReviewResult } = await import('../post-actions.js');
+    vi.mocked(runReviewRaw).mockResolvedValue({ status: 'success' } as never);
+    vi.mocked(formatReviewResult).mockResolvedValue('{"schemaVersion":"codeagora.review.v1"}');
+
+    const { registerReviewFull } = await import('../tools/review-full.js');
+    const { server, getHandler } = createServerStub();
+    registerReviewFull(server as never);
+
+    const result = await getHandler('review_full')({ diff: '+x', output_format: 'json' });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.schemaVersion).toBe('codeagora.review.v1');
+    expect(formatReviewResult).toHaveBeenCalledWith(expect.anything(), 'json');
+  });
+
   it('returns error on pipeline failure', async () => {
     const { runReviewCompact } = await import('../helpers.js');
     vi.mocked(runReviewCompact).mockRejectedValue(new Error('out of tokens'));

--- a/packages/mcp/src/tests/v2.3-features.test.ts
+++ b/packages/mcp/src/tests/v2.3-features.test.ts
@@ -70,6 +70,32 @@ describe('post-actions exports', () => {
     expect(typeof mod.postToGitHub).toBe('function');
   });
 
+  it('formats output_format=json with the CLI agent contract marker', async () => {
+    const { formatReviewResult } = await import('../post-actions.js');
+    const formatted = await formatReviewResult({
+      sessionId: '001',
+      date: '2026-04-27',
+      status: 'success',
+      summary: {
+        decision: 'ACCEPT',
+        reasoning: 'No blocking issues.',
+        totalReviewers: 3,
+        forfeitedReviewers: 0,
+        severityCounts: {},
+        topIssues: [],
+        totalDiscussions: 0,
+        resolved: 0,
+        escalated: 0,
+      },
+      evidenceDocs: [],
+      discussions: [],
+    }, 'json');
+
+    const parsed = JSON.parse(formatted);
+    expect(parsed.schemaVersion).toBe('codeagora.review.v1');
+    expect(parsed.status).toBe('success');
+    expect(parsed.summary.decision).toBe('ACCEPT');
+  });
 });
 
 // ============================================================================

--- a/packages/mcp/src/tools/shared-schema.ts
+++ b/packages/mcp/src/tools/shared-schema.ts
@@ -20,7 +20,7 @@ export const reviewOptionsSchema = {
   repo_path: z.string().optional().describe('Git repo root path for surrounding code context'),
   context_lines: z.number().min(0).optional().describe('Context lines around changes (default 20, 0 = disabled)'),
   output_format: z.enum(['compact', 'text', 'json', 'md', 'github', 'html', 'junit', 'sarif']).optional()
-    .describe('Result format (default: compact)'),
+    .describe('Result format (default: compact; json returns the versioned codeagora.review.v1 agent contract)'),
 };
 
 /**

--- a/packages/shared/src/utils/diff.ts
+++ b/packages/shared/src/utils/diff.ts
@@ -25,7 +25,7 @@ export interface DiffFileRange {
  */
 export function parseDiffFileRanges(diffContent: string): DiffFileRange[] {
   const result: DiffFileRange[] = [];
-  const sections = diffContent.split(/(?=diff --git )/);
+  const sections = diffContent.split(/(?=^diff --git )/m);
 
   for (const section of sections) {
     const trimmed = section.trim();
@@ -176,11 +176,11 @@ export interface CodeSnippet {
  */
 export function extractFileListFromDiff(diffContent: string): string[] {
   const files: string[] = [];
-  const sections = diffContent.split(/(?=diff --git)/);
+  const sections = diffContent.split(/(?=^diff --git )/m);
 
   for (const section of sections) {
     // Match: diff --git a/path/to/file.ts b/path/to/file.ts
-    const match = section.match(/diff --git a\/(.+?) b\//);
+    const match = section.match(/^diff --git a\/(.+?) b\//m);
     if (match) {
       files.push(match[1]);
     }
@@ -246,6 +246,9 @@ export function extractCodeSnippet(
   if (!fileSection) {
     return null;
   }
+  if (!extractFileListFromDiff(fileSection).includes(filePath)) {
+    return null;
+  }
 
   // Extract lines around the target range
   const lines = fileSection.split('\n');
@@ -306,15 +309,22 @@ export function extractCodeSnippet(
  * Extract file section from full diff
  */
 function extractFileSection(diffContent: string, filePath: string): string | null {
-  const sections = diffContent.split(/(?=diff --git)/);
+  const sections = diffContent.split(/(?=^diff --git )/m);
 
   for (const section of sections) {
-    if (section.includes(`b/${filePath}`)) {
+    if (sectionMatchesFilePath(section, filePath)) {
       return section;
     }
   }
 
   return null;
+}
+
+function sectionMatchesFilePath(section: string, filePath: string): boolean {
+  const escapedFilePath = escapeRegExp(filePath);
+  const gitHeader = new RegExp(`^diff --git a/.+ b/${escapedFilePath}$`, 'm');
+  const newFileHeader = new RegExp(`^\\+\\+\\+ b/${escapedFilePath}$`, 'm');
+  return gitHeader.test(section) || newFileHeader.test(section);
 }
 
 /**

--- a/src/tests/context-aware-review.test.ts
+++ b/src/tests/context-aware-review.test.ts
@@ -147,6 +147,28 @@ describe('parseDiffFileRanges', () => {
     expect(parseDiffFileRanges('   \n\n  ')).toEqual([]);
   });
 
+  it('ignores embedded diff headers inside added fixture lines', () => {
+    const diff = `diff --git a/benchmarks/golden-bugs/example/diff.patch b/benchmarks/golden-bugs/example/diff.patch
+--- a/benchmarks/golden-bugs/example/diff.patch
++++ b/benchmarks/golden-bugs/example/diff.patch
+@@ -1,2 +1,6 @@
++diff --git a/src/admin.ts b/src/admin.ts
++--- a/src/admin.ts
++++ b/src/admin.ts
++@@ -1 +1,2 @@
+++export function adminOnly(user) { return true; }
+`;
+
+    const result = parseDiffFileRanges(diff);
+
+    expect(result).toEqual([
+      {
+        file: 'benchmarks/golden-bugs/example/diff.patch',
+        ranges: [[1, 6]],
+      },
+    ]);
+  });
+
   it('handles hunk with no count (single line change)', () => {
     const diff = `diff --git a/file.ts b/file.ts
 --- a/file.ts

--- a/src/tests/l2-dedup.test.ts
+++ b/src/tests/l2-dedup.test.ts
@@ -114,6 +114,27 @@ describe('findDuplicates()', () => {
       expect(result.get('multi-1')).toContain('multi-2');
       expect(result.get('multi-1')).toContain('multi-3');
     });
+
+    it('groups same root-cause security findings even when titles differ', () => {
+      const d1 = makeDiscussion({
+        id: 'root-1',
+        filePath: 'src/admin.ts',
+        lineRange: [42, 48],
+        issueTitle: 'Admin endpoint bypasses authorization',
+        codeSnippet: '42 | router.post("/admin", async (req) => deleteUser(req.body.id));',
+      });
+      const d2 = makeDiscussion({
+        id: 'root-2',
+        filePath: 'src/admin.ts',
+        lineRange: [43, 47],
+        issueTitle: 'Missing permission check before destructive route',
+        codeSnippet: '43 | router.post("/admin", async (req) => deleteUser(req.body.id));',
+      });
+
+      const result = findDuplicates([d1, d2]);
+
+      expect(result.get('root-1')).toContain('root-2');
+    });
   });
 });
 

--- a/src/tests/l3-grouping.test.ts
+++ b/src/tests/l3-grouping.test.ts
@@ -76,6 +76,23 @@ describe('groupDiff()', () => {
       expect(result[0].diffContent).toContain('diff --git a/src/auth.ts b/src/auth.ts');
     });
 
+    it('does not create groups for diff headers embedded in added file content', () => {
+      const diff = `diff --git a/benchmarks/golden-bugs/example/diff.patch b/benchmarks/golden-bugs/example/diff.patch
+new file mode 100644
+--- /dev/null
++++ b/benchmarks/golden-bugs/example/diff.patch
+@@ -0,0 +1,4 @@
++diff --git a/src/admin.ts b/src/admin.ts
++--- a/src/admin.ts
+++++ b/src/admin.ts
++@@ -1 +1 @@
+`;
+      const result = groupDiff(diff);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].files).toEqual(['benchmarks/golden-bugs/example/diff.patch']);
+    });
+
     it('group prSummary mentions the directory and file count', () => {
       const diff = makeDiffSection('src/auth.ts');
       const result = groupDiff(diff);

--- a/src/tests/rules-integration.test.ts
+++ b/src/tests/rules-integration.test.ts
@@ -66,6 +66,26 @@ describe('matchRules', () => {
     expect(doc.lineRange[0]).toBe(doc.lineRange[1]); // single line
   });
 
+  it('does not treat embedded diff headers in added content as real files', () => {
+    const diff = `diff --git a/benchmarks/golden-bugs/example/diff.patch b/benchmarks/golden-bugs/example/diff.patch
+new file mode 100644
+--- /dev/null
++++ b/benchmarks/golden-bugs/example/diff.patch
+@@ -0,0 +1,7 @@
++diff --git a/src/index.ts b/src/index.ts
++--- a/src/index.ts
+++++ b/src/index.ts
++@@ -1,2 +1,3 @@
++ const x = 1;
+++console.log(x);
++ export default x;
+`;
+    const results = matchRules(diff, [makeRule()]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].filePath).toBe('benchmarks/golden-bugs/example/diff.patch');
+  });
+
   it('sets source="rule" on all returned documents', () => {
     const diff = `diff --git a/src/app.ts b/src/app.ts
 --- a/src/app.ts

--- a/src/tests/utils-diff.test.ts
+++ b/src/tests/utils-diff.test.ts
@@ -97,6 +97,21 @@ describe('extractFileListFromDiff', () => {
     expect(result).toEqual(['src/parser.ts', 'src/validator.ts']);
   });
 
+  it('ignores embedded diff headers inside added fixture lines', () => {
+    const fixtureDiff = `diff --git a/benchmarks/golden-bugs/example/diff.patch b/benchmarks/golden-bugs/example/diff.patch
+--- a/benchmarks/golden-bugs/example/diff.patch
++++ b/benchmarks/golden-bugs/example/diff.patch
+@@ -1,2 +1,4 @@
++diff --git a/src/admin.ts b/src/admin.ts
++--- a/src/admin.ts
++++ b/src/admin.ts
+++export function adminOnly(user) { return true; }
+`;
+
+    const result = extractFileListFromDiff(fixtureDiff);
+    expect(result).toEqual(['benchmarks/golden-bugs/example/diff.patch']);
+  });
+
   it('extracts the "a/" path from a renamed-file diff header', () => {
     // The regex captures the a/ side: a/src/old-name.ts
     const result = extractFileListFromDiff(RENAMED_FILE_DIFF);
@@ -151,6 +166,20 @@ describe('extractCodeSnippet', () => {
   it('returns null when the file is not in the diff', () => {
     const result = extractCodeSnippet(SINGLE_FILE_DIFF, 'src/missing.ts', [1, 3]);
     expect(result).toBeNull();
+  });
+
+  it('does not extract snippets from embedded fixture diff headers as real files', () => {
+    const fixtureDiff = `diff --git a/benchmarks/golden-bugs/example/diff.patch b/benchmarks/golden-bugs/example/diff.patch
+--- a/benchmarks/golden-bugs/example/diff.patch
++++ b/benchmarks/golden-bugs/example/diff.patch
+@@ -1,2 +1,4 @@
++diff --git a/src/admin.ts b/src/admin.ts
++--- a/src/admin.ts
++++ b/src/admin.ts
+++export function adminOnly(user) { return true; }
+`;
+
+    expect(extractCodeSnippet(fixtureDiff, 'src/admin.ts', [1, 1])).toBeNull();
   });
 
   it('returns null when the line range falls entirely outside diff content', () => {


### PR DESCRIPTION
## Summary
- expand golden-bug coverage from 5 to 11 fixtures with new recall and FP-regression cases
- stabilize the CLI/MCP agent review contract around JSON, NDJSON, and review exit-code semantics
- harden the desktop MVP session surface by reading .ca/sessions directly, exposing repo info, filters, richer details, config save defaults, and CLI fallback execution

## Validation
- pnpm bench:fn -- --validate-only
- pnpm --filter @codeagora/cli test -- src/tests/agent-contract.test.ts
- pnpm --filter @codeagora/mcp test -- src/tests/tool-handlers.test.ts src/tests/v2.3-features.test.ts
- pnpm --filter @codeagora/desktop typecheck
- pnpm --filter @codeagora/desktop build
- pnpm --filter @codeagora/desktop tauri:check
- pnpm typecheck
- pnpm build
- pnpm test