### PR TITLE
fix(action): harden GitHub Action production path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
     required: false
     default: '5000'
 
+  post-results:
+    description: Post review comments and commit status to GitHub
+    required: false
+    default: 'true'
+
 outputs:
   verdict:
     description: Final verdict — ACCEPT, REJECT, or NEEDS_HUMAN
@@ -33,6 +38,22 @@ outputs:
   session-id:
     description: CodeAgora session ID for audit trail
     value: ${{ steps.review.outputs.session-id }}
+
+  degraded:
+    description: Whether the action ran in degraded or skipped mode
+    value: ${{ steps.review.outputs.degraded }}
+
+  degraded-reason:
+    description: Reason for degraded or skipped mode
+    value: ${{ steps.review.outputs.degraded-reason }}
+
+  head-sha:
+    description: Pull request head SHA reviewed by CodeAgora
+    value: ${{ steps.review.outputs.head-sha }}
+
+  base-sha:
+    description: Pull request base SHA used for diff acquisition
+    value: ${{ steps.review.outputs.base-sha }}
 
 runs:
   using: composite
@@ -80,7 +101,11 @@ runs:
           --sha "$HEAD_SHA" \
           --repo "$REPO" \
           --fail-on-reject "$FAIL_ON_REJECT" \
-          --max-diff-lines "$MAX_DIFF_LINES"
+          --max-diff-lines "$MAX_DIFF_LINES" \
+          --post-results "$POST_RESULTS" \
+          --base-sha "$BASE_SHA" \
+          --base-repo "$BASE_REPO" \
+          --head-repo "$HEAD_REPO"
       env:
         ACTION_PATH: ${{ github.action_path }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
@@ -89,4 +114,8 @@ runs:
         REPO: ${{ github.repository }}
         FAIL_ON_REJECT: ${{ inputs.fail-on-reject }}
         MAX_DIFF_LINES: ${{ inputs.max-diff-lines }}
+        POST_RESULTS: ${{ inputs.post-results }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         CONFIG_PATH: ${{ inputs.config-path }}

--- a/packages/github/src/action-policy.ts
+++ b/packages/github/src/action-policy.ts
@@ -1,0 +1,114 @@
+import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
+
+export interface ActionInputs {
+  diff: string;
+  pr: number;
+  sha: string;
+  repo: string;
+  token: string;
+  failOnReject: boolean;
+  maxDiffLines: number;
+  postResults: boolean;
+  baseSha?: string;
+  baseRepo?: string;
+  headRepo?: string;
+}
+
+export interface ActionPolicy {
+  shouldRunReview: boolean;
+  shouldPostResults: boolean;
+  degraded: boolean;
+  degradedReason?: string;
+  verdictOverride?: 'SKIPPED';
+}
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value === '') return defaultValue;
+  return value.toLowerCase() === 'true';
+}
+
+export function parseActionInputs(argv: string[], env: NodeJS.ProcessEnv = process.env): ActionInputs {
+  const args: Record<string, string> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--') && i + 1 < argv.length) {
+      args[arg.slice(2)] = argv[i + 1]!;
+      i++;
+    }
+  }
+
+  const diff = args['diff'];
+  const pr = parseInt(args['pr'] ?? '', 10);
+  const sha = args['sha'] ?? '';
+  const repo = args['repo'] ?? '';
+  const token = env['GITHUB_TOKEN'] ?? '';
+  const failOnReject = parseBoolean(args['fail-on-reject'], false);
+  const maxDiffLines = parseInt(args['max-diff-lines'] ?? '5000', 10);
+  const postResults = parseBoolean(args['post-results'], true);
+  const baseSha = args['base-sha'];
+  const baseRepo = args['base-repo'];
+  const headRepo = args['head-repo'];
+
+  if (!diff) throw new Error('--diff is required');
+  if (isNaN(pr)) throw new Error('--pr must be a valid number');
+  if (!sha) throw new Error('--sha is required');
+  if (!repo || !repo.includes('/')) throw new Error('--repo must be in owner/repo format');
+  if (isNaN(maxDiffLines)) throw new Error('--max-diff-lines must be a valid number');
+
+  return { diff, pr, sha, repo, token, failOnReject, maxDiffLines, postResults, baseSha, baseRepo, headRepo };
+}
+
+export function hasProviderCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Object.values(PROVIDER_ENV_VARS).some((envVar) => {
+    if (envVar === 'GITHUB_TOKEN' || envVar === 'GITHUB_COPILOT_TOKEN') return false;
+    return Boolean(env[envVar]);
+  });
+}
+
+export function isForkContext(inputs: Pick<ActionInputs, 'baseRepo' | 'headRepo'>): boolean {
+  return Boolean(inputs.baseRepo && inputs.headRepo && inputs.baseRepo !== inputs.headRepo);
+}
+
+export function determineActionPolicy(
+  inputs: ActionInputs,
+  env: NodeJS.ProcessEnv = process.env,
+): ActionPolicy {
+  if (!inputs.token && inputs.postResults) {
+    return {
+      shouldRunReview: false,
+      shouldPostResults: false,
+      degraded: true,
+      degradedReason: 'missing-github-token',
+      verdictOverride: 'SKIPPED',
+    };
+  }
+
+  if (!hasProviderCredentials(env)) {
+    return {
+      shouldRunReview: false,
+      shouldPostResults: false,
+      degraded: true,
+      degradedReason: isForkContext(inputs) ? 'fork-missing-provider-secrets' : 'missing-provider-secrets',
+      verdictOverride: 'SKIPPED',
+    };
+  }
+
+  if (!inputs.postResults) {
+    return {
+      shouldRunReview: true,
+      shouldPostResults: false,
+      degraded: true,
+      degradedReason: 'posting-disabled',
+    };
+  }
+
+  return {
+    shouldRunReview: true,
+    shouldPostResults: true,
+    degraded: false,
+  };
+}
+
+export function isStaleHead(expectedHeadSha: string, currentHeadSha: string | undefined): boolean {
+  return Boolean(currentHeadSha && currentHeadSha !== expectedHeadSha);
+}

