### PR TITLE
fix: bundle MCP runtime dependencies for packed installs

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,10 +39,29 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@ai-sdk/anthropic": "^3.0.58",
+    "@ai-sdk/baseten": "^1.0.38",
+    "@ai-sdk/cohere": "^3.0.25",
+    "@ai-sdk/deepinfra": "^2.0.39",
+    "@ai-sdk/fireworks": "^2.0.40",
+    "@ai-sdk/google": "^3.0.43",
+    "@ai-sdk/groq": "^3.0.29",
+    "@ai-sdk/huggingface": "^1.0.37",
+    "@ai-sdk/moonshotai": "^2.0.10",
+    "@ai-sdk/openai": "^3.0.41",
+    "@ai-sdk/openai-compatible": "^2.0.35",
+    "@ai-sdk/perplexity": "^3.0.23",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@openrouter/ai-sdk-provider": "^2.3.1",
+    "ai": "^6.0.116",
+    "picocolors": "^1.1.1",
+    "yaml": "^2.8.2",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@codeagora/cli": "workspace:*",
     "@codeagora/core": "workspace:*",
+    "@codeagora/github": "workspace:*",
     "@codeagora/shared": "workspace:*"
   }
 }

--- a/packages/mcp/src/tests/critical-errors.test.ts
+++ b/packages/mcp/src/tests/critical-errors.test.ts
@@ -229,6 +229,30 @@ describe('M-09: explain_session path traversal protection', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Error:');
   });
+
+  it('explain_session tool passes repo_path to the CLI session explainer', async () => {
+    vi.resetModules();
+    const explainSessionMock = vi.fn(async () => ({ narrative: 'Session narrative' }));
+    vi.doMock('@codeagora/cli/commands/explain.js', () => ({
+      explainSession: explainSessionMock,
+    }));
+
+    const { registerExplain } = await import('../tools/explain.js');
+
+    let capturedHandler: ((args: { session: string; repo_path?: string }) => Promise<unknown>) | null = null;
+    const mockServer = {
+      tool: vi.fn((_name: string, _desc: string, _schema: unknown, handler: (args: { session: string; repo_path?: string }) => Promise<unknown>) => {
+        capturedHandler = handler;
+      }),
+    };
+
+    registerExplain(mockServer as never);
+    expect(capturedHandler).not.toBeNull();
+
+    await capturedHandler!({ session: '2026-01-01/001', repo_path: '/tmp/target-repo' });
+
+    expect(explainSessionMock).toHaveBeenCalledWith('/tmp/target-repo', '2026-01-01/001');
+  });
 });
 
 // ============================================================================

--- a/packages/mcp/src/tests/stdio-tools.test.ts
+++ b/packages/mcp/src/tests/stdio-tools.test.ts
@@ -1,9 +1,9 @@
-import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const repoRoot = path.resolve(packageRoot, '..', '..');
@@ -20,18 +20,39 @@ const expectedToolNames = [
   'config_set',
 ] as const;
 
-const testWithBuiltServer = existsSync(serverEntry) ? it : it.skip;
+const sampleDiff = [
+  'diff --git a/a.ts b/a.ts',
+  'new file mode 100644',
+  'index 0000000..1111111',
+  '--- /dev/null',
+  '+++ b/a.ts',
+  '@@ -0,0 +1 @@',
+  '+const x = 1;',
+  '',
+].join('\n');
+
+type ToolTextResult = {
+  content?: Array<{ type?: string; text?: string }>;
+};
 
 describe('MCP stdio startup', () => {
   let client: Client | undefined;
+
+  beforeAll(() => {
+    execFileSync('pnpm', ['--filter', '@codeagora/mcp', 'build'], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+      env: { ...process.env, CI: 'true' },
+    });
+  }, 30_000);
 
   afterEach(async () => {
     await client?.close();
     client = undefined;
   });
 
-  testWithBuiltServer('advertises the expected tool list from dist/index.js', async () => {
-    client = new Client(
+  async function connectClient(): Promise<Client> {
+    const nextClient = new Client(
       { name: 'mcp-stdio-regression', version: '1.0.0' },
       { capabilities: {} },
     );
@@ -42,11 +63,39 @@ describe('MCP stdio startup', () => {
       cwd: repoRoot,
     });
 
-    await client.connect(transport);
+    await nextClient.connect(transport);
+    client = nextClient;
+    return nextClient;
+  }
 
-    const result = await client.listTools();
+  it('advertises the expected tool list from dist/index.js', async () => {
+    const connectedClient = await connectClient();
+
+    const result = await connectedClient.listTools();
     const toolNames = result.tools.map((tool) => tool.name).sort();
 
     expect(toolNames).toEqual([...expectedToolNames].sort());
+  });
+
+  it('runs dry_run through the dist stdio server', async () => {
+    const connectedClient = await connectClient();
+
+    const result = await connectedClient.callTool({
+      name: 'dry_run',
+      arguments: { diff: sampleDiff },
+    }) as ToolTextResult;
+
+    const text = result.content?.find((item) => item.type === 'text')?.text;
+    expect(text).toBeDefined();
+
+    const payload = JSON.parse(text!) as {
+      files: number;
+      lines: { total: number; added: number; removed: number };
+      estimatedCost: string;
+    };
+
+    expect(payload.files).toBeGreaterThan(0);
+    expect(payload.lines.added).toBe(1);
+    expect(payload.estimatedCost).toMatch(/^~?\$[\d.]+$/);
   });
 });

--- a/packages/mcp/src/tests/stdio-tools.test.ts
+++ b/packages/mcp/src/tests/stdio-tools.test.ts
@@ -1,0 +1,52 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+const serverEntry = path.resolve(packageRoot, 'dist/index.js');
+const expectedToolNames = [
+  'review_quick',
+  'review_full',
+  'review_pr',
+  'dry_run',
+  'explain_session',
+  'get_leaderboard',
+  'get_stats',
+  'config_get',
+  'config_set',
+] as const;
+
+const testWithBuiltServer = existsSync(serverEntry) ? it : it.skip;
+
+describe('MCP stdio startup', () => {
+  let client: Client | undefined;
+
+  afterEach(async () => {
+    await client?.close();
+    client = undefined;
+  });
+
+  testWithBuiltServer('advertises the expected tool list from dist/index.js', async () => {
+    client = new Client(
+      { name: 'mcp-stdio-regression', version: '1.0.0' },
+      { capabilities: {} },
+    );
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [serverEntry],
+      cwd: repoRoot,
+    });
+
+    await client.connect(transport);
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((tool) => tool.name).sort();
+
+    expect(toolNames).toEqual([...expectedToolNames].sort());
+  });
+});

