### PR TITLE
feat: quantify golden bug benchmark metrics

### DIFF
--- a/benchmarks/.ca/config.free-smoke.json
+++ b/benchmarks/.ca/config.free-smoke.json
@@ -1,0 +1,27 @@
+{
+  "mode": "pragmatic",
+  "language": "en",
+  "reviewers": [
+    { "id": "r-qwen-free", "model": "qwen/qwen3-coder:free", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    { "id": "r-minimax-free", "model": "minimax/minimax-m2.5:free", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    { "id": "r-nvidia-free", "model": "nvidia/nemotron-3-super-120b-a12b:free", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 }
+  ],
+  "supporters": {
+    "pool": [
+      { "id": "s-qwen-free", "model": "qwen/qwen3.6-plus:free", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 }
+    ],
+    "pickCount": 1,
+    "pickStrategy": "random",
+    "devilsAdvocate": { "id": "da-nvidia-free", "model": "nvidia/nemotron-nano-9b-v2:free", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
+    "personaAssignment": "random"
+  },
+  "moderator": { "model": "qwen/qwen3-30b-a3b:free", "backend": "api", "provider": "openrouter" },
+  "discussion": {
+    "maxRounds": 1,
+    "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null },
+    "codeSnippetRange": 10
+  },
+  "head": { "backend": "api", "model": "qwen/qwen3-30b-a3b:free", "provider": "openrouter", "enabled": true },
+  "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
+}

--- a/benchmarks/.ca/config.low-cost-diverse.json
+++ b/benchmarks/.ca/config.low-cost-diverse.json
@@ -1,0 +1,27 @@
+{
+  "mode": "pragmatic",
+  "language": "en",
+  "reviewers": [
+    { "id": "r-qwen-coder", "model": "qwen/qwen3-coder-30b-a3b-instruct", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    { "id": "r-xiaomi", "model": "xiaomi/mimo-v2-flash", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    { "id": "r-nvidia", "model": "nvidia/nemotron-3-nano-30b-a3b:nitro", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 }
+  ],
+  "supporters": {
+    "pool": [
+      { "id": "s-baidu-thinking", "model": "baidu/ernie-4.5-21b-a3b-thinking", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 }
+    ],
+    "pickCount": 1,
+    "pickStrategy": "random",
+    "devilsAdvocate": { "id": "da-tencent", "model": "tencent/hunyuan-a13b-instruct", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 120 },
+    "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
+    "personaAssignment": "random"
+  },
+  "moderator": { "model": "deepseek/deepseek-v3.2", "backend": "api", "provider": "openrouter" },
+  "discussion": {
+    "maxRounds": 2,
+    "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null },
+    "codeSnippetRange": 10
+  },
+  "head": { "backend": "api", "model": "deepseek/deepseek-v3.2", "provider": "openrouter", "enabled": true },
+  "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
+}

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -53,6 +53,19 @@ export async function loadConfigFrom(baseDir: string): Promise<Config> {
 }
 
 /**
+ * Load config from an explicit JSON/YAML file path.
+ */
+export async function loadConfigFile(filePath: string): Promise<Config> {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.yaml' || ext === '.yml') {
+    return loadYamlConfig(filePath);
+  }
+
+  const data = await readJson(filePath);
+  return validateConfig(data);
+}
+
+/**
  * Load config using process.cwd() as the base directory (default behaviour).
  */
 export async function loadConfig(): Promise<Config> {

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -4,7 +4,7 @@
  */
 
 import { SessionManager, recoverStaleSessions } from '../session/manager.js';
-import { loadConfig, normalizeConfig } from '../config/loader.js';
+import { loadConfig, loadConfigFile, normalizeConfig } from '../config/loader.js';
 import { writeAllReviews } from '../l1/writer.js';
 import { applyThreshold } from '../l2/threshold.js';
 import { writeModeratorReport, writeSuggestions } from '../l2/writer.js';
@@ -56,6 +56,8 @@ export interface PipelineInput {
   repoPath?: string;
   /** Number of surrounding lines to include around changed ranges (default 20, 0 = disabled) */
   contextLines?: number;
+  /** Explicit config file path. Defaults to process.cwd()/.ca/config.* */
+  configPath?: string;
 }
 
 export interface PipelineSummary {
@@ -128,7 +130,9 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
 
     // Load config and normalize (expand declarative reviewers if needed)
     progress?.stageStart('init', 'Loading config...');
-    const rawConfig = await loadConfig();
+    const rawConfig = input.configPath
+      ? await loadConfigFile(input.configPath)
+      : await loadConfig();
     const config = normalizeConfig(rawConfig);
 
     // Apply CLI overrides to config

--- a/packages/shared/src/tests/golden-bug-scorer.test.ts
+++ b/packages/shared/src/tests/golden-bug-scorer.test.ts
@@ -149,6 +149,13 @@ describe('scoreCase — recall path', () => {
     expect(result.isFpRegression).toBe(false);
     expect(result.matched).toHaveLength(1);
     expect(result.missed).toHaveLength(0);
+    expect(result.metrics).toMatchObject({
+      truePositives: 1,
+      falsePositives: 0,
+      falseNegatives: 0,
+      actualFindings: 1,
+      expectedFindings: 1,
+    });
     expect(result.recallAtK[3]).toBe(1);
     expect(result.recallAtK[5]).toBe(1);
   });
@@ -158,6 +165,12 @@ describe('scoreCase — recall path', () => {
     const result = scoreCase(fx, [finding({ lineRange: [100, 101] })]);
     expect(result.matched).toHaveLength(0);
     expect(result.missed).toHaveLength(1);
+    expect(result.falsePositives).toHaveLength(1);
+    expect(result.metrics).toMatchObject({
+      truePositives: 0,
+      falsePositives: 1,
+      falseNegatives: 1,
+    });
     expect(result.recallAtK[3]).toBe(0);
   });
 
@@ -198,6 +211,7 @@ describe('scoreCase — recall path', () => {
     const result = scoreCase(fx, [finding()]);
     expect(result.matched).toHaveLength(1);
     expect(result.missed).toHaveLength(1);
+    expect(result.falsePositives).toHaveLength(0);
     expect(result.recallAtK[3]).toBe(0.5);
   });
 });
@@ -208,6 +222,13 @@ describe('scoreCase — FP regression path', () => {
     const result = scoreCase(fx, []);
     expect(result.isFpRegression).toBe(true);
     expect(result.falsePositives).toEqual([]);
+    expect(result.metrics).toMatchObject({
+      truePositives: 0,
+      falsePositives: 0,
+      falseNegatives: 0,
+      actualFindings: 0,
+      expectedFindings: 0,
+    });
     expect(result.recallAtK[3]).toBeNull();
   });
 
@@ -215,6 +236,7 @@ describe('scoreCase — FP regression path', () => {
     const fx = fixture({ expectedFindings: [] });
     const result = scoreCase(fx, [finding(), finding({ filePath: 'src/other.ts' })]);
     expect(result.falsePositives).toHaveLength(2);
+    expect(result.metrics.falsePositives).toBe(2);
   });
 });
 
@@ -234,6 +256,17 @@ describe('aggregate', () => {
     expect(report.fpRegressionCases).toBe(1);
     expect(report.meanRecallAtK[3]).toBe(0.5);
     expect(report.fpRegressionsTriggered).toBe(1);
+    expect(report.metrics).toMatchObject({
+      truePositives: 1,
+      falsePositives: 1,
+      falseNegatives: 1,
+      actualFindings: 2,
+      expectedFindings: 2,
+      precision: 0.5,
+      recall: 0.5,
+      f1: 0.5,
+      fpCleanRate: 0,
+    });
   });
 
   it('returns 0 mean recall when no recall cases exist', () => {
@@ -241,5 +274,9 @@ describe('aggregate', () => {
     const report = aggregate([scoreCase(fp, [])]);
     expect(report.meanRecallAtK[3]).toBe(0);
     expect(report.fpRegressionsTriggered).toBe(0);
+    expect(report.metrics.precision).toBeNull();
+    expect(report.metrics.recall).toBeNull();
+    expect(report.metrics.f1).toBeNull();
+    expect(report.metrics.fpCleanRate).toBe(1);
   });
 });

--- a/packages/shared/src/utils/golden-bug-scorer.ts
+++ b/packages/shared/src/utils/golden-bug-scorer.ts
@@ -42,6 +42,13 @@ export interface CaseResult {
   matched: CaseMatch[];
   missed: ExpectedFinding[];
   falsePositives: ActualFinding[];
+  metrics: {
+    truePositives: number;
+    falsePositives: number;
+    falseNegatives: number;
+    actualFindings: number;
+    expectedFindings: number;
+  };
   /** recall@k for several k values. For FP cases, recall is undefined. */
   recallAtK: Record<number, number | null>;
 }
@@ -126,6 +133,13 @@ export function scoreCase(
       matched: [],
       missed: [],
       falsePositives: [...actual],
+      metrics: {
+        truePositives: 0,
+        falsePositives: actual.length,
+        falseNegatives: 0,
+        actualFindings: actual.length,
+        expectedFindings: 0,
+      },
       recallAtK: Object.fromEntries(kValues.map((k) => [k, null])),
     };
   }
@@ -147,6 +161,7 @@ export function scoreCase(
 
   const matchedExpected = new Set(matched.map((m) => m.expected));
   const missed = fixture.expectedFindings.filter((e) => !matchedExpected.has(e));
+  const falsePositives = ranked.filter((_, i) => !claimedActualIdx.has(i));
 
   const recallAtK: Record<number, number | null> = {};
   for (const k of kValues) {
@@ -172,7 +187,14 @@ export function scoreCase(
     isFpRegression: false,
     matched,
     missed,
-    falsePositives: [],
+    falsePositives,
+    metrics: {
+      truePositives: matched.length,
+      falsePositives: falsePositives.length,
+      falseNegatives: missed.length,
+      actualFindings: actual.length,
+      expectedFindings: fixture.expectedFindings.length,
+    },
     recallAtK,
   };
 }
@@ -183,7 +205,22 @@ export interface AggregateReport {
   fpRegressionCases: number;
   meanRecallAtK: Record<number, number>;
   fpRegressionsTriggered: number;
+  metrics: {
+    truePositives: number;
+    falsePositives: number;
+    falseNegatives: number;
+    actualFindings: number;
+    expectedFindings: number;
+    precision: number | null;
+    recall: number | null;
+    f1: number | null;
+    fpCleanRate: number | null;
+  };
   perCase: CaseResult[];
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator;
 }
 
 export function aggregate(
@@ -209,7 +246,37 @@ export function aggregate(
     fpRegressionCases: fpCases.length,
     meanRecallAtK,
     fpRegressionsTriggered: fpCases.filter((r) => r.falsePositives.length > 0).length,
+    metrics: aggregateMetrics(results, fpCases),
     perCase: results,
+  };
+}
+
+function aggregateMetrics(
+  results: CaseResult[],
+  fpCases: CaseResult[],
+): AggregateReport['metrics'] {
+  const truePositives = results.reduce((sum, r) => sum + r.metrics.truePositives, 0);
+  const falsePositives = results.reduce((sum, r) => sum + r.metrics.falsePositives, 0);
+  const falseNegatives = results.reduce((sum, r) => sum + r.metrics.falseNegatives, 0);
+  const actualFindings = results.reduce((sum, r) => sum + r.metrics.actualFindings, 0);
+  const expectedFindings = results.reduce((sum, r) => sum + r.metrics.expectedFindings, 0);
+  const precision = ratio(truePositives, truePositives + falsePositives);
+  const recall = ratio(truePositives, truePositives + falseNegatives);
+  const f1 = precision === null || recall === null || precision + recall === 0
+    ? null
+    : (2 * precision * recall) / (precision + recall);
+  const cleanFpCases = fpCases.filter((r) => r.metrics.falsePositives === 0).length;
+
+  return {
+    truePositives,
+    falsePositives,
+    falseNegatives,
+    actualFindings,
+    expectedFindings,
+    precision,
+    recall,
+    f1,
+    fpCleanRate: ratio(cleanFpCases, fpCases.length),
   };
 }
 

--- a/scripts/bench-fn-run.ts
+++ b/scripts/bench-fn-run.ts
@@ -9,6 +9,7 @@
 // Usage:
 //   pnpm bench:fn:run -- --results <dir>                     # run all fixtures
 //   pnpm bench:fn:run -- --results <dir> --fixtures id1,id2  # subset
+//   pnpm bench:fn:run -- --results <dir> --config .ca/config.low-cost-diverse.json
 //   pnpm bench:fn:run -- --results <dir> --skip-head         # skip L3 verdict
 //
 // Requirements:
@@ -40,6 +41,7 @@ interface Args {
   fixtureFilter: Set<string> | null;
   skipHead: boolean;
   dryRun: boolean;
+  configPath: string | null;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -48,6 +50,7 @@ function parseArgs(argv: string[]): Args {
     fixtureFilter: null,
     skipHead: false,
     dryRun: false,
+    configPath: null,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -57,9 +60,10 @@ function parseArgs(argv: string[]): Args {
       args.fixtureFilter = new Set(list.split(',').map((s) => s.trim()).filter(Boolean));
     } else if (a === '--skip-head') args.skipHead = true;
     else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--config') args.configPath = argv[++i] ?? null;
     else if (a === '--help' || a === '-h') {
       console.log(
-        'Usage: pnpm bench:fn:run -- --results <dir> [--fixtures id1,id2] [--skip-head] [--dry-run]',
+        'Usage: pnpm bench:fn:run -- --results <dir> [--fixtures id1,id2] [--config <path>] [--skip-head] [--dry-run]',
       );
       process.exit(0);
     }
@@ -94,9 +98,13 @@ async function loadFixtures(filter: Set<string> | null): Promise<GoldenBugFixtur
   return out.sort((a, b) => a.id.localeCompare(b.id));
 }
 
-async function runOne(fixtureId: string, skipHead: boolean): Promise<unknown[]> {
+async function runOne(
+  fixtureId: string,
+  skipHead: boolean,
+  configPath: string | null,
+): Promise<unknown[]> {
   const diffPath = path.join(fixturesDir, fixtureId, 'diff.patch');
-  const result = await runPipeline({ diffPath, skipHead });
+  const result = await runPipeline({ diffPath, skipHead, configPath: configPath ?? undefined });
   if (result.status !== 'success') {
     throw new Error(`pipeline error for ${fixtureId}: ${result.error ?? 'unknown'}`);
   }
@@ -118,10 +126,14 @@ async function main(): Promise<void> {
   }
 
   const resultsDir = path.resolve(process.cwd(), args.resultsDir);
+  const configPath = args.configPath
+    ? path.resolve(process.cwd(), args.configPath)
+    : null;
   await mkdir(resultsDir, { recursive: true });
 
   if (args.dryRun) {
     console.log(`[dry-run] would run ${fixtures.length} fixture(s):`);
+    console.log(`  config: ${configPath ?? path.join(benchmarkCwd, '.ca', 'config.json')}`);
     for (const f of fixtures) console.log(`  - ${f.id} → ${path.join(resultsDir, `${f.id}.json`)}`);
     return;
   }
@@ -138,7 +150,7 @@ async function main(): Promise<void> {
       process.stderr.write(`[${fixture.id}] running... `);
       const started = Date.now();
       try {
-        const findings = await runOne(fixture.id, args.skipHead);
+        const findings = await runOne(fixture.id, args.skipHead, configPath);
         const outPath = path.join(resultsDir, `${fixture.id}.json`);
         await writeFile(outPath, JSON.stringify(findings, null, 2) + '\n');
         summary.push({ id: fixture.id, findings: findings.length, status: 'ok' });

--- a/scripts/bench-fn.ts
+++ b/scripts/bench-fn.ts
@@ -115,6 +115,12 @@ function printHumanReport(report: AggregateReport, opts: { hadAnyResults: boolea
     console.log(
       `mean recall@3: ${pct(report.meanRecallAtK[3])}  @5: ${pct(report.meanRecallAtK[5])}  @10: ${pct(report.meanRecallAtK[10])}`,
     );
+    console.log(
+      `TP: ${report.metrics.truePositives}  FP: ${report.metrics.falsePositives}  FN: ${report.metrics.falseNegatives}  actual: ${report.metrics.actualFindings}  expected: ${report.metrics.expectedFindings}`,
+    );
+    console.log(
+      `precision: ${pct(report.metrics.precision)}  recall: ${pct(report.metrics.recall)}  F1: ${pct(report.metrics.f1)}  FP clean-rate: ${pct(report.metrics.fpCleanRate)}`,
+    );
     console.log(`FP regressions triggered: ${report.fpRegressionsTriggered}/${report.fpRegressionCases}`);
   } else {
     console.log('no --results supplied — fixture validation only');
@@ -128,7 +134,7 @@ function printHumanReport(report: AggregateReport, opts: { hadAnyResults: boolea
       const hits = r.matched.length;
       const total = r.matched.length + r.missed.length;
       console.log(
-        `  [rec] ${r.fixtureId.padEnd(32)} ${hits}/${total}  r@3=${pct(r.recallAtK[3])} r@5=${pct(r.recallAtK[5])} r@10=${pct(r.recallAtK[10])}`,
+        `  [rec] ${r.fixtureId.padEnd(32)} ${hits}/${total}  fp=${r.metrics.falsePositives}  r@3=${pct(r.recallAtK[3])} r@5=${pct(r.recallAtK[5])} r@10=${pct(r.recallAtK[10])}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- add aggregate TP/FP/FN, precision, recall, F1, and FP clean-rate metrics to golden-bug scoring
- include per-fixture actual/expected/fp counts in benchmark reports
- cover the new metric contract in scorer tests

## Validation
- pnpm --filter @codeagora/shared test -- src/tests/golden-bug-scorer.test.ts
- pnpm bench:fn -- --validate-only
- pnpm bench:fn -- --json
- pnpm typecheck

Note: live model benchmark execution was not run because OPENROUTER_API_KEY is not set in this environment.