--- a/packages/github/src/action.ts
+++ b/packages/github/src/action.ts
@@ -16,62 +16,40 @@ import { buildDiffPositionIndex } from './diff-parser.js';
 import { mapToGitHubReview } from './mapper.js';
 import { postReview, setCommitStatus, handleNeedsHuman } from './poster.js';
 import { createAppOctokit } from './client.js';
+import { fetchPrMetadata } from './pr-diff.js';
 import { buildSarifReport, serializeSarif } from './sarif.js';
 import { loadConfigFrom } from '@codeagora/core/config/loader.js';
 import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
-
-// ============================================================================
-// Input Parsing
-// ============================================================================
-
-interface ActionInputs {
-  diff: string;
-  pr: number;
-  sha: string;
-  repo: string; // "owner/repo"
-  token: string;
-  failOnReject: boolean;
-  maxDiffLines: number;
-}
-
-function parseArgs(argv: string[]): ActionInputs {
-  const args: Record<string, string> = {};
-  for (let i = 2; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg.startsWith('--') && i + 1 < argv.length) {
-      args[arg.slice(2)] = argv[i + 1];
-      i++;
-    }
-  }
-
-  const diff = args['diff'];
-  const pr = parseInt(args['pr'] ?? '', 10);
-  const sha = args['sha'] ?? '';
-  const repo = args['repo'] ?? '';
-  const token = process.env['GITHUB_TOKEN'] ?? '';
-  const failOnReject = args['fail-on-reject'] === 'true';
-  const maxDiffLines = parseInt(args['max-diff-lines'] ?? '5000', 10);
-
-  if (!diff) throw new Error('--diff is required');
-  if (isNaN(pr)) throw new Error('--pr must be a valid number');
-  if (!sha) throw new Error('--sha is required');
-  if (!repo || !repo.includes('/')) throw new Error('--repo must be in owner/repo format');
-  if (!token) throw new Error('GITHUB_TOKEN environment variable is required');
-
-  return { diff, pr, sha, repo, token, failOnReject, maxDiffLines };
-}
+import { determineActionPolicy, isStaleHead, parseActionInputs } from './action-policy.js';
 
 // ============================================================================
 // Main
 // ============================================================================
 
 async function main(): Promise<void> {
-  const inputs = parseArgs(process.argv);
+  const inputs = parseActionInputs(process.argv);
   const [owner, repo] = inputs.repo.split('/');
 
   if (!owner || !repo) {
     console.error('Error: --repo must be in <owner>/<repo> format');
     process.exit(1);
+  }
+
+  setActionOutput('head-sha', inputs.sha);
+  if (inputs.baseSha) setActionOutput('base-sha', inputs.baseSha);
+
+  const actionPolicy = determineActionPolicy(inputs);
+  if (actionPolicy.degraded) {
+    setActionOutput('degraded', 'true');
+    if (actionPolicy.degradedReason) setActionOutput('degraded-reason', actionPolicy.degradedReason);
+  } else {
+    setActionOutput('degraded', 'false');
+  }
+
+  if (!actionPolicy.shouldRunReview) {
+    console.log(`::warning::CodeAgora review skipped: ${actionPolicy.degradedReason ?? 'degraded'}`);
+    setActionOutput('verdict', actionPolicy.verdictOverride ?? 'SKIPPED');
+    return;
   }
 
   // Check diff line count
@@ -80,6 +58,8 @@ async function main(): Promise<void> {
     const lineCount = diffContent.split('\n').length;
     if (lineCount > inputs.maxDiffLines) {
       console.log(`::warning::Diff has ${lineCount} lines (limit: ${inputs.maxDiffLines}). Skipping review.`);
+      setActionOutput('degraded', 'true');
+      setActionOutput('degraded-reason', 'diff-too-large');
       setActionOutput('verdict', 'SKIPPED');
       return;
     }
@@ -119,11 +99,8 @@ async function main(): Promise<void> {
     ? new Map(Object.entries(result.reviewerOpinions))
     : undefined;
 
-  // Build and post review
+  // Build review payload
   const ghConfig = { token: inputs.token, owner, repo };
-  console.log('::group::Posting review to GitHub');
-
-  // Wire config.github settings to mapper (#257)
   const ghIntegration = config?.github;
   const review = mapToGitHubReview({
     summary: result.summary,
@@ -148,16 +125,45 @@ async function main(): Promise<void> {
 
   const appKit = await createAppOctokit(owner, repo);
   if (appKit) console.log('Using GitHub App authentication (CodeAgora Bot)');
-  const postResult = await postReview(ghConfig, inputs.pr, review, appKit ?? undefined);
-  await setCommitStatus(ghConfig, inputs.sha, postResult.verdict, postResult.reviewUrl);
 
-  // Handle NEEDS_HUMAN: request reviewers and add label
-  if (postResult.verdict === 'NEEDS_HUMAN') {
-    await handleNeedsHuman(ghConfig, inputs.pr, {
-      humanReviewers: ghIntegration?.humanReviewers,
-      humanTeams: ghIntegration?.humanTeams,
-      needsHumanLabel: ghIntegration?.needsHumanLabel,
-    });
+  let reviewUrl = '';
+  let postedVerdict = result.summary.decision;
+
+  if (actionPolicy.shouldPostResults) {
+    console.log('::group::Posting review to GitHub');
+    const currentPr = await fetchPrMetadata(ghConfig, inputs.pr, appKit ?? undefined);
+    if (isStaleHead(inputs.sha, currentPr.headSha)) {
+      console.log(`::warning::PR head changed from ${inputs.sha} to ${currentPr.headSha}; skipping stale posting.`);
+      setActionOutput('degraded', 'true');
+      setActionOutput('degraded-reason', 'stale-head-sha');
+      setActionOutput('verdict', 'SKIPPED');
+      console.log('::endgroup::');
+      return;
+    }
+
+    try {
+      const postResult = await postReview(ghConfig, inputs.pr, review, appKit ?? undefined);
+      await setCommitStatus(ghConfig, inputs.sha, postResult.verdict, postResult.reviewUrl, appKit ?? undefined);
+      reviewUrl = postResult.reviewUrl;
+      postedVerdict = postResult.verdict;
+
+      // Handle NEEDS_HUMAN: request reviewers and add label
+      if (postResult.verdict === 'NEEDS_HUMAN') {
+        await handleNeedsHuman(ghConfig, inputs.pr, {
+          humanReviewers: ghIntegration?.humanReviewers,
+          humanTeams: ghIntegration?.humanTeams,
+          needsHumanLabel: ghIntegration?.needsHumanLabel,
+        }, appKit ?? undefined);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.log(`::warning::GitHub posting degraded: ${message}`);
+      setActionOutput('degraded', 'true');
+      setActionOutput('degraded-reason', 'github-post-failed');
+    }
+    console.log('::endgroup::');
+  } else {
+    console.log(`::warning::GitHub posting skipped: ${actionPolicy.degradedReason ?? 'posting-disabled'}`);
   }
 
   // Generate SARIF output — validate path to prevent traversal attacks
@@ -173,18 +179,16 @@ async function main(): Promise<void> {
     console.error(`::warning::SARIF output path rejected: ${sarifValidation.error}`);
   }
 
-  console.log('::endgroup::');
-
   // Set outputs
   setActionOutput('verdict', result.summary.decision);
-  setActionOutput('review-url', postResult.reviewUrl);
+  if (reviewUrl) setActionOutput('review-url', reviewUrl);
   setActionOutput('session-id', result.sessionId);
 
-  console.log(`Review posted: ${postResult.reviewUrl}`);
+  if (reviewUrl) console.log(`Review posted: ${reviewUrl}`);
   console.log(`Verdict: ${result.summary.decision}`);
 
   // Exit with failure if REJECT and failOnReject is enabled
-  if (result.summary.decision === 'REJECT' && inputs.failOnReject) {
+  if (postedVerdict === 'REJECT' && inputs.failOnReject) {
     process.exit(1);
   }
 }

--- a/packages/github/src/pr-diff.ts
+++ b/packages/github/src/pr-diff.ts
@@ -13,6 +13,36 @@ function repoFullName(repo: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
+export async function fetchPrMetadata(
+  config: GitHubConfig,
+  prNumber: number,
+  octokit?: Octokit,
+): Promise<Omit<PullRequestInfo, 'diff' | 'truncated'>> {
+  const kit = octokit ?? createOctokit(config);
+  const { data: pr } = await kit.pulls.get({
+    owner: config.owner,
+    repo: config.repo,
+    pull_number: prNumber,
+  });
+
+  const baseRepoFullName = repoFullName(pr.base.repo);
+  const headRepoFullName = repoFullName(pr.head.repo);
+
+  return {
+    number: pr.number,
+    title: pr.title,
+    baseBranch: pr.base.ref,
+    headBranch: pr.head.ref,
+    baseSha: pr.base.sha,
+    headSha: pr.head.sha,
+    baseRepoFullName,
+    headRepoFullName,
+    isFork: baseRepoFullName !== undefined && headRepoFullName !== undefined
+      ? baseRepoFullName !== headRepoFullName
+      : undefined,
+  };
+}
+
 /**
  * Fetch a pull request's metadata and unified diff.
  *
@@ -26,13 +56,7 @@ export async function fetchPrDiff(
   octokit?: Octokit
 ): Promise<PullRequestInfo> {
   const kit = octokit ?? createOctokit(config);
-
-  // Fetch PR metadata (JSON)
-  const { data: pr } = await kit.pulls.get({
-    owner: config.owner,
-    repo: config.repo,
-    pull_number: prNumber,
-  });
+  const metadata = await fetchPrMetadata(config, prNumber, kit);
 
   // Fetch raw diff using the diff media type
   const diffResponse = await kit.pulls.get({
@@ -54,17 +78,7 @@ export async function fetchPrDiff(
   }
 
   return {
-    number: pr.number,
-    title: pr.title,
-    baseBranch: pr.base.ref,
-    headBranch: pr.head.ref,
-    baseSha: pr.base.sha,
-    headSha: pr.head.sha,
-    baseRepoFullName: repoFullName(pr.base.repo),
-    headRepoFullName: repoFullName(pr.head.repo),
-    isFork: repoFullName(pr.base.repo) !== undefined && repoFullName(pr.head.repo) !== undefined
-      ? repoFullName(pr.base.repo) !== repoFullName(pr.head.repo)
-      : undefined,
+    ...metadata,
     diff: diffContent,
     truncated,
   };

--- a/packages/github/src/tests/pr-diff.test.ts
+++ b/packages/github/src/tests/pr-diff.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { fetchPrDiff } from '../pr-diff.js';
+import { fetchPrDiff, fetchPrMetadata } from '../pr-diff.js';
 import type { GitHubConfig } from '../client.js';
 
 // ============================================================================
@@ -57,6 +57,32 @@ function makeOctokit(options: {
 // ============================================================================
 // fetchPrDiff
 // ============================================================================
+
+describe('fetchPrMetadata', () => {
+  it('returns PR metadata without fetching the raw diff', async () => {
+    const octokit = makeOctokit({
+      prData: {
+        number: 7,
+        title: 'Fresh head',
+        base: { ref: 'main', sha: 'base1', repo: { full_name: 'test-owner/test-repo' } },
+        head: { ref: 'feature', sha: 'head1', repo: { full_name: 'fork-owner/test-repo' } },
+      },
+    });
+
+    const result = await fetchPrMetadata(makeConfig(), 7, octokit as never);
+
+    expect(result).toEqual(expect.objectContaining({
+      number: 7,
+      title: 'Fresh head',
+      baseSha: 'base1',
+      headSha: 'head1',
+      baseRepoFullName: 'test-owner/test-repo',
+      headRepoFullName: 'fork-owner/test-repo',
+      isFork: true,
+    }));
+    expect(octokit.pulls.get).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('fetchPrDiff', () => {
   it('returns PR number, title, baseBranch, headBranch, and diff', async () => {

--- a/src/tests/github-action-parse-args.test.ts
+++ b/src/tests/github-action-parse-args.test.ts
@@ -1,51 +1,23 @@
 /**
- * github-action.ts parseArgs unit tests
- * Exercises the exported parseArgs function via dynamic import.
+ * GitHub Action input and policy tests.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import {
+  determineActionPolicy,
+  hasProviderCredentials,
+  isForkContext,
+  isStaleHead,
+  parseActionInputs,
+} from '@codeagora/github/action-policy.js';
 
-// parseArgs reads process.env.GITHUB_TOKEN — set it before importing
 const TOKEN = 'test-token-123';
 
-// We test parseArgs by re-implementing it inline (it is not exported),
-// so we copy the function signature from the source for isolated unit testing.
-
-function parseArgs(argv: string[], token: string): {
-  diff: string;
-  pr: number;
-  sha: string;
-  repo: string;
-  token: string;
-  failOnReject: boolean;
-  maxDiffLines: number;
-} {
-  const args: Record<string, string> = {};
-  for (let i = 2; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg.startsWith('--') && i + 1 < argv.length) {
-      args[arg.slice(2)] = argv[i + 1];
-      i++;
-    }
-  }
-
-  const diff = args['diff'];
-  const pr = parseInt(args['pr'] ?? '', 10);
-  const sha = args['sha'] ?? '';
-  const repo = args['repo'] ?? '';
-  const failOnReject = args['fail-on-reject'] === 'true';
-  const maxDiffLines = parseInt(args['max-diff-lines'] ?? '5000', 10);
-
-  if (!diff) throw new Error('--diff is required');
-  if (isNaN(pr)) throw new Error('--pr must be a valid number');
-  if (!sha) throw new Error('--sha is required');
-  if (!repo || !repo.includes('/')) throw new Error('--repo must be in owner/repo format');
-  if (!token) throw new Error('GITHUB_TOKEN environment variable is required');
-
-  return { diff, pr, sha, repo, token, failOnReject, maxDiffLines };
+function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...overrides };
 }
 
-describe('github-action parseArgs', () => {
+describe('github-action parseActionInputs', () => {
   const validArgv = [
     'node', 'github-action.js',
     '--diff', '/tmp/pr.diff',
@@ -55,7 +27,7 @@ describe('github-action parseArgs', () => {
   ];
 
   it('parses valid arguments correctly', () => {
-    const result = parseArgs(validArgv, TOKEN);
+    const result = parseActionInputs(validArgv, env({ GITHUB_TOKEN: TOKEN }));
     expect(result.diff).toBe('/tmp/pr.diff');
     expect(result.pr).toBe(42);
     expect(result.sha).toBe('abc123');
@@ -63,41 +35,123 @@ describe('github-action parseArgs', () => {
     expect(result.token).toBe(TOKEN);
     expect(result.failOnReject).toBe(false);
     expect(result.maxDiffLines).toBe(5000);
+    expect(result.postResults).toBe(true);
   });
 
-  it('parses --fail-on-reject true correctly', () => {
-    const argv = [...validArgv, '--fail-on-reject', 'true'];
-    const result = parseArgs(argv, TOKEN);
+  it('parses production-path metadata and posting controls', () => {
+    const result = parseActionInputs([
+      ...validArgv,
+      '--fail-on-reject', 'true',
+      '--max-diff-lines', '1000',
+      '--post-results', 'false',
+      '--base-sha', 'base123',
+      '--base-repo', 'owner/repo',
+      '--head-repo', 'fork/repo',
+    ], env({ GITHUB_TOKEN: TOKEN }));
+
     expect(result.failOnReject).toBe(true);
-  });
-
-  it('parses custom --max-diff-lines', () => {
-    const argv = [...validArgv, '--max-diff-lines', '1000'];
-    const result = parseArgs(argv, TOKEN);
     expect(result.maxDiffLines).toBe(1000);
+    expect(result.postResults).toBe(false);
+    expect(result.baseSha).toBe('base123');
+    expect(result.baseRepo).toBe('owner/repo');
+    expect(result.headRepo).toBe('fork/repo');
   });
 
   it('throws when --diff is missing', () => {
     const argv = ['node', 'github-action.js', '--pr', '1', '--sha', 'x', '--repo', 'a/b'];
-    expect(() => parseArgs(argv, TOKEN)).toThrow('--diff is required');
+    expect(() => parseActionInputs(argv, env({ GITHUB_TOKEN: TOKEN }))).toThrow('--diff is required');
   });
 
   it('throws when --pr is not a number', () => {
     const argv = ['node', 'github-action.js', '--diff', 'f', '--pr', 'abc', '--sha', 'x', '--repo', 'a/b'];
-    expect(() => parseArgs(argv, TOKEN)).toThrow('--pr must be a valid number');
+    expect(() => parseActionInputs(argv, env({ GITHUB_TOKEN: TOKEN }))).toThrow('--pr must be a valid number');
   });
 
   it('throws when --sha is missing', () => {
     const argv = ['node', 'github-action.js', '--diff', 'f', '--pr', '1', '--repo', 'a/b'];
-    expect(() => parseArgs(argv, TOKEN)).toThrow('--sha is required');
+    expect(() => parseActionInputs(argv, env({ GITHUB_TOKEN: TOKEN }))).toThrow('--sha is required');
   });
 
   it('throws when --repo is missing slash', () => {
     const argv = ['node', 'github-action.js', '--diff', 'f', '--pr', '1', '--sha', 'x', '--repo', 'noslash'];
-    expect(() => parseArgs(argv, TOKEN)).toThrow('--repo must be in owner/repo format');
+    expect(() => parseActionInputs(argv, env({ GITHUB_TOKEN: TOKEN }))).toThrow('--repo must be in owner/repo format');
   });
 
-  it('throws when GITHUB_TOKEN is empty', () => {
-    expect(() => parseArgs(validArgv, '')).toThrow('GITHUB_TOKEN environment variable is required');
+  it('allows missing GITHUB_TOKEN so runtime can return degraded outputs', () => {
+    const result = parseActionInputs(validArgv, env());
+    expect(result.token).toBe('');
+  });
+});
+
+describe('github-action production policy', () => {
+  const baseInputs = parseActionInputs([
+    'node', 'github-action.js',
+    '--diff', '/tmp/pr.diff',
+    '--pr', '42',
+    '--sha', 'head123',
+    '--repo', 'owner/repo',
+    '--base-repo', 'owner/repo',
+    '--head-repo', 'owner/repo',
+  ], env({ GITHUB_TOKEN: TOKEN }));
+
+  it('runs and posts for normal same-repository PRs', () => {
+    expect(determineActionPolicy(baseInputs, env({ GITHUB_TOKEN: TOKEN, GROQ_API_KEY: 'key' }))).toEqual({
+      shouldRunReview: true,
+      shouldPostResults: true,
+      degraded: false,
+    });
+  });
+
+  it('skips clearly when GitHub posting is enabled but token is missing', () => {
+    const inputs = { ...baseInputs, token: '' };
+    expect(determineActionPolicy(inputs, env())).toEqual({
+      shouldRunReview: false,
+      shouldPostResults: false,
+      degraded: true,
+      degradedReason: 'missing-github-token',
+      verdictOverride: 'SKIPPED',
+    });
+  });
+
+  it('skips same-repository PRs without provider credentials with a clear reason', () => {
+    expect(determineActionPolicy(baseInputs, env({ GITHUB_TOKEN: TOKEN }))).toEqual({
+      shouldRunReview: false,
+      shouldPostResults: false,
+      degraded: true,
+      degradedReason: 'missing-provider-secrets',
+      verdictOverride: 'SKIPPED',
+    });
+  });
+
+  it('skips fork PRs without provider credentials to avoid secret-dependent failures', () => {
+    const inputs = { ...baseInputs, baseRepo: 'owner/repo', headRepo: 'fork/repo' };
+    expect(isForkContext(inputs)).toBe(true);
+    expect(determineActionPolicy(inputs, env({ GITHUB_TOKEN: TOKEN }))).toEqual({
+      shouldRunReview: false,
+      shouldPostResults: false,
+      degraded: true,
+      degradedReason: 'fork-missing-provider-secrets',
+      verdictOverride: 'SKIPPED',
+    });
+  });
+
+  it('keeps review execution but disables posting when requested', () => {
+    const inputs = { ...baseInputs, postResults: false };
+    expect(determineActionPolicy(inputs, env({ GITHUB_TOKEN: TOKEN, GROQ_API_KEY: 'key' }))).toEqual({
+      shouldRunReview: true,
+      shouldPostResults: false,
+      degraded: true,
+      degradedReason: 'posting-disabled',
+    });
+  });
+
+  it('detects provider credentials without treating GITHUB_TOKEN as an LLM secret', () => {
+    expect(hasProviderCredentials(env({ GITHUB_TOKEN: TOKEN }))).toBe(false);
+    expect(hasProviderCredentials(env({ GITHUB_TOKEN: TOKEN, OPENAI_API_KEY: 'sk-test' }))).toBe(true);
+  });
+
+  it('detects stale head SHAs before posting', () => {
+    expect(isStaleHead('head123', 'head123')).toBe(false);
+    expect(isStaleHead('head123', 'head456')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add source-tested GitHub Action policy parsing for degraded/skip modes, provider secret checks, fork handling, and stale head SHA detection.
- Preserve PR head/base metadata separately from diff retrieval and surface `degraded`, `degraded-reason`, `head-sha`, and `base-sha` outputs.
- Rebuild the committed Action bundle and update the composite Action manifest for production-path inputs/outputs.

Refs #520

## Verification
- LSP diagnostics clean for changed TypeScript files.
- `pnpm vitest run src/tests/github-action-parse-args.test.ts packages/github/src/tests/pr-diff.test.ts packages/github/src/tests/github-poster.test.ts packages/github/src/tests/github-poster-extended.test.ts src/tests/github-action-sarif-path.test.ts src/tests/github-sarif.test.ts src/tests/pipeline-dryrun.test.ts`
- `pnpm typecheck`
- `pnpm build:action`
- `pnpm build`
- `pnpm test`
- Bundled action smoke: fork PR without provider secrets exits 0 and outputs `degraded=true`, `degraded-reason=fork-missing-provider-secrets`, `verdict=SKIPPED`, `head-sha=head123`, `base-sha=base123`.

## Notes
- A local `.github/workflows/build-action.yml` trigger tweak was intentionally omitted from this branch because the current OAuth credentials cannot push workflow-file changes without `workflow` scope.