--- a/packages/mcp/src/tests/tools.test.ts
+++ b/packages/mcp/src/tests/tools.test.ts
@@ -122,7 +122,7 @@ describe('review_full input schema', () => {
 });
 
 describe('explain_session input schema', () => {
-  const schema = z.object({ session: z.string() });
+  const schema = z.object({ session: z.string(), repo_path: z.string().optional() });
 
   it('accepts a valid session path', () => {
     expect(schema.safeParse({ session: '2026-03-21/001' }).success).toBe(true);
@@ -134,6 +134,10 @@ describe('explain_session input schema', () => {
 
   it('rejects numeric session', () => {
     expect(schema.safeParse({ session: 42 }).success).toBe(false);
+  });
+
+  it('accepts an explicit repo path', () => {
+    expect(schema.safeParse({ session: '2026-03-21/001', repo_path: '/tmp/repo' }).success).toBe(true);
   });
 });
 

--- a/packages/mcp/src/tools/explain.ts
+++ b/packages/mcp/src/tools/explain.ts
@@ -12,10 +12,11 @@ export function registerExplain(server: McpServer): void {
     'Read session artifacts and produce a narrative summary of a past review. No LLM calls.',
     {
       session: z.string().describe('Session path (e.g. 2026-03-19/001)'),
+      repo_path: z.string().optional().describe('Repository path containing the .ca session directory'),
     },
-    async ({ session }) => {
+    async ({ session, repo_path }) => {
       try {
-        const result = await explainSession(process.cwd(), session);
+        const result = await explainSession(repo_path ?? process.cwd(), session);
         return { content: [{ type: 'text' as const, text: result.narrative }] };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -31,12 +31,10 @@ export default defineConfig({
   clean: true,
   bundle: true,
   splitting: false,
-  noExternal: [/^@codeagora\/(core|shared)/],
+  noExternal: [/^@codeagora\/(core|shared|cli|github)/],
   external: [
     /^@ai-sdk\//,
     /^@openrouter\//,
-    /^@codeagora\/cli/,
-    /^@codeagora\/github/,
     '@modelcontextprotocol/sdk',
     'ai',
     'zod',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,13 +207,70 @@ importers:
 
   packages/mcp:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.58
+        version: 3.0.58(zod@3.25.76)
+      '@ai-sdk/baseten':
+        specifier: ^1.0.38
+        version: 1.0.38(zod@3.25.76)
+      '@ai-sdk/cohere':
+        specifier: ^3.0.25
+        version: 3.0.25(zod@3.25.76)
+      '@ai-sdk/deepinfra':
+        specifier: ^2.0.39
+        version: 2.0.39(zod@3.25.76)
+      '@ai-sdk/fireworks':
+        specifier: ^2.0.40
+        version: 2.0.40(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^3.0.43
+        version: 3.0.43(zod@3.25.76)
+      '@ai-sdk/groq':
+        specifier: ^3.0.29
+        version: 3.0.29(zod@3.25.76)
+      '@ai-sdk/huggingface':
+        specifier: ^1.0.37
+        version: 1.0.37(zod@3.25.76)
+      '@ai-sdk/moonshotai':
+        specifier: ^2.0.10
+        version: 2.0.10(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^3.0.41
+        version: 3.0.41(zod@3.25.76)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.35
+        version: 2.0.35(zod@3.25.76)
+      '@ai-sdk/perplexity':
+        specifier: ^3.0.23
+        version: 3.0.23(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.27.1(zod@3.25.76)
+      '@openrouter/ai-sdk-provider':
+        specifier: ^2.3.1
+        version: 2.3.1(ai@6.0.116(zod@3.25.76))(zod@3.25.76)
+      ai:
+        specifier: ^6.0.116
+        version: 6.0.116(zod@3.25.76)
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
+      '@codeagora/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@codeagora/core':
         specifier: workspace:*
         version: link:../core
+      '@codeagora/github':
+        specifier: workspace:*
+        version: link:../github
       '@codeagora/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary
- Bundles internal CodeAgora workspace packages into the MCP dist build so packed installs do not depend on unpublished packages.
- Declares the external runtime packages that remain external in the MCP bundle.
- Runs the stdio startup regression against `dist/index.js` and lets `explain_session` resolve sessions from a provided target repo path.

## Verification
- `pnpm typecheck`
- `pnpm --filter @codeagora/mcp build`
- `pnpm --filter @codeagora/mcp test`
- `pnpm test`
- `pnpm build`
- Manual `pnpm --filter @codeagora/mcp pack` + local `npm install` + MCP stdio `listTools()` smoke

## Notes
- `pnpm --filter @codeagora/mcp typecheck` still fails because the package-local tsconfig does not include the root alias paths for existing `@codeagora/*` subpath imports; root `pnpm typecheck` passes and is the configured monorepo typecheck.