### PR TITLE
Add P4-P6 production release gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,50 @@
-# Oh My CodeReview - Environment Variables
+# CodeAgora environment template
+# Copy to .env for local development only. Never commit real secrets.
 
-# ============================================
-# OpenCode Backend (API 키 불필요!)
-# ============================================
+# ============================================================
+# Local CLI review providers
+# ============================================================
+# Set at least one provider key for live API-backed reviews.
+# CLI-backed providers such as Claude Code, Codex CLI, Gemini CLI, or OpenCode
+# may use their own local authentication instead of these variables.
 
-# OpenCode에 모든 인증 설정 완료:
-# - Claude Haiku: GitHub Copilot
-# - Kimi, Minimax: OpenCode Zen
-# - Gemini: OpenCode Google Auth
-#
-# 프로젝트에서 API 키 설정 필요 없음!
+OPENAI_API_KEY=sk-your-openai-key-here
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-key-here
+GOOGLE_GENERATIVE_AI_API_KEY=your-google-generative-ai-key-here
+GOOGLE_API_KEY=your-google-api-key-here
+GROQ_API_KEY=gsk-your-groq-key-here
+OPENROUTER_API_KEY=sk-or-your-openrouter-key-here
 
-# ============================================
-# GitHub Integration (Optional)
-# ============================================
-# Required only if you want to post reviews to GitHub PRs
+# Optional provider integrations supported by the provider registry.
+MISTRAL_API_KEY=your-mistral-key-here
+CEREBRAS_API_KEY=your-cerebras-key-here
+TOGETHER_API_KEY=your-together-key-here
+XAI_API_KEY=your-xai-key-here
+DEEPSEEK_API_KEY=your-deepseek-key-here
+QWEN_API_KEY=your-qwen-key-here
+ZAI_API_KEY=your-zai-key-here
+NVIDIA_NIM_API_KEY=your-nvidia-nim-key-here
 
-# GITHUB_TOKEN=ghp_your-github-token-here
+# ============================================================
+# GitHub Action / PR posting
+# ============================================================
+# Required by GitHub PR posting flows. In GitHub Actions, prefer
+# `${{ secrets.GITHUB_TOKEN }}` or the workflow-provided token.
+
+GITHUB_TOKEN=your-github-token-placeholder
+
+# ============================================================
+# Benchmarks
+# ============================================================
+# Required CI benchmark gates are offline and do not need provider keys:
+#   pnpm bench:ci
+#   pnpm bench:fn -- --validate-only
+#   pnpm bench:reference -- --validate-only
+# Manual live benchmark runs do require provider keys for the selected config:
+#   pnpm bench:fn:run -- --results ./bench-out
+
+# ============================================================
+# MCP server
+# ============================================================
+# MCP config/status tools can run without provider keys. Live review tools use
+# the same provider variables above, and PR review tools may need GITHUB_TOKEN.

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ XAI_API_KEY=your-xai-key-here
 DEEPSEEK_API_KEY=your-deepseek-key-here
 QWEN_API_KEY=your-qwen-key-here
 ZAI_API_KEY=your-zai-key-here
-NVIDIA_NIM_API_KEY=your-nvidia-nim-key-here
+NVIDIA_API_KEY=your-nvidia-nim-key-here
 
 # ============================================================
 # GitHub Action / PR posting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm test --no-file-parallelism
+      - name: Deterministic benchmark gate
+        if: matrix.node-version == 20
+        run: pnpm bench:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test --no-file-parallelism
+      - run: pnpm bench:ci
 
-      # Smoke test: pack and verify CLI works
-      - name: Smoke test
-        run: |
-          npm pack
-          SMOKE_DIR="$(mktemp -d)"
-          cd "$SMOKE_DIR"
-          npm init -y
-          npm i $GITHUB_WORKSPACE/codeagora-review-*.tgz
-          npx agora --version
-          npx agora doctor || echo "::warning::doctor check failed (expected without API keys)"
+      # Non-publishing RC gate: package dry-runs, CLI help, MCP tools/list, Action bundle.
+      - name: Release candidate smoke
+        run: pnpm release:rc-smoke
 
       # Publish review package
       - name: Publish @codeagora/review

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ benchmarks/.ca/model-quality.json
 # OMC
 .omc
 
+# Agent-local planning/evidence
+.sisyphus/
+
 # Archives
 .archive/
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ An initial private scaffold lives in `packages/desktop` while the desktop MVP ta
 
 Tools: `review_quick`, `review_full`, `review_pr`, `dry_run`, `explain_session`, `get_leaderboard`, `get_stats`, `config_get`, `config_set`.
 
+Package-local MCP onboarding: [`packages/mcp/README.md`](packages/mcp/README.md).
+
 ---
 
 ## Extensions
@@ -198,14 +200,24 @@ pnpm dev review path/to/diff.patch
 
 ## Benchmarks
 
-Golden-bug fixtures under `benchmarks/golden-bugs/` drive the false-negative measurement framework (see #472).
+Golden-bug fixtures under `benchmarks/golden-bugs/` drive the false-negative and FP-regression framework (see #472). The current deterministic RC gate covers 20 fixtures: 14 recall cases and 6 FP-regression cases.
+
+**Required offline gate** (fast, no API calls):
+
+```bash
+pnpm bench:ci                                      # schema + reference gate for CI
+pnpm bench:fn -- --validate-only                   # schema-check fixtures
+pnpm bench:reference -- --validate-only            # validate the 20-fixture reference gate
+```
+
+The required gate is provider-free. Live benchmark runs are manual evidence artifacts, and `bench-out*` result directories stay uncommitted; CI/workflows should upload artifacts instead.
 
 **Score pre-computed results** (fast, no API calls):
 
 ```bash
-pnpm bench:fn -- --validate-only                     # schema-check fixtures
 pnpm bench:fn -- --results path/to/results-dir       # score against pre-computed review output
 pnpm bench:fn -- --results path/to/results-dir --json  # CI-friendly JSON report
+pnpm bench:fn:compare -- --baseline old-results --candidate new-results
 ```
 
 **Run the live pipeline against every fixture** (produces the results dir above):
@@ -223,7 +235,7 @@ Two fixture kinds live side by side:
 - **Recall cases** (`expectedFindings` non-empty) — review must surface each listed bug. Misses count as FN.
 - **FP regression cases** (`expectedFindings` is `[]`) — review must report nothing. Any finding is a regression.
 
-Current seed fixtures: 8 recall cases (10 expected findings total) + 4 FP regression cases. See `benchmarks/golden-bugs/README.md` for fixture format.
+Current reference fixtures: 14 recall cases + 6 FP regression cases. See `benchmarks/golden-bugs/README.md` for fixture format and reference-gate semantics.
 
 ### Latest low-cost diverse aggregate (2026-04-28 KST)
 

--- a/benchmarks/golden-bugs/README.md
+++ b/benchmarks/golden-bugs/README.md
@@ -14,7 +14,7 @@ See `scripts/bench-fn.ts` (scorer) and `scripts/bench-fn-run.ts` (live-pipeline 
 
 The Phase 2 reference dataset currently contains 20 fixtures: 14 recall cases and 6 FP-regression cases.
 
-The read-only reference set lives at `benchmarks/references/phase2-quality-gate.json`:
+The read-only reference set lives at `benchmarks/references/phase2-quality-gate.json`. It is the deterministic offline RC contract for the current 20-fixture corpus: required gates validate fixture schemas and the reference file without provider keys or network calls. Live provider runs are optional evidence artifacts; score those precomputed result directories separately when comparing model changes.
 
 ```bash
 pnpm bench:reference -- --validate-only

--- a/benchmarks/references/phase2-quality-gate.json
+++ b/benchmarks/references/phase2-quality-gate.json
@@ -32,5 +32,5 @@
     "maxFalsePositives": 0,
     "maxFalseNegatives": 0
   },
-  "notes": "Read-only reference set for model-change regression checks. Validate with pnpm bench:reference -- --validate-only; score a live result directory with pnpm bench:reference -- --results <dir>."
+  "notes": "Deterministic offline RC reference for the 20-fixture golden-bug corpus. Required gates validate this schema/reference without provider calls; live result directories are evidence artifacts scored with pnpm bench:reference -- --results <dir>."
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -94,7 +94,7 @@ agora sessions prune --days 30               # Delete old
 
 ## `agora metrics`
 
-Generate local quality/cost artifacts without a web dashboard.
+Generate local quality/cost artifacts without a web dashboard. For release-candidate benchmark gates, use `pnpm bench:ci` for provider-free schema/reference validation and `pnpm bench:fn:compare` to compare precomputed candidate and baseline result directories.
 
 ```bash
 agora metrics benchmark --results ./bench-out-l3-20-20260428
@@ -102,7 +102,7 @@ agora metrics benchmark --results ./bench-out-l3-20-20260428 --json
 agora metrics benchmark --results ./bench-out-l3-20-20260428 --out ./bench-reports/phase2
 ```
 
-`--out` writes `benchmark-metrics.json` and `benchmark-metrics.md`.
+`--out` writes `benchmark-metrics.json` and `benchmark-metrics.md`. Live benchmark result directories such as `bench-out*` are evidence artifacts and should be uploaded or archived outside git rather than committed.
 
 ## `agora research`
 

--- a/docs/PRODUCTION_READINESS_ROADMAP.md
+++ b/docs/PRODUCTION_READINESS_ROADMAP.md
@@ -147,7 +147,7 @@ Make quality claims evidence-based instead of anecdotal.
 - High-severity seeded findings meet the agreed recall threshold before release.
 - FP regression fixtures remain clean within the agreed tolerance.
 - No accepted production candidate fabricates files, line ranges, or code quotes in benchmark output.
-- CI blocks benchmark schema regressions and flags material quality regressions.
+- CI blocks benchmark schema regressions and flags material quality regressions with `pnpm bench:ci`, a provider-free gate that validates fixture schemas and the 20-fixture reference file.
 
 ## Phase 5: Security And Abuse Resistance
 
@@ -186,7 +186,7 @@ Make install, first run, upgrade, and release boring.
 
 ### Acceptance Gate
 
-- Clean checkout: `pnpm install`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
+- Clean checkout: `pnpm install`, `pnpm build`, `pnpm typecheck`, `pnpm test`, and `pnpm bench:ci` pass.
 - Package dry-run includes only intended files and working binaries.
 - Global install smoke runs `agora --help`, `agora init --yes`, and a minimal review path.
 - MCP smoke starts via package command and lists tools.
@@ -219,7 +219,7 @@ A production release candidate requires all of the following:
 - Phase 0 through Phase 6 acceptance gates complete.
 - `pnpm typecheck`, `pnpm build`, `pnpm test`, and action bundle build pass on clean checkout.
 - CLI, GitHub Action, and MCP manual QA pass through their real user surfaces.
-- Latest benchmark report is linked from README or release notes.
+- Latest benchmark report is linked from README or release notes, and live `bench:fn:run` result directories are treated as uploaded artifacts rather than committed `bench-out*` directories.
 - Known limits are documented, especially provider nondeterminism, cost variance, language coverage, and fork-secret behavior.
 - No retired surface is required for setup, review execution, or result inspection.
 

--- a/docs/RC_READINESS_P4_P6.md
+++ b/docs/RC_READINESS_P4_P6.md
@@ -1,0 +1,88 @@
+# P4-P6 RC Readiness Summary
+
+Updated: 2026-05-02
+
+This document summarizes the release-candidate readiness gates added for the production-readiness P4-P6 track. The scope is intentionally limited to deterministic validation, security hardening, documentation, and non-publishing RC smoke checks. It does not perform npm publishing, GitHub release creation, tagging, dist-tag updates, or marketplace distribution.
+
+## P4: Benchmark Gate
+
+The required benchmark gate is now deterministic and provider-free:
+
+```bash
+pnpm bench:ci
+```
+
+The gate validates the golden-bug fixture schema and the phase-2 quality reference. CI runs this gate on Node 20 so release readiness does not depend on live LLM providers or quota availability.
+
+Current reference contract:
+
+- 20 fixtures validated
+- 14 recall fixtures
+- 6 FP-regression fixtures
+- Reference file: `benchmarks/references/phase2-quality-gate.json`
+- Fixture format notes: `benchmarks/golden-bugs/README.md`
+
+## P5: Security Boundaries
+
+Path hardening now covers the production entry points that read user-controlled files:
+
+- Explicit config paths must resolve within the configured project root.
+- GitHub Action `diff` inputs are validated before filesystem reads.
+- Shared path validation resolves real paths before root containment checks.
+
+Redaction now covers persisted and outward-facing review artifacts:
+
+- L1 reviewer session artifacts
+- L2 discussion, report, and suggestion artifacts
+- L3 final verdict artifacts
+- GitHub PR review body and inline comment output
+- MCP compact responses and structured tool errors
+
+Bearer-token style secrets are included in the shared redaction contract.
+
+Large-diff prioritization is also regression-tested so security findings stay ahead of low-priority comments when inline review output is capped.
+
+## P6: RC Smoke And Onboarding
+
+The RC smoke command is non-publishing by design:
+
+```bash
+pnpm release:rc-smoke
+```
+
+It verifies:
+
+- workspace build
+- production GitHub Action bundle build
+- root package dry-run contents
+- MCP package dry-run contents
+- CLI `--help` smoke
+- MCP initialize plus `tools/list` smoke
+
+The release workflow runs the deterministic benchmark gate and RC smoke before publish-capable steps. The checklist in `docs/RELEASE_CHECKLIST.md` documents manual guardrails for actual release operations.
+
+MCP onboarding is now package-local in `packages/mcp/README.md`, and the MCP server version is sourced from `packages/mcp/package.json` rather than a hard-coded string.
+
+## Verification Evidence
+
+Local verification completed with:
+
+```bash
+pnpm typecheck
+pnpm build
+pnpm bench:ci
+pnpm test
+pnpm release:rc-smoke
+pnpm exec node scripts/verify-package-contents.mjs
+```
+
+Observed results:
+
+- `pnpm typecheck`: passed
+- `pnpm build`: passed
+- `pnpm bench:ci`: passed; 20 fixtures validated
+- `pnpm test`: 204 files passed, 1 skipped; 3408 tests passed, 21 skipped
+- `pnpm release:rc-smoke`: passed; package dry-run, CLI smoke, MCP smoke all passed
+- `verify-package-contents`: passed; root files 12, MCP files 3
+
+Evidence logs are stored under `.sisyphus/evidence/` for local audit and are not required release artifacts.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,32 @@
+# Release Candidate Checklist
+
+This checklist verifies P4-P6 release-candidate readiness without publishing anything.
+
+## Scope Guardrails
+
+The RC gate does not perform npm publish, npm dist-tag promotion, GitHub tag creation, GitHub Release creation, marketplace publication, or Action release promotion. Those operations remain out of scope until a separate release approval.
+
+## Release Surfaces
+
+1. Root CLI package: `@codeagora/review`, including the `codeagora` and `agora` binaries.
+2. MCP package: `@codeagora/mcp`, including the `codeagora-mcp` binary and package-local onboarding.
+3. GitHub Action: repo-native composite Action backed by `dist/action.js`.
+
+## RC Gates
+
+1. Confirm package version consistency between release notes, root `package.json`, and `packages/mcp/package.json`.
+2. Run `pnpm typecheck`.
+3. Run `pnpm test`.
+4. Run `pnpm build`.
+5. Run `pnpm bench:ci` to validate deterministic benchmark schema/reference gates without live providers.
+6. Run `pnpm release:rc-smoke` to validate local package and Action smoke behavior without publishing.
+7. Run root package pack dry-run and confirm runtime files for `codeagora`/`agora` are included while tests, `.env`, `bench-out*`, and `.sisyphus/evidence` are excluded.
+8. Run `pnpm --filter @codeagora/mcp pack --dry-run` and confirm `dist/index.js`, `package.json`, and `README.md` are included while tests and secrets are excluded.
+9. Run the GitHub Action smoke path through `pnpm build:action` and the release smoke script.
+10. Review README, CLI docs, MCP onboarding, `.env.example`, and Action docs for current install and secret requirements.
+11. Open the PR and verify remote checks: CI Node 20/22, CodeAgora review, and PR size label.
+12. Confirm P6 RC readiness only after P4 deterministic benchmark gates and P5 security abuse gates pass.
+
+## Evidence
+
+Capture command output under `.sisyphus/evidence/` for typecheck, test, build, `bench:ci`, `release:rc-smoke`, root package dry-run, MCP package dry-run, and security regression tests.

--- a/docs/golden-bug-benchmark-report-2026-04-27.md
+++ b/docs/golden-bug-benchmark-report-2026-04-27.md
@@ -25,12 +25,16 @@ The final confirmed low-cost diverse aggregate reached full benchmark coverage o
 
 No API key values were inspected or recorded. Only key presence and behavior were validated during the run.
 
+Current RC note: this historical live-run report remains benchmark evidence, but required CI now uses the deterministic 20-fixture offline gate: `pnpm bench:ci`, which runs fixture schema validation and `benchmarks/references/phase2-quality-gate.json` reference validation without provider keys. New `bench-out*` live result directories should remain uncommitted and be uploaded as workflow artifacts when needed.
+
 ## Benchmark Scope
 
-The benchmark used the fixtures in `benchmarks/golden-bugs/`:
+The historical live benchmark used the then-current fixtures in `benchmarks/golden-bugs/`:
 
 - 8 recall fixtures with 10 expected findings total.
 - 4 FP-regression fixtures where a clean review must emit no findings.
+
+The current deterministic reference gate has since expanded to 20 fixtures: 14 recall cases and 6 FP-regression cases.
 
 The low-cost aggregate used `benchmarks/.ca/config.low-cost-diverse.json` with:
 

--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
     "test:coverage": "vitest run --coverage",
     "dev": "pnpm --filter @codeagora/cli dev",
     "build:action": "node scripts/build-action.mjs",
+    "release:rc-smoke": "node scripts/rc-smoke.mjs",
     "bench:fn": "tsx scripts/bench-fn.ts",
     "bench:fn:run": "tsx scripts/bench-fn-run.ts",
     "bench:fn:compare": "tsx scripts/bench-fn-compare.ts",
     "bench:reference": "tsx scripts/bench-reference-check.ts",
+    "bench:ci": "pnpm bench:fn -- --validate-only && pnpm bench:reference -- --validate-only",
     "bench:rate-limit": "tsx scripts/bench-rate-limit-sim.ts"
   },
   "dependencies": {

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { parse as parseYaml } from 'yaml';
 import { Config, validateConfig, type AgentConfig, type ReviewerEntry, type DeclarativeReviewers } from '../types/config.js';
 import { readJson, CA_ROOT } from '@codeagora/shared/utils/fs.js';
+import { validatePathWithinRoot } from '@codeagora/shared/utils/path-validation.js';
 
 // ============================================================================
 // Config Loader
@@ -55,13 +56,19 @@ export async function loadConfigFrom(baseDir: string): Promise<Config> {
 /**
  * Load config from an explicit JSON/YAML file path.
  */
-export async function loadConfigFile(filePath: string): Promise<Config> {
-  const ext = path.extname(filePath).toLowerCase();
+export async function loadConfigFile(
+  filePath: string,
+  options?: { rootDir?: string },
+): Promise<Config> {
+  const safePath = options?.rootDir
+    ? await validateExplicitConfigPath(filePath, options.rootDir)
+    : filePath;
+  const ext = path.extname(safePath).toLowerCase();
   if (ext === '.yaml' || ext === '.yml') {
-    return loadYamlConfig(filePath);
+    return loadYamlConfig(safePath);
   }
 
-  const data = await readJson(filePath);
+  const data = await readJson(safePath);
   return validateConfig(data);
 }
 
@@ -100,6 +107,14 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function validateExplicitConfigPath(filePath: string, rootDir: string): Promise<string> {
+  const validation = await validatePathWithinRoot(filePath, rootDir);
+  if (!validation.success) {
+    throw new Error(`Config path rejected: ${validation.error}`);
+  }
+  return validation.data;
 }
 
 async function loadYamlConfig(filePath: string): Promise<Config> {

--- a/packages/core/src/l1/writer.ts
+++ b/packages/core/src/l1/writer.ts
@@ -5,6 +5,7 @@
 
 import type { ReviewOutput, EvidenceDocument } from '../types/core.js';
 import { writeMarkdown, getReviewsDir } from '@codeagora/shared/utils/fs.js';
+import { redactSecrets } from '@codeagora/shared/utils/redaction.js';
 import path from 'path';
 
 // ============================================================================
@@ -25,7 +26,7 @@ export async function writeReviewOutput(
   const filename = `${review.reviewerId}${chunkSuffix}-${sanitizedModel}.md`;
   const filePath = path.join(reviewsDir, filename);
 
-  const content = formatReviewOutput(review);
+  const content = redactSecrets(formatReviewOutput(review));
   await writeMarkdown(filePath, content);
 
   return filePath;

--- a/packages/core/src/l2/writer.ts
+++ b/packages/core/src/l2/writer.ts
@@ -7,6 +7,7 @@ import type { DiscussionRound, DiscussionVerdict, ModeratorReport, EvidenceDocum
 import { writeMarkdown, getDiscussionsDir, getSuggestionsPath, getReportPath } from '@codeagora/shared/utils/fs.js';
 import path from 'path';
 import { writeFile } from 'fs/promises';
+import { redactDeep, redactSecrets } from '@codeagora/shared/utils/redaction.js';
 
 // Type for selected supporter (imported from moderator.ts logic)
 interface SelectedSupporter {
@@ -36,7 +37,7 @@ export async function writeDiscussionRound(
   const { ensureDir } = await import('@codeagora/shared/utils/fs.js');
   await ensureDir(discussionDir);
 
-  const content = formatDiscussionRound(round);
+  const content = redactSecrets(formatDiscussionRound(round));
   await writeMarkdown(roundFile, content);
 }
 
@@ -56,7 +57,7 @@ export async function writeDiscussionVerdict(
   const { ensureDir } = await import('@codeagora/shared/utils/fs.js');
   await ensureDir(discussionDir);
 
-  const content = formatVerdict(verdict);
+  const content = redactSecrets(formatVerdict(verdict));
   await writeMarkdown(verdictFile, content);
 }
 
@@ -85,7 +86,7 @@ export async function writeSuggestions(
     lines.push('');
   }
 
-  await writeMarkdown(suggestionsPath, lines.join('\n'));
+  await writeMarkdown(suggestionsPath, redactSecrets(lines.join('\n')));
 }
 
 /**
@@ -98,7 +99,7 @@ export async function writeModeratorReport(
 ): Promise<void> {
   const reportPath = getReportPath(date, sessionId);
 
-  const content = formatModeratorReport(report);
+  const content = redactSecrets(formatModeratorReport(report));
   await writeMarkdown(reportPath, content);
 }
 
@@ -138,7 +139,7 @@ export async function writeSupportersLog(
     combination: `${models} / ${personas}`,
   };
 
-  await writeFile(supportersFile, JSON.stringify(log, null, 2), 'utf-8');
+  await writeFile(supportersFile, JSON.stringify(redactDeep(log), null, 2), 'utf-8');
 }
 
 // ============================================================================

--- a/packages/core/src/l3/writer.ts
+++ b/packages/core/src/l3/writer.ts
@@ -5,6 +5,7 @@
 
 import type { HeadVerdict } from '../types/core.js';
 import { writeMarkdown, getResultPath } from '@codeagora/shared/utils/fs.js';
+import { redactSecrets } from '@codeagora/shared/utils/redaction.js';
 
 /**
  * Write head verdict to result.md
@@ -16,7 +17,7 @@ export async function writeHeadVerdict(
 ): Promise<void> {
   const resultPath = getResultPath(date, sessionId);
 
-  const content = formatHeadVerdict(verdict);
+  const content = redactSecrets(formatHeadVerdict(verdict));
   await writeMarkdown(resultPath, content);
 }
 

--- a/packages/core/src/pipeline/cache-manager.ts
+++ b/packages/core/src/pipeline/cache-manager.ts
@@ -8,6 +8,7 @@ import type { PipelineResult } from './orchestrator.js';
 import { lookupCache, addToCache } from '@codeagora/shared/utils/cache.js';
 import { CA_ROOT } from '@codeagora/shared/utils/fs.js';
 import { computeHash } from '@codeagora/shared/utils/hash.js';
+import { redactDeep } from '@codeagora/shared/utils/redaction.js';
 import fs from 'fs/promises';
 
 /**
@@ -54,7 +55,7 @@ export async function persistResultCache(
 ): Promise<void> {
   try {
     const resultJsonPath = `${CA_ROOT}/sessions/${date}/${sessionId}/result.json`;
-    await fs.writeFile(resultJsonPath, JSON.stringify(pipelineResult, null, 2), 'utf-8');
+    await fs.writeFile(resultJsonPath, JSON.stringify(redactDeep(pipelineResult), null, 2), 'utf-8');
     if (!noCache) {
       await addToCache(CA_ROOT, cacheKey, `${date}/${sessionId}`);
     }

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -131,7 +131,7 @@ export async function runPipeline(input: PipelineInput, progress?: ProgressEmitt
     // Load config and normalize (expand declarative reviewers if needed)
     progress?.stageStart('init', 'Loading config...');
     const rawConfig = input.configPath
-      ? await loadConfigFile(input.configPath)
+      ? await loadConfigFile(input.configPath, { rootDir: input.repoPath ?? process.cwd() })
       : await loadConfig();
     const config = normalizeConfig(rawConfig);
 

--- a/packages/github/src/action-policy.ts
+++ b/packages/github/src/action-policy.ts
@@ -1,4 +1,5 @@
 import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
+import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
 
 export interface ActionInputs {
   diff: string;
@@ -111,4 +112,17 @@ export function determineActionPolicy(
 
 export function isStaleHead(expectedHeadSha: string, currentHeadSha: string | undefined): boolean {
   return Boolean(currentHeadSha && currentHeadSha !== expectedHeadSha);
+}
+
+export function validateActionDiffPath(
+  diffPath: string,
+  workspaceRoot: string = process.cwd(),
+): string {
+  const validation = validateDiffPath(diffPath, {
+    allowedRoots: [workspaceRoot, '/tmp'],
+  });
+  if (!validation.success) {
+    throw new Error(`Action diff path rejected: ${validation.error}`);
+  }
+  return validation.data;
 }

--- a/packages/github/src/action-policy.ts
+++ b/packages/github/src/action-policy.ts
@@ -1,5 +1,5 @@
 import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
-import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
+import { validatePathWithinRoot } from '@codeagora/shared/utils/path-validation.js';
 
 export interface ActionInputs {
   diff: string;
@@ -114,15 +114,20 @@ export function isStaleHead(expectedHeadSha: string, currentHeadSha: string | un
   return Boolean(currentHeadSha && currentHeadSha !== expectedHeadSha);
 }
 
-export function validateActionDiffPath(
+export async function validateActionDiffPath(
   diffPath: string,
   workspaceRoot: string = process.cwd(),
-): string {
-  const validation = validateDiffPath(diffPath, {
-    allowedRoots: [workspaceRoot, '/tmp'],
-  });
-  if (!validation.success) {
-    throw new Error(`Action diff path rejected: ${validation.error}`);
+): Promise<string> {
+  const allowedRoots = [workspaceRoot, '/tmp'];
+  let lastError = 'Path is outside allowed roots';
+
+  for (const root of allowedRoots) {
+    const validation = await validatePathWithinRoot(diffPath, root);
+    if (validation.success) {
+      return validation.data;
+    }
+    lastError = validation.error;
   }
-  return validation.data;
+
+  throw new Error(`Action diff path rejected: ${lastError}`);
 }

--- a/packages/github/src/action-policy.ts
+++ b/packages/github/src/action-policy.ts
@@ -1,3 +1,4 @@
+import fs from 'fs/promises';
 import path from 'path';
 import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
 import { validatePathWithinRoot } from '@codeagora/shared/utils/path-validation.js';
@@ -138,11 +139,73 @@ export async function validateActionDiffPath(
   throw new Error(`Action diff path rejected: ${lastError}`);
 }
 
+export async function validateActionOutputPath(
+  outputPath: string,
+  workspaceRoot: string = process.cwd(),
+): Promise<string> {
+  if (outputPath === '') {
+    throw new Error('Action output path rejected: Path must not be empty');
+  }
+  if (outputPath.includes('\x00')) {
+    throw new Error('Action output path rejected: Path must not contain null bytes');
+  }
+  if (outputPath.split(/[\\/]/).includes('..')) {
+    throw new Error('Action output path rejected: Path traversal detected: path contains ".." segments');
+  }
+
+  const allowedRoots = [workspaceRoot, '/tmp'];
+  let lastError = 'Path is outside allowed roots';
+
+  for (const root of allowedRoots) {
+    if (!isInputPathUnderRoot(outputPath, root)) {
+      continue;
+    }
+
+    const resolved = path.isAbsolute(outputPath)
+      ? path.resolve(outputPath)
+      : path.resolve(root, outputPath);
+    const parent = path.dirname(resolved);
+
+    try {
+      const [realRoot, realParent] = await Promise.all([
+        fs.realpath(path.resolve(root)),
+        fs.realpath(parent),
+      ]);
+      if (!isResolvedPathUnderRoot(realParent, realRoot)) {
+        lastError = 'Path resolves outside allowed roots';
+        break;
+      }
+
+      const existing = await fs.lstat(resolved).catch((error: unknown) => {
+        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+          return null;
+        }
+        throw error;
+      });
+      if (existing?.isSymbolicLink()) {
+        throw new Error('Path must not be a symlink');
+      }
+
+      return resolved;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      lastError = `Path could not be resolved safely: ${message}`;
+      break;
+    }
+  }
+
+  throw new Error(`Action output path rejected: ${lastError}`);
+}
+
 function isInputPathUnderRoot(inputPath: string, rootDir: string): boolean {
   const root = path.resolve(rootDir);
   const resolved = path.isAbsolute(inputPath)
     ? path.resolve(inputPath)
     : path.resolve(root, inputPath);
-  const relative = path.relative(root, resolved);
+  return isResolvedPathUnderRoot(resolved, root);
+}
+
+function isResolvedPathUnderRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }

--- a/packages/github/src/action-policy.ts
+++ b/packages/github/src/action-policy.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
 import { validatePathWithinRoot } from '@codeagora/shared/utils/path-validation.js';
 
@@ -122,12 +123,26 @@ export async function validateActionDiffPath(
   let lastError = 'Path is outside allowed roots';
 
   for (const root of allowedRoots) {
+    if (!isInputPathUnderRoot(diffPath, root)) {
+      continue;
+    }
+
     const validation = await validatePathWithinRoot(diffPath, root);
     if (validation.success) {
       return validation.data;
     }
     lastError = validation.error;
+    break;
   }
 
   throw new Error(`Action diff path rejected: ${lastError}`);
+}
+
+function isInputPathUnderRoot(inputPath: string, rootDir: string): boolean {
+  const root = path.resolve(rootDir);
+  const resolved = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(root, inputPath);
+  const relative = path.relative(root, resolved);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }

--- a/packages/github/src/action.ts
+++ b/packages/github/src/action.ts
@@ -20,7 +20,7 @@ import { fetchPrMetadata } from './pr-diff.js';
 import { buildSarifReport, serializeSarif } from './sarif.js';
 import { loadConfigFrom } from '@codeagora/core/config/loader.js';
 import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
-import { determineActionPolicy, isStaleHead, parseActionInputs } from './action-policy.js';
+import { determineActionPolicy, isStaleHead, parseActionInputs, validateActionDiffPath } from './action-policy.js';
 
 // ============================================================================
 // Main
@@ -38,6 +38,8 @@ async function main(): Promise<void> {
   setActionOutput('head-sha', inputs.sha);
   if (inputs.baseSha) setActionOutput('base-sha', inputs.baseSha);
 
+  const safeDiffPath = validateActionDiffPath(inputs.diff);
+
   const actionPolicy = determineActionPolicy(inputs);
   if (actionPolicy.degraded) {
     setActionOutput('degraded', 'true');
@@ -54,7 +56,7 @@ async function main(): Promise<void> {
 
   // Check diff line count
   if (inputs.maxDiffLines > 0) {
-    const diffContent = await fs.readFile(inputs.diff, 'utf-8');
+    const diffContent = await fs.readFile(safeDiffPath, 'utf-8');
     const lineCount = diffContent.split('\n').length;
     if (lineCount > inputs.maxDiffLines) {
       console.log(`::warning::Diff has ${lineCount} lines (limit: ${inputs.maxDiffLines}). Skipping review.`);
@@ -72,7 +74,7 @@ async function main(): Promise<void> {
 
   // Run pipeline (#259: pass repoPath for surrounding code context)
   console.log('::group::Running CodeAgora review pipeline');
-  const result = await runPipeline({ diffPath: inputs.diff, repoPath: process.cwd() });
+  const result = await runPipeline({ diffPath: safeDiffPath, repoPath: process.cwd() });
   console.log('::endgroup::');
 
   if (result.status === 'error') {
@@ -88,7 +90,7 @@ async function main(): Promise<void> {
   }
 
   // Read diff for position index
-  const diffContent = await fs.readFile(inputs.diff, 'utf-8');
+  const diffContent = await fs.readFile(safeDiffPath, 'utf-8');
   const positionIndex = buildDiffPositionIndex(diffContent);
 
   // Use full evidence docs, discussions, and reviewer map from pipeline result

--- a/packages/github/src/action.ts
+++ b/packages/github/src/action.ts
@@ -9,7 +9,6 @@
 
 import crypto from 'crypto';
 import fs from 'fs/promises';
-import path from 'path';
 import { appendFileSync } from 'fs';
 import { runPipeline } from '@codeagora/core/pipeline/orchestrator.js';
 import { buildDiffPositionIndex } from './diff-parser.js';
@@ -18,9 +17,8 @@ import { postReview, setCommitStatus, handleNeedsHuman } from './poster.js';
 import { createAppOctokit } from './client.js';
 import { fetchPrMetadata } from './pr-diff.js';
 import { buildSarifReport, serializeSarif } from './sarif.js';
-import { loadConfigFrom } from '@codeagora/core/config/loader.js';
-import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
-import { determineActionPolicy, isStaleHead, parseActionInputs, validateActionDiffPath } from './action-policy.js';
+import { loadConfigFile } from '@codeagora/core/config/loader.js';
+import { determineActionPolicy, isStaleHead, parseActionInputs, validateActionDiffPath, validateActionOutputPath } from './action-policy.js';
 
 // ============================================================================
 // Main
@@ -69,12 +67,15 @@ async function main(): Promise<void> {
 
   // Load config early — used for pipeline and mapper options.
   const configPath = process.env['CONFIG_PATH'] || '.ca/config.json';
-  const configBaseDir = path.resolve(process.cwd(), path.dirname(path.dirname(configPath)));
-  const config = await loadConfigFrom(configBaseDir).catch(() => null);
+  const config = await loadConfigFile(configPath, { rootDir: process.cwd() }).catch(() => null);
 
   // Run pipeline (#259: pass repoPath for surrounding code context)
   console.log('::group::Running CodeAgora review pipeline');
-  const result = await runPipeline({ diffPath: safeDiffPath, repoPath: process.cwd() });
+  const result = await runPipeline({
+    diffPath: safeDiffPath,
+    repoPath: process.cwd(),
+    configPath: config ? configPath : undefined,
+  });
   console.log('::endgroup::');
 
   if (result.status === 'error') {
@@ -170,15 +171,14 @@ async function main(): Promise<void> {
 
   // Generate SARIF output — validate path to prevent traversal attacks
   const rawSarifPath = config?.github?.sarifOutputPath ?? '/tmp/codeagora-results.sarif';
-  const sarifValidation = validateDiffPath(rawSarifPath, {
-    allowedRoots: [process.cwd(), '/tmp'],
-  });
-  if (sarifValidation.success) {
+  try {
+    const safeSarifPath = await validateActionOutputPath(rawSarifPath, process.cwd());
     const sarifReport = buildSarifReport(evidenceDocs, result.sessionId, result.date);
-    await fs.writeFile(sarifValidation.data, serializeSarif(sarifReport));
-    console.log(`SARIF report written to ${sarifValidation.data}`);
-  } else {
-    console.error(`::warning::SARIF output path rejected: ${sarifValidation.error}`);
+    await fs.writeFile(safeSarifPath, serializeSarif(sarifReport));
+    console.log(`SARIF report written to ${safeSarifPath}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`::warning::SARIF output path rejected: ${message}`);
   }
 
   // Set outputs

--- a/packages/github/src/action.ts
+++ b/packages/github/src/action.ts
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
   setActionOutput('head-sha', inputs.sha);
   if (inputs.baseSha) setActionOutput('base-sha', inputs.baseSha);
 
-  const safeDiffPath = validateActionDiffPath(inputs.diff);
+  const safeDiffPath = await validateActionDiffPath(inputs.diff);
 
   const actionPolicy = determineActionPolicy(inputs);
   if (actionPolicy.degraded) {

--- a/packages/github/src/poster.ts
+++ b/packages/github/src/poster.ts
@@ -188,9 +188,9 @@ async function postReviewWithRetry(
         owner: config.owner,
         repo: config.repo,
         pull_number: prNumber,
-        commit_id: review.commit_id,
+        commit_id: safeReview.commit_id,
         event: effectiveEvent,
-        body: review.body,
+        body: safeReview.body,
         comments: [],
       });
       return response.data;

--- a/packages/github/src/poster.ts
+++ b/packages/github/src/poster.ts
@@ -11,6 +11,7 @@ import type { GitHubConfig } from './client.js';
 import { createOctokit } from './client.js';
 import type { GitHubReview, PostResult } from './types.js';
 import { findPriorReviews, dismissPriorReviews } from './dedup.js';
+import { redactSecrets } from '@codeagora/shared/utils/redaction.js';
 
 /** Maximum inline comments per review (GitHub's practical limit). */
 const MAX_COMMENTS_PER_REVIEW = 50;
@@ -132,6 +133,11 @@ async function postReviewWithRetry(
   review: GitHubReview,
   inlineComments: Array<{ path: string; position: number; body: string }>,
 ): Promise<{ id: number; html_url: string }> {
+  const safeReview = redactGitHubReview(review);
+  const safeInlineComments = inlineComments.map((comment) => ({
+    ...comment,
+    body: redactSecrets(comment.body),
+  }));
   // Effective review may be downgraded below (APPROVE → COMMENT) if the token
   // lacks approval permission. `effectiveEvent` is the event used for all
   // downstream posts once that downgrade decision is made.
@@ -142,10 +148,10 @@ async function postReviewWithRetry(
       owner: config.owner,
       repo: config.repo,
       pull_number: prNumber,
-      commit_id: review.commit_id,
+      commit_id: safeReview.commit_id,
       event: effectiveEvent,
-      body: review.body,
-      comments: inlineComments,
+      body: safeReview.body,
+      comments: safeInlineComments,
     });
     return response.data;
   } catch (err: unknown) {
@@ -162,10 +168,10 @@ async function postReviewWithRetry(
           owner: config.owner,
           repo: config.repo,
           pull_number: prNumber,
-          commit_id: review.commit_id,
+          commit_id: safeReview.commit_id,
           event: effectiveEvent,
-          body: review.body,
-          comments: inlineComments,
+          body: safeReview.body,
+          comments: safeInlineComments,
         });
         return response.data;
       } catch (retryErr: unknown) {
@@ -175,7 +181,7 @@ async function postReviewWithRetry(
     }
 
     // 422: at least one comment has a bad position — bisect to find valid ones
-    const totalCount = inlineComments.length;
+    const totalCount = safeInlineComments.length;
     if (totalCount === 0) {
       // No comments to bisect — post without inline comments
       const response = await createReviewWithRateLimit(kit, {
@@ -193,7 +199,7 @@ async function postReviewWithRetry(
     console.warn(`[GitHub] 422 error with ${totalCount} inline comment(s). Attempting bisection retry to preserve valid comments.`);
 
     // Bisect: try each half independently, collect survivors
-    const survivors = await bisectComments(kit, config, prNumber, review, inlineComments);
+    const survivors = await bisectComments(kit, config, prNumber, safeReview, safeInlineComments);
     const droppedCount = totalCount - survivors.length;
 
     if (droppedCount > 0) {
@@ -205,13 +211,24 @@ async function postReviewWithRetry(
       owner: config.owner,
       repo: config.repo,
       pull_number: prNumber,
-      commit_id: review.commit_id,
+      commit_id: safeReview.commit_id,
       event: effectiveEvent,
-      body: review.body,
+      body: safeReview.body,
       comments: survivors,
     });
     return response.data;
   }
+}
+
+function redactGitHubReview(review: GitHubReview): GitHubReview {
+  return {
+    ...review,
+    body: redactSecrets(review.body),
+    comments: review.comments.map((comment) => ({
+      ...comment,
+      body: redactSecrets(comment.body),
+    })),
+  };
 }
 
 /**
@@ -285,6 +302,7 @@ export async function postReview(
   octokit?: Octokit,
 ): Promise<PostResult> {
   const kit = octokit ?? createOctokit(config);
+  const safeReview = redactGitHubReview(review);
 
   // Step 1: Dismiss prior reviews
   const priorIds = await findPriorReviews(config, prNumber, kit);
@@ -293,7 +311,7 @@ export async function postReview(
   }
 
   // Step 2: Sort by severity (highest first) and truncate to limit
-  const sortedComments = [...review.comments].sort(
+  const sortedComments = [...safeReview.comments].sort(
     (a, b) => extractSeverityPriority(a.body) - extractSeverityPriority(b.body),
   );
   if (sortedComments.length > MAX_COMMENTS_PER_REVIEW) {
@@ -311,7 +329,7 @@ export async function postReview(
     }));
 
   // Step 3: Post the review with retry logic for 422 (bisection) and 429 (rate limit)
-  const data = await postReviewWithRetry(kit, config, prNumber, review, inlineComments);
+  const data = await postReviewWithRetry(kit, config, prNumber, safeReview, inlineComments);
 
   // Step 4: Post file-level comments as individual issue comments
   const fileLevelComments = comments.filter((c) => c.position === undefined);
@@ -328,9 +346,9 @@ export async function postReview(
 
   // Determine verdict from event and body content
   let verdict: PostResult['verdict'];
-  if (review.event === 'REQUEST_CHANGES') {
+  if (safeReview.event === 'REQUEST_CHANGES') {
     verdict = 'REJECT';
-  } else if (review.body.includes('NEEDS HUMAN REVIEW')) {
+  } else if (safeReview.body.includes('NEEDS HUMAN REVIEW')) {
     verdict = 'NEEDS_HUMAN';
   } else {
     verdict = 'ACCEPT';

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,76 @@
+# @codeagora/mcp
+
+CodeAgora MCP server for Claude Code, Cursor, and other MCP-compatible clients.
+
+## Install
+
+Release-candidate local smoke uses a packed tarball instead of publishing:
+
+```bash
+pnpm --filter @codeagora/mcp build
+pnpm --filter @codeagora/mcp pack --dry-run
+```
+
+After publication, users can run the package with:
+
+```bash
+npx -y @codeagora/mcp
+```
+
+## Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "codeagora": {
+      "command": "npx",
+      "args": ["-y", "@codeagora/mcp"]
+    }
+  }
+}
+```
+
+For local RC validation, point your client at the built workspace binary instead:
+
+```json
+{
+  "mcpServers": {
+    "codeagora": {
+      "command": "node",
+      "args": ["/absolute/path/to/CodeAgora/packages/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+## Environment Variables
+
+Provider keys are required only for live review tools that call LLM providers. Config and stats tools do not require provider keys.
+
+- `OPENAI_API_KEY` for OpenAI models.
+- `ANTHROPIC_API_KEY` for Anthropic models.
+- `GOOGLE_GENERATIVE_AI_API_KEY` or `GOOGLE_API_KEY` for Gemini models.
+- `GROQ_API_KEY` for Groq models.
+- `OPENROUTER_API_KEY` for OpenRouter models.
+- `GITHUB_TOKEN` for PR review workflows that fetch or post GitHub data.
+
+Deterministic benchmark CI gates such as `pnpm bench:ci` do not require live provider keys. Manual live benchmark runs with `pnpm bench:fn:run` do.
+
+## Tools
+
+- `review_quick`: fast L1-only diff review.
+- `review_full`: full L0-L3 review with debate and head verdict.
+- `review_pr`: PR-oriented review flow.
+- `dry_run`: validate diff/config without a full review.
+- `explain_session`: explain a previous session.
+- `get_leaderboard`: inspect model ranking data.
+- `get_stats`: inspect review statistics.
+- `config_get`: read current reviewer configuration.
+- `config_set`: update supported configuration fields.
+
+## Troubleshooting
+
+- If the server exits immediately, run `pnpm --filter @codeagora/mcp build` and confirm `packages/mcp/dist/index.js` exists.
+- If review tools return missing-provider errors, set the provider key for the configured reviewer backend.
+- If `repo_path` is rejected, pass a real directory inside the current repository boundary. Symlinks and paths outside the repo are intentionally rejected.
+- If a client cannot find the command, use an absolute `node` path and an absolute `dist/index.js` path for local RC smoke.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,7 +31,8 @@
     "codeagora-mcp": "./dist/index.js"
   },
   "files": [
-    "dist/**/*.js"
+    "dist/**/*.js",
+    "README.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -11,6 +11,7 @@ import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { formatCompact, type CompactReviewResult } from '@codeagora/core/pipeline/compact-formatter.js';
 import type { PipelineResult } from '@codeagora/core/pipeline/orchestrator.js';
+import { redactDeep } from '@codeagora/shared/utils/redaction.js';
 
 const execFile = promisify(execFileCb);
 
@@ -108,7 +109,7 @@ export async function runReviewRaw(
 
   try {
     const { runPipeline } = await import('@codeagora/core/pipeline/orchestrator.js');
-    return await runPipeline(mapToPipelineInput(tmpFile, options));
+    return redactDeep(await runPipeline(mapToPipelineInput(tmpFile, options)));
   } finally {
     await fs.unlink(tmpFile).catch((error: unknown) => {
       void error;
@@ -135,7 +136,7 @@ export async function runReviewCompact(
     };
   }
 
-  return formatCompact({
+  return redactDeep(formatCompact({
     decision: result.summary.decision,
     reasoning: result.summary.reasoning,
     evidenceDocs: result.evidenceDocs ?? [],
@@ -143,6 +144,6 @@ export async function runReviewCompact(
     reviewerMap: result.reviewerMap,
     reviewerOpinions: result.reviewerOpinions,
     sessionId: `${result.date}/${result.sessionId}`,
-  });
+  }));
 }
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -15,10 +15,11 @@ import { registerLeaderboard } from './tools/leaderboard.js';
 import { registerStats } from './tools/stats.js';
 import { registerConfigGet } from './tools/config-get.js';
 import { registerConfigSet } from './tools/config-set.js';
+import { readMcpPackageVersion } from './version.js';
 
 const server = new McpServer({
   name: 'codeagora',
-  version: '2.3.4',
+  version: readMcpPackageVersion(),
 });
 
 // Register all tools

--- a/packages/mcp/src/tools/shared-response.ts
+++ b/packages/mcp/src/tools/shared-response.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
+import { redactDeep } from '@codeagora/shared/utils/redaction.js';
 
 const execFile = promisify(execFileCb);
 
@@ -46,7 +47,7 @@ export function mcpErrorResponse(
   details?: Record<string, unknown>,
 ): McpToolResponse {
   return {
-    content: [{ type: 'text', text: JSON.stringify(createStructuredError(code, message, details), null, 2) }],
+    content: [{ type: 'text', text: JSON.stringify(redactDeep(createStructuredError(code, message, details)), null, 2) }],
     isError: true,
   };
 }

--- a/packages/mcp/src/version.ts
+++ b/packages/mcp/src/version.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+
+export function readMcpPackageVersion(): string {
+  const packageJsonUrl = new URL('../package.json', import.meta.url);
+  const parsed = JSON.parse(readFileSync(packageJsonUrl, 'utf-8')) as { version?: unknown };
+  if (typeof parsed.version !== 'string' || parsed.version.length === 0) {
+    throw new Error('packages/mcp/package.json must define a version string');
+  }
+  return parsed.version;
+}

--- a/packages/shared/src/utils/path-validation.ts
+++ b/packages/shared/src/utils/path-validation.ts
@@ -2,6 +2,7 @@
  * Path Validation Utility
  */
 
+import fs from 'fs/promises';
 import path from 'path';
 import type { Result } from '../types/result.js';
 import { ok, err } from '../types/result.js';
@@ -52,4 +53,54 @@ export function validateDiffPath(
   }
 
   return ok(resolved);
+}
+
+export async function validatePathWithinRoot(
+  inputPath: string,
+  rootDir: string,
+): Promise<Result<string, string>> {
+  if (inputPath === '') {
+    return err('Path must not be empty');
+  }
+
+  if (inputPath.includes('\x00')) {
+    return err('Path must not contain null bytes');
+  }
+
+  const parts = inputPath.split(/[\\/]/);
+  if (parts.includes('..')) {
+    return err('Path traversal detected: path contains ".." segments');
+  }
+
+  const root = path.resolve(rootDir);
+  const resolved = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(root, inputPath);
+
+  if (!isPathWithinRoot(resolved, root)) {
+    return err('Path is outside the repository root');
+  }
+
+  let realRoot: string;
+  let realTarget: string;
+  try {
+    [realRoot, realTarget] = await Promise.all([
+      fs.realpath(root),
+      fs.realpath(resolved),
+    ]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return err(`Path could not be resolved safely: ${message}`);
+  }
+
+  if (!isPathWithinRoot(realTarget, realRoot)) {
+    return err('Path resolves outside the repository root');
+  }
+
+  return ok(realTarget);
+}
+
+function isPathWithinRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }

--- a/packages/shared/src/utils/redaction.ts
+++ b/packages/shared/src/utils/redaction.ts
@@ -1,7 +1,8 @@
 const SECRET_ASSIGNMENT_RE = /\b([A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)|(?:api[_-]?key|token|secret|password))\s*[:=]\s*(["']?)([^\s"']+)\2/gi;
 const STANDALONE_SECRET_RE = /\b(?:sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,}|xox[baprs]-[A-Za-z0-9-]{8,}|AIza[0-9A-Za-z_-]{12,})\b/g;
 const ENCODED_TOKEN_RE = /\b(?:[A-Za-z0-9+/]{12,}={0,2}|[A-Za-z0-9_.~%-]*%[0-9A-Fa-f]{2}[A-Za-z0-9_.~%-]*)\b/g;
-const BEARER_TOKEN_RE = /\b(Authorization\s*:\s*Bearer\s+)([^\s"']+)/gi;
+const AUTHORIZATION_BEARER_TOKEN_RE = /\b(Authorization\s*:\s*Bearer\s+)([^\s"']+)/gi;
+const BEARER_TOKEN_RE = /\b(Bearer\s+)([A-Za-z0-9._~+/=-]+)/g;
 
 function decodedVariants(value: string): string[] {
   const variants = [value];
@@ -38,6 +39,7 @@ function containsKnownSecret(value: string): boolean {
 export function redactSecrets(input: string): string {
   return input
     .replace(SECRET_ASSIGNMENT_RE, (_match, key: string) => `${key}=[REDACTED]`)
+    .replace(AUTHORIZATION_BEARER_TOKEN_RE, (_match, prefix: string) => `${prefix}[REDACTED]`)
     .replace(BEARER_TOKEN_RE, (_match, prefix: string) => `${prefix}[REDACTED]`)
     .replace(STANDALONE_SECRET_RE, '[REDACTED]')
     .replace(ENCODED_TOKEN_RE, (match) => containsKnownSecret(match) ? '[REDACTED]' : match);

--- a/packages/shared/src/utils/redaction.ts
+++ b/packages/shared/src/utils/redaction.ts
@@ -1,6 +1,7 @@
 const SECRET_ASSIGNMENT_RE = /\b([A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)|(?:api[_-]?key|token|secret|password))\s*[:=]\s*(["']?)([^\s"']+)\2/gi;
 const STANDALONE_SECRET_RE = /\b(?:sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,}|xox[baprs]-[A-Za-z0-9-]{8,}|AIza[0-9A-Za-z_-]{12,})\b/g;
 const ENCODED_TOKEN_RE = /\b(?:[A-Za-z0-9+/]{12,}={0,2}|[A-Za-z0-9_.~%-]*%[0-9A-Fa-f]{2}[A-Za-z0-9_.~%-]*)\b/g;
+const BEARER_TOKEN_RE = /\b(Authorization\s*:\s*Bearer\s+)([^\s"']+)/gi;
 
 function decodedVariants(value: string): string[] {
   const variants = [value];
@@ -37,6 +38,7 @@ function containsKnownSecret(value: string): boolean {
 export function redactSecrets(input: string): string {
   return input
     .replace(SECRET_ASSIGNMENT_RE, (_match, key: string) => `${key}=[REDACTED]`)
+    .replace(BEARER_TOKEN_RE, (_match, prefix: string) => `${prefix}[REDACTED]`)
     .replace(STANDALONE_SECRET_RE, '[REDACTED]')
     .replace(ENCODED_TOKEN_RE, (match) => containsKnownSecret(match) ? '[REDACTED]' : match);
 }

--- a/scripts/rc-smoke.mjs
+++ b/scripts/rc-smoke.mjs
@@ -1,41 +1,153 @@
 #!/usr/bin/env node
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+
+const SENSITIVE_ENV_KEYS = new Set([
+  'ANTHROPIC_API_KEY',
+  'CEREBRAS_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'GITHUB_TOKEN',
+  'GOOGLE_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'GROQ_API_KEY',
+  'MISTRAL_API_KEY',
+  'NODE_AUTH_TOKEN',
+  'NPM_TOKEN',
+  'NVIDIA_API_KEY',
+  'OPENAI_API_KEY',
+  'OPENROUTER_API_KEY',
+  'QWEN_API_KEY',
+  'TOGETHER_API_KEY',
+  'XAI_API_KEY',
+  'ZAI_API_KEY',
+]);
+const SENSITIVE_ENV_PATTERN = /(?:^|_)(?:API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)(?:_|$)/i;
+const MCP_TIMEOUT_MS = 5_000;
+const CHILD_EXIT_GRACE_MS = 2_000;
+
+function smokeEnv(extra = {}) {
+  const env = { ...process.env, ...extra };
+  for (const key of Object.keys(env)) {
+    if (SENSITIVE_ENV_KEYS.has(key) || SENSITIVE_ENV_PATTERN.test(key)) {
+      env[key] = '';
+    }
+  }
+  return env;
+}
 
 function run(command, args, options = {}) {
   console.log(`$ ${command} ${args.join(' ')}`);
   execFileSync(command, args, {
     stdio: 'inherit',
-    env: {
-      ...process.env,
-      NPM_TOKEN: '',
-      NODE_AUTH_TOKEN: '',
-    },
+    env: smokeEnv(),
     ...options,
   });
 }
 
 function runCapture(command, args, options = {}) {
   console.log(`$ ${command} ${args.join(' ')}`);
-  return execFileSync(command, args, {
+  const result = spawnSync(command, args, {
     encoding: 'utf-8',
-    env: {
-      ...process.env,
-      NPM_TOKEN: '',
-      NODE_AUTH_TOKEN: '',
-    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: smokeEnv(),
     ...options,
   });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status ?? 'signal'}): ${command} ${args.join(' ')}\nstdout=${result.stdout}\nstderr=${result.stderr}`);
+  }
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+async function writeJsonLine(child, message) {
+  const line = `${JSON.stringify(message)}\n`;
+  if (child.stdin.write(line)) {
+    return;
+  }
+  await new Promise((resolve, reject) => {
+    child.stdin.once('drain', resolve);
+    child.stdin.once('error', reject);
+  });
+}
+
+function hasExpectedTools(stdout) {
+  return stdout.includes('review_quick') && stdout.includes('review_full') && stdout.includes('config_get');
+}
+
+function waitForMcpTools(child, getOutput) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('MCP tools/list smoke timed out'));
+    }, MCP_TIMEOUT_MS);
+    timeout.unref?.();
+
+    const check = () => {
+      if (hasExpectedTools(getOutput().stdout)) {
+        cleanup();
+        resolve();
+      }
+    };
+    const fail = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const closeBeforeResponse = (code, signal) => {
+      cleanup();
+      const { stdout, stderr } = getOutput();
+      reject(new Error(`MCP server exited before tools/list completed. code=${code ?? 'null'} signal=${signal ?? 'null'} stdout=${stdout} stderr=${stderr}`));
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off('data', check);
+      child.stderr.off('data', check);
+      child.stdin.off('error', fail);
+      child.off('error', fail);
+      child.off('close', closeBeforeResponse);
+    };
+
+    child.stdout.on('data', check);
+    child.stderr.on('data', check);
+    child.stdin.once('error', fail);
+    child.once('error', fail);
+    child.once('close', closeBeforeResponse);
+    check();
+  });
+}
+
+async function closeChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  const closed = new Promise((resolve) => {
+    child.once('close', resolve);
+  });
+  child.stdin.end();
+  if (await Promise.race([closed.then(() => true), delay(CHILD_EXIT_GRACE_MS).then(() => false)])) {
+    return;
+  }
+  child.kill('SIGTERM');
+  if (await Promise.race([closed.then(() => true), delay(CHILD_EXIT_GRACE_MS).then(() => false)])) {
+    return;
+  }
+  child.kill('SIGKILL');
+  await closed;
 }
 
 async function smokeMcpServer() {
   console.log('$ node packages/mcp/dist/index.js  # MCP initialize + tools/list smoke');
   const child = spawn(process.execPath, ['packages/mcp/dist/index.js'], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: {
-      ...process.env,
-      NPM_TOKEN: '',
-      NODE_AUTH_TOKEN: '',
-    },
+    env: smokeEnv(),
   });
 
   let stdout = '';
@@ -54,16 +166,19 @@ async function smokeMcpServer() {
     { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
     { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
   ];
-  for (const message of messages) {
-    child.stdin.write(`${JSON.stringify(message)}\n`);
+
+  try {
+    const toolsReady = waitForMcpTools(child, () => ({ stdout, stderr }));
+    for (const message of messages) {
+      await writeJsonLine(child, message);
+    }
+    await toolsReady;
+  } catch (error) {
+    throw new Error(`MCP tools/list smoke failed. stdout=${stdout} stderr=${stderr}`, { cause: error });
+  } finally {
+    await closeChild(child);
   }
 
-  await new Promise((resolve) => setTimeout(resolve, 1_000));
-  child.kill('SIGTERM');
-
-  if (!stdout.includes('review_quick') || !stdout.includes('review_full') || !stdout.includes('config_get')) {
-    throw new Error(`MCP tools/list smoke failed. stdout=${stdout} stderr=${stderr}`);
-  }
   console.log('OK: MCP tools/list smoke passed');
 }
 

--- a/scripts/rc-smoke.mjs
+++ b/scripts/rc-smoke.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { execFileSync, spawn } from 'node:child_process';
+
+function run(command, args, options = {}) {
+  console.log(`$ ${command} ${args.join(' ')}`);
+  execFileSync(command, args, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NPM_TOKEN: '',
+      NODE_AUTH_TOKEN: '',
+    },
+    ...options,
+  });
+}
+
+function runCapture(command, args, options = {}) {
+  console.log(`$ ${command} ${args.join(' ')}`);
+  return execFileSync(command, args, {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      NPM_TOKEN: '',
+      NODE_AUTH_TOKEN: '',
+    },
+    ...options,
+  });
+}
+
+async function smokeMcpServer() {
+  console.log('$ node packages/mcp/dist/index.js  # MCP initialize + tools/list smoke');
+  const child = spawn(process.execPath, ['packages/mcp/dist/index.js'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      NPM_TOKEN: '',
+      NODE_AUTH_TOKEN: '',
+    },
+  });
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf-8');
+  child.stderr.setEncoding('utf-8');
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  const messages = [
+    { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'codeagora-rc-smoke', version: '0.0.0' } } },
+    { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+  ];
+  for (const message of messages) {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+  child.kill('SIGTERM');
+
+  if (!stdout.includes('review_quick') || !stdout.includes('review_full') || !stdout.includes('config_get')) {
+    throw new Error(`MCP tools/list smoke failed. stdout=${stdout} stderr=${stderr}`);
+  }
+  console.log('OK: MCP tools/list smoke passed');
+}
+
+run('pnpm', ['build']);
+run('pnpm', ['build:action']);
+run('pnpm', ['exec', 'node', 'scripts/verify-package-contents.mjs']);
+
+const help = runCapture(process.execPath, ['packages/cli/dist/index.js', '--help']);
+if (!help.includes('CodeAgora') && !help.includes('agora')) {
+  throw new Error('CLI help smoke failed');
+}
+console.log('OK: CLI help smoke passed');
+
+await smokeMcpServer();
+console.log('OK: release candidate smoke passed');

--- a/scripts/verify-package-contents.mjs
+++ b/scripts/verify-package-contents.mjs
@@ -2,17 +2,76 @@
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
+const SENSITIVE_ENV_KEYS = new Set([
+  'ANTHROPIC_API_KEY',
+  'CEREBRAS_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'GITHUB_TOKEN',
+  'GOOGLE_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'GROQ_API_KEY',
+  'MISTRAL_API_KEY',
+  'NODE_AUTH_TOKEN',
+  'NPM_TOKEN',
+  'NVIDIA_API_KEY',
+  'OPENAI_API_KEY',
+  'OPENROUTER_API_KEY',
+  'QWEN_API_KEY',
+  'TOGETHER_API_KEY',
+  'XAI_API_KEY',
+  'ZAI_API_KEY',
+]);
+const SENSITIVE_ENV_PATTERN = /(?:^|_)(?:API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)(?:_|$)/i;
+
+function packEnv() {
+  const env = { ...process.env, npm_config_ignore_scripts: 'true' };
+  for (const key of Object.keys(env)) {
+    if (SENSITIVE_ENV_KEYS.has(key) || SENSITIVE_ENV_PATTERN.test(key)) {
+      env[key] = '';
+    }
+  }
+  return env;
+}
+
+function parsePackOutput(output, cwd) {
+  const trimmed = output.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch (firstError) {
+    const start = trimmed.indexOf('[');
+    const end = trimmed.lastIndexOf(']');
+    if (start !== -1 && end > start) {
+      try {
+        return JSON.parse(trimmed.slice(start, end + 1));
+      } catch (secondError) {
+        throw new Error(`npm pack returned invalid JSON for ${cwd}. parse=${firstError.message} fallback=${secondError.message}`);
+      }
+    }
+    throw new Error(`npm pack returned invalid JSON for ${cwd}. parse=${firstError.message}`);
+  }
+}
+
+function normalizePackPath(file) {
+  return file.replace(/\\/g, '/');
+}
+
 function packFiles(cwd) {
-  const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
     cwd,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: packEnv(),
   });
-  const parsed = JSON.parse(output);
+  const parsed = parsePackOutput(output, cwd);
   if (!Array.isArray(parsed) || parsed.length === 0 || !Array.isArray(parsed[0].files)) {
     throw new Error(`Unexpected npm pack output for ${cwd}`);
   }
-  return parsed[0].files.map((file) => file.path).sort();
+  return parsed[0].files.map((file) => {
+    if (typeof file.path !== 'string') {
+      throw new Error(`Unexpected npm pack file entry for ${cwd}`);
+    }
+    return normalizePackPath(file.path);
+  }).sort();
 }
 
 function assertIncludes(files, expected, label) {
@@ -25,7 +84,7 @@ function assertIncludes(files, expected, label) {
 
 function assertExcludes(files, forbidden, label) {
   for (const pattern of forbidden) {
-    const match = files.find((file) => pattern.test(file));
+    const match = files.find((file) => pattern.test(normalizePackPath(file)));
     if (match) {
       throw new Error(`${label} package includes forbidden file ${match}`);
     }

--- a/scripts/verify-package-contents.mjs
+++ b/scripts/verify-package-contents.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+function packFiles(cwd) {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const parsed = JSON.parse(output);
+  if (!Array.isArray(parsed) || parsed.length === 0 || !Array.isArray(parsed[0].files)) {
+    throw new Error(`Unexpected npm pack output for ${cwd}`);
+  }
+  return parsed[0].files.map((file) => file.path).sort();
+}
+
+function assertIncludes(files, expected, label) {
+  for (const file of expected) {
+    if (!files.includes(file)) {
+      throw new Error(`${label} package is missing ${file}`);
+    }
+  }
+}
+
+function assertExcludes(files, forbidden, label) {
+  for (const pattern of forbidden) {
+    const match = files.find((file) => pattern.test(file));
+    if (match) {
+      throw new Error(`${label} package includes forbidden file ${match}`);
+    }
+  }
+}
+
+const repoRoot = process.cwd();
+const rootFiles = packFiles(repoRoot);
+assertIncludes(rootFiles, [
+  'package.json',
+  'README.md',
+  'LICENSE',
+  'packages/cli/dist/index.js',
+  'scripts/postinstall.cjs',
+], 'root');
+assertExcludes(rootFiles, [
+  /^\.env$/,
+  /^bench-out/,
+  /^\.sisyphus\//,
+  /(^|\/)src\/tests\//,
+  /\.test\.[cm]?[jt]s$/,
+], 'root');
+
+const mcpRoot = path.join(repoRoot, 'packages/mcp');
+const mcpFiles = packFiles(mcpRoot);
+assertIncludes(mcpFiles, [
+  'package.json',
+  'README.md',
+  'dist/index.js',
+], 'mcp');
+assertExcludes(mcpFiles, [
+  /^\.env$/,
+  /(^|\/)src\/tests\//,
+  /\.test\.[cm]?[jt]s$/,
+], 'mcp');
+
+console.log('OK: package dry-run contents verified');
+console.log(`root files: ${rootFiles.length}`);
+console.log(`mcp files: ${mcpFiles.length}`);

--- a/src/tests/benchmark-ci-gate.test.ts
+++ b/src/tests/benchmark-ci-gate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import { execFileSync } from 'child_process';
+
+function readText(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+describe('deterministic benchmark CI gate', () => {
+  it('defines bench:ci as offline schema then reference validation', () => {
+    const manifest = JSON.parse(readText('package.json')) as { scripts?: Record<string, string> };
+
+    expect(manifest.scripts?.['bench:ci']).toBe('pnpm bench:fn -- --validate-only && pnpm bench:reference -- --validate-only');
+    expect(manifest.scripts?.['bench:ci']).not.toContain('bench:fn:run');
+  });
+
+  it('runs benchmark validation without provider keys', () => {
+    const output = execFileSync('pnpm', ['bench:ci'], {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        OPENAI_API_KEY: '',
+        GROQ_API_KEY: '',
+        OPENROUTER_API_KEY: '',
+      },
+    });
+
+    expect(output).toContain('OK: 20 fixture(s) validated');
+    expect(output).toContain('OK: reference');
+  });
+
+  it('runs in CI only on Node 20 matrix jobs', () => {
+    const ciWorkflow = readText('.github/workflows/ci.yml');
+
+    expect(ciWorkflow).toContain('run: pnpm bench:ci');
+    expect(ciWorkflow).toContain('if: matrix.node-version == 20');
+  });
+});

--- a/src/tests/config-path-security.test.ts
+++ b/src/tests/config-path-security.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfigFile } from '@codeagora/core/config/loader.js';
+
+const configJson = JSON.stringify({
+  mode: 'pragmatic',
+  reviewers: [
+    { id: 'r1', model: 'llama', backend: 'api', provider: 'groq', timeout: 120, enabled: true },
+  ],
+  supporters: {
+    pool: [
+      { id: 's1', model: 'llama', backend: 'api', provider: 'groq', timeout: 60, enabled: true },
+    ],
+    pickCount: 1,
+    pickStrategy: 'random',
+    devilsAdvocate: { id: 'da', model: 'llama', backend: 'api', provider: 'groq', timeout: 60, enabled: false },
+    personaPool: ['.ca/personas/strict.md'],
+    personaAssignment: 'random',
+  },
+  moderator: { provider: 'groq', model: 'llama', backend: 'api' },
+  discussion: {
+    maxRounds: 2,
+    registrationThreshold: { HARSHLY_CRITICAL: 1, CRITICAL: 1, WARNING: 2, SUGGESTION: null },
+    codeSnippetRange: 10,
+  },
+  head: { provider: 'groq', model: 'auto', backend: 'api', enabled: true },
+  errorHandling: { maxRetries: 2, forfeitThreshold: 0.7 },
+});
+
+describe('explicit configPath security', () => {
+  let repoRoot: string;
+  let outsideRoot: string;
+
+  beforeEach(async () => {
+    repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-config-root-'));
+    outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-config-outside-'));
+    await fs.mkdir(path.join(repoRoot, '.ca'), { recursive: true });
+    await fs.writeFile(path.join(repoRoot, '.ca', 'config.json'), configJson);
+    await fs.writeFile(path.join(outsideRoot, 'secret-config.json'), configJson);
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      fs.rm(repoRoot, { recursive: true, force: true }),
+      fs.rm(outsideRoot, { recursive: true, force: true }),
+    ]);
+  });
+
+  it('loads safe in-root config paths', async () => {
+    const config = await loadConfigFile('.ca/config.json', { rootDir: repoRoot });
+
+    expect(config.errorHandling.maxRetries).toBe(2);
+  });
+
+  it('rejects traversal before loading config content', async () => {
+    await expect(loadConfigFile('../../.env', { rootDir: repoRoot })).rejects.toThrow(/Config path rejected/);
+  });
+
+  it('rejects absolute paths outside the repository root', async () => {
+    await expect(loadConfigFile('/etc/passwd', { rootDir: repoRoot })).rejects.toThrow(/Config path rejected/);
+  });
+
+  it('rejects symlink escapes outside the repository root', async () => {
+    const linkPath = path.join(repoRoot, '.ca', 'linked-config.json');
+    await fs.symlink(path.join(outsideRoot, 'secret-config.json'), linkPath);
+
+    await expect(loadConfigFile('.ca/linked-config.json', { rootDir: repoRoot })).rejects.toThrow(/Config path rejected/);
+  });
+});

--- a/src/tests/github-action-diff-path-security.test.ts
+++ b/src/tests/github-action-diff-path-security.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { validateActionDiffPath } from '@codeagora/github/action-policy.js';
+
+describe('github action diff path security', () => {
+  const workspaceRoot = '/workspace/project';
+
+  it('accepts a valid in-workspace diff file path', () => {
+    const result = validateActionDiffPath('/workspace/project/.ca/pr.diff', workspaceRoot);
+
+    expect(result).toBe('/workspace/project/.ca/pr.diff');
+  });
+
+  it('accepts the action-managed temporary diff path', () => {
+    const result = validateActionDiffPath('/tmp/codeagora-pr.diff', workspaceRoot);
+
+    expect(result).toBe('/tmp/codeagora-pr.diff');
+  });
+
+  it('rejects traversal diff paths before file IO', () => {
+    expect(() => validateActionDiffPath('../../.env', workspaceRoot)).toThrow(/Action diff path rejected/);
+  });
+
+  it('rejects absolute paths outside the workspace and action temp root', () => {
+    expect(() => validateActionDiffPath('/etc/passwd', workspaceRoot)).toThrow(/Action diff path rejected/);
+  });
+});

--- a/src/tests/github-action-diff-path-security.test.ts
+++ b/src/tests/github-action-diff-path-security.test.ts
@@ -1,26 +1,59 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { validateActionDiffPath } from '@codeagora/github/action-policy.js';
 
 describe('github action diff path security', () => {
-  const workspaceRoot = '/workspace/project';
+  let workspaceRoot: string;
+  let outsideRoot: string;
+  const tempRoots: string[] = [];
 
-  it('accepts a valid in-workspace diff file path', () => {
-    const result = validateActionDiffPath('/workspace/project/.ca/pr.diff', workspaceRoot);
-
-    expect(result).toBe('/workspace/project/.ca/pr.diff');
+  beforeEach(async () => {
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-workspace-'));
+    outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-outside-'));
+    tempRoots.push(workspaceRoot, outsideRoot);
   });
 
-  it('accepts the action-managed temporary diff path', () => {
-    const result = validateActionDiffPath('/tmp/codeagora-pr.diff', workspaceRoot);
-
-    expect(result).toBe('/tmp/codeagora-pr.diff');
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
   });
 
-  it('rejects traversal diff paths before file IO', () => {
-    expect(() => validateActionDiffPath('../../.env', workspaceRoot)).toThrow(/Action diff path rejected/);
+  it('accepts a valid in-workspace diff file path', async () => {
+    const diffPath = path.join(workspaceRoot, '.ca', 'pr.diff');
+    await fs.mkdir(path.dirname(diffPath), { recursive: true });
+    await fs.writeFile(diffPath, 'diff --git a/a b/a');
+
+    const result = await validateActionDiffPath(diffPath, workspaceRoot);
+
+    expect(result).toBe(await fs.realpath(diffPath));
   });
 
-  it('rejects absolute paths outside the workspace and action temp root', () => {
-    expect(() => validateActionDiffPath('/etc/passwd', workspaceRoot)).toThrow(/Action diff path rejected/);
+  it('accepts the action-managed temporary diff path', async () => {
+    const tempDir = await fs.mkdtemp('/tmp/codeagora-action-');
+    tempRoots.push(tempDir);
+    const diffPath = path.join(tempDir, 'review.diff');
+    await fs.writeFile(diffPath, 'diff --git a/a b/a');
+
+    const result = await validateActionDiffPath(diffPath, workspaceRoot);
+
+    expect(result).toBe(await fs.realpath(diffPath));
+  });
+
+  it('rejects traversal diff paths before file IO', async () => {
+    await expect(validateActionDiffPath('../../.env', workspaceRoot)).rejects.toThrow(/Action diff path rejected/);
+  });
+
+  it('rejects absolute paths outside the workspace and action temp root', async () => {
+    await expect(validateActionDiffPath('/etc/passwd', workspaceRoot)).rejects.toThrow(/Action diff path rejected/);
+  });
+
+  it('rejects symlinks that resolve outside allowed roots', async () => {
+    const outsideDiff = path.join(outsideRoot, 'secret.diff');
+    const linkedDiff = path.join(workspaceRoot, 'linked.diff');
+    await fs.writeFile(outsideDiff, 'secret');
+    await fs.symlink(outsideDiff, linkedDiff);
+
+    await expect(validateActionDiffPath(linkedDiff, workspaceRoot)).rejects.toThrow(/Action diff path rejected/);
   });
 });

--- a/src/tests/github-action-sarif-path.test.ts
+++ b/src/tests/github-action-sarif-path.test.ts
@@ -1,41 +1,59 @@
-/**
- * Tests for SARIF output path validation in github-action.ts
- * Issue #107: validate sarifOutputPath to prevent path traversal
- */
-
-import { describe, it, expect } from 'vitest';
-import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { validateActionOutputPath } from '@codeagora/github/action-policy.js';
 
 describe('SARIF output path validation', () => {
-  const allowedRoots = ['/workspace/project', '/tmp'];
+  let workspaceRoot: string;
+  let outsideRoot: string;
+  const tempRoots: string[] = [];
 
-  it('accepts default /tmp path', () => {
-    const result = validateDiffPath('/tmp/codeagora-results.sarif', { allowedRoots });
-    expect(result.success).toBe(true);
+  beforeEach(async () => {
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-sarif-workspace-'));
+    outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-sarif-outside-'));
+    await fs.mkdir(path.join(workspaceRoot, '.ca'), { recursive: true });
+    tempRoots.push(workspaceRoot, outsideRoot);
   });
 
-  it('accepts path under project root', () => {
-    const result = validateDiffPath('/workspace/project/.ca/results.sarif', { allowedRoots });
-    expect(result.success).toBe(true);
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
   });
 
-  it('rejects path outside allowed roots', () => {
-    const result = validateDiffPath('/etc/evil.sarif', { allowedRoots });
-    expect(result.success).toBe(false);
+  it('accepts default /tmp path', async () => {
+    const result = await validateActionOutputPath('/tmp/codeagora-results.sarif', workspaceRoot);
+
+    expect(result).toBe(path.resolve('/tmp/codeagora-results.sarif'));
   });
 
-  it('rejects path with traversal segments', () => {
-    const result = validateDiffPath('/tmp/../etc/passwd', { allowedRoots });
-    expect(result.success).toBe(false);
+  it('accepts path under project root', async () => {
+    const result = await validateActionOutputPath(path.join(workspaceRoot, '.ca', 'results.sarif'), workspaceRoot);
+
+    expect(result).toBe(path.join(workspaceRoot, '.ca', 'results.sarif'));
   });
 
-  it('rejects path with null bytes', () => {
-    const result = validateDiffPath('/tmp/safe.sarif\x00.evil', { allowedRoots });
-    expect(result.success).toBe(false);
+  it('rejects path outside allowed roots', async () => {
+    await expect(validateActionOutputPath('/etc/evil.sarif', workspaceRoot)).rejects.toThrow(/Action output path rejected/);
   });
 
-  it('rejects empty path', () => {
-    const result = validateDiffPath('', { allowedRoots });
-    expect(result.success).toBe(false);
+  it('rejects path with traversal segments', async () => {
+    await expect(validateActionOutputPath('/tmp/../etc/passwd', workspaceRoot)).rejects.toThrow(/Action output path rejected/);
+  });
+
+  it('rejects path with null bytes', async () => {
+    await expect(validateActionOutputPath('/tmp/safe.sarif\x00.evil', workspaceRoot)).rejects.toThrow(/Action output path rejected/);
+  });
+
+  it('rejects empty path', async () => {
+    await expect(validateActionOutputPath('', workspaceRoot)).rejects.toThrow(/Action output path rejected/);
+  });
+
+  it('rejects existing symlink output targets', async () => {
+    const outsideFile = path.join(outsideRoot, 'results.sarif');
+    const linkPath = path.join(workspaceRoot, 'linked.sarif');
+    await fs.writeFile(outsideFile, '{}');
+    await fs.symlink(outsideFile, linkPath);
+
+    await expect(validateActionOutputPath(linkPath, workspaceRoot)).rejects.toThrow(/Action output path rejected/);
   });
 });

--- a/src/tests/large-diff-security-priority.test.ts
+++ b/src/tests/large-diff-security-priority.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { chunkDiffWithMetadata } from '@codeagora/core/pipeline/chunker.js';
+import { redactSecrets } from '@codeagora/shared/utils/redaction.js';
+
+function fileDiff(filePath: string, addedLines: string[]): string {
+  return [
+    `diff --git a/${filePath} b/${filePath}`,
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+    '@@ -1,1 +1,2 @@',
+    '-old',
+    ...addedLines.map((line) => `+${line}`),
+  ].join('\n');
+}
+
+describe('large-diff security priority surfaces', () => {
+  it('prioritizes security-sensitive chunks before docs/noise chunks', async () => {
+    const docsLines = Array.from({ length: 80 }, (_, index) => `docs line ${index} with harmless release note text`);
+    const diff = [
+      fileDiff('docs/runbook.md', docsLines),
+      fileDiff('.github/workflows/ci.yml', ['permissions: write-all', 'Authorization: Bearer test-secret']),
+      fileDiff('src/auth/session.ts', ['const token = process.env.GITHUB_TOKEN;', 'if (role === "admin") return true;']),
+      fileDiff('src/config/secrets.ts', ['const fallback = "OPENAI_API_KEY=sk-test-secret";']),
+      fileDiff('docs/changelog.md', docsLines),
+    ].join('\n');
+
+    const result = await chunkDiffWithMetadata(diff, { maxTokens: 120 });
+
+    expect(result.metadata.diffChunking.priorityFiles).toEqual([
+      '.github/workflows/ci.yml',
+      'src/auth/session.ts',
+      'src/config/secrets.ts',
+    ]);
+    expect(result.chunks.length).toBeGreaterThan(1);
+    expect(result.chunks[0]?.files).toContain('.github/workflows/ci.yml');
+    expect(result.chunks[0]?.files).not.toContain('docs/changelog.md');
+  });
+
+  it('keeps security-priority evidence sanitized for public surfaces', async () => {
+    const diff = [
+      fileDiff('src/auth/session.ts', ['const token = "OPENAI_API_KEY=sk-test-secret";', 'Authorization: Bearer test-secret']),
+      fileDiff('docs/readme.md', ['safe docs update']),
+    ].join('\n');
+
+    const result = await chunkDiffWithMetadata(diff, { maxTokens: 80 });
+    const publicSurfacePayload = redactSecrets(JSON.stringify({
+      cli: result.chunks[0]?.files,
+      github: result.metadata.diffChunking.priorityFiles,
+      mcp: result.metadata.diffChunking.priorityFiles,
+      diff: result.chunks[0]?.diffContent,
+    }));
+
+    expect(publicSurfacePayload).toContain('src/auth/session.ts');
+    expect(publicSurfacePayload).not.toContain('sk-test-secret');
+    expect(publicSurfacePayload).not.toContain('Bearer test-secret');
+  });
+});

--- a/src/tests/mcp-version.test.ts
+++ b/src/tests/mcp-version.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import { readMcpPackageVersion } from '@codeagora/mcp/version.js';
+
+describe('MCP package metadata', () => {
+  it('uses packages/mcp/package.json as the server version source', () => {
+    const pkg = JSON.parse(fs.readFileSync('packages/mcp/package.json', 'utf-8')) as { version: string };
+
+    expect(readMcpPackageVersion()).toBe(pkg.version);
+  });
+
+  it('ships package-local onboarding in the MCP package', () => {
+    const pkg = JSON.parse(fs.readFileSync('packages/mcp/package.json', 'utf-8')) as { files: string[] };
+    const readme = fs.readFileSync('packages/mcp/README.md', 'utf-8');
+    const rootReadme = fs.readFileSync('README.md', 'utf-8');
+
+    expect(pkg.files).toContain('README.md');
+    expect(readme).toContain('Environment Variables');
+    expect(readme).toContain('review_quick');
+    expect(readme).toContain('Troubleshooting');
+    expect(rootReadme).toContain('packages/mcp/README.md');
+  });
+});

--- a/src/tests/package-contents.test.ts
+++ b/src/tests/package-contents.test.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import { describe, expect, it } from 'vitest';
+
+describe('release package content verification', () => {
+  it('has package-content verification wired into rc smoke', () => {
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8')) as { scripts: Record<string, string> };
+    const smoke = fs.readFileSync('scripts/rc-smoke.mjs', 'utf-8');
+
+    expect(pkg.scripts['release:rc-smoke']).toBe('node scripts/rc-smoke.mjs');
+    expect(smoke).toContain('scripts/verify-package-contents.mjs');
+  });
+
+  it('asserts root and MCP package include/exclude rules', () => {
+    const verifier = fs.readFileSync('scripts/verify-package-contents.mjs', 'utf-8');
+
+    expect(verifier).toContain('packages/cli/dist/index.js');
+    expect(verifier).toContain('scripts/postinstall.cjs');
+    expect(verifier).toContain('dist/index.js');
+    expect(verifier).toContain('README.md');
+    expect(verifier).toContain('bench-out');
+    expect(verifier).toContain('.sisyphus');
+    expect(verifier).toContain('.test');
+  });
+});

--- a/src/tests/redaction-boundaries.test.ts
+++ b/src/tests/redaction-boundaries.test.ts
@@ -14,11 +14,12 @@ import type { DiscussionRound, DiscussionVerdict, EvidenceDocument, HeadVerdict,
 const rawSecret = 'OPENAI_API_KEY=sk-test-secret';
 const rawGithubToken = 'GITHUB_TOKEN=ghp_testsecret';
 const rawBearer = 'Authorization: Bearer test-secret';
+const rawBareBearer = 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature';
 const date = '2026-05-02';
 const sessionId = '001';
 
 function secretText(): string {
-  return `${rawSecret}\n${rawGithubToken}\n${rawBearer}`;
+  return `${rawSecret}\n${rawGithubToken}\n${rawBearer}\n${rawBareBearer}`;
 }
 
 const evidenceDoc: EvidenceDocument = {
@@ -35,6 +36,7 @@ function expectNoRawSecrets(output: string): void {
   expect(output).not.toContain('sk-test-secret');
   expect(output).not.toContain('ghp_testsecret');
   expect(output).not.toContain('Bearer test-secret');
+  expect(output).not.toContain('eyJhbGciOiJIUzI1NiJ9.payload.signature');
 }
 
 describe('redaction utilities', () => {
@@ -45,6 +47,7 @@ describe('redaction utilities', () => {
     expect(output).toContain('OPENAI_API_KEY=[REDACTED]');
     expect(output).toContain('GITHUB_TOKEN=[REDACTED]');
     expect(output).toContain('Authorization: Bearer [REDACTED]');
+    expect(output).toContain('Bearer [REDACTED]');
   });
 
   it('preserves structured fields while redacting nested values', () => {

--- a/src/tests/redaction-boundaries.test.ts
+++ b/src/tests/redaction-boundaries.test.ts
@@ -1,0 +1,200 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { writeReviewOutput } from '@codeagora/core/l1/writer.js';
+import { writeDiscussionRound, writeDiscussionVerdict, writeModeratorReport, writeSuggestions } from '@codeagora/core/l2/writer.js';
+import { writeHeadVerdict } from '@codeagora/core/l3/writer.js';
+import { mcpErrorResponse } from '@codeagora/mcp/tools/shared-response.js';
+import { postReview } from '@codeagora/github/poster.js';
+import type { Octokit } from '@octokit/rest';
+import { redactDeep, redactSecrets } from '@codeagora/shared/utils/redaction.js';
+import type { DiscussionRound, DiscussionVerdict, EvidenceDocument, HeadVerdict, ModeratorReport, ReviewOutput } from '@codeagora/core/types/core.js';
+
+const rawSecret = 'OPENAI_API_KEY=sk-test-secret';
+const rawGithubToken = 'GITHUB_TOKEN=ghp_testsecret';
+const rawBearer = 'Authorization: Bearer test-secret';
+const date = '2026-05-02';
+const sessionId = '001';
+
+function secretText(): string {
+  return `${rawSecret}\n${rawGithubToken}\n${rawBearer}`;
+}
+
+const evidenceDoc: EvidenceDocument = {
+  issueTitle: 'Secret leakage in config',
+  problem: `Problem contains ${secretText()}`,
+  evidence: [`Evidence contains ${secretText()}`],
+  severity: 'CRITICAL',
+  suggestion: `Remove ${secretText()} from output`,
+  filePath: 'src/auth.ts',
+  lineRange: [12, 12],
+};
+
+function expectNoRawSecrets(output: string): void {
+  expect(output).not.toContain('sk-test-secret');
+  expect(output).not.toContain('ghp_testsecret');
+  expect(output).not.toContain('Bearer test-secret');
+}
+
+describe('redaction utilities', () => {
+  it('redacts assignment, GitHub token, and bearer token patterns', () => {
+    const output = redactSecrets(secretText());
+
+    expectNoRawSecrets(output);
+    expect(output).toContain('OPENAI_API_KEY=[REDACTED]');
+    expect(output).toContain('GITHUB_TOKEN=[REDACTED]');
+    expect(output).toContain('Authorization: Bearer [REDACTED]');
+  });
+
+  it('preserves structured fields while redacting nested values', () => {
+    const redacted = redactDeep({ file: 'src/auth.ts', line: 12, severity: 'CRITICAL', verdict: 'REJECT', token: rawSecret });
+
+    expect(redacted.file).toBe('src/auth.ts');
+    expect(redacted.line).toBe(12);
+    expect(redacted.severity).toBe('CRITICAL');
+    expect(redacted.verdict).toBe('REJECT');
+    expect(redacted.token).toBe('OPENAI_API_KEY=[REDACTED]');
+  });
+});
+
+describe('persisted review artifact redaction', () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-redaction-'));
+    process.chdir(tmpRoot);
+    await fs.mkdir(path.join('.ca', 'sessions', date, sessionId, 'reviews'), { recursive: true });
+    await fs.mkdir(path.join('.ca', 'sessions', date, sessionId, 'discussions', 'd001'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('redacts L1 review output artifacts without removing structured evidence', async () => {
+    const review: ReviewOutput = {
+      reviewerId: 'r1',
+      model: 'test-model',
+      group: 'auth',
+      evidenceDocs: [evidenceDoc],
+      rawResponse: secretText(),
+      status: 'success',
+    };
+
+    const filePath = await writeReviewOutput(date, sessionId, review);
+    const output = await fs.readFile(filePath, 'utf-8');
+
+    expectNoRawSecrets(output);
+    expect(output).toContain('**File:** src/auth.ts:12-12');
+    expect(output).toContain('**Severity:** CRITICAL');
+  });
+
+  it('redacts L2 and L3 persisted artifacts', async () => {
+    const round: DiscussionRound = {
+      round: 1,
+      moderatorPrompt: secretText(),
+      supporterResponses: [{ supporterId: 's1', stance: 'agree', response: secretText() }],
+    };
+    const verdict: DiscussionVerdict = {
+      discussionId: 'd001',
+      filePath: 'src/auth.ts',
+      lineRange: [12, 12],
+      finalSeverity: 'CRITICAL',
+      reasoning: secretText(),
+      consensusReached: true,
+      rounds: 1,
+    };
+    const report: ModeratorReport = {
+      discussions: [verdict],
+      roundsPerDiscussion: { d001: [round] },
+      unconfirmedIssues: [evidenceDoc],
+      suggestions: [evidenceDoc],
+      summary: { totalDiscussions: 1, resolved: 1, escalated: 0 },
+    };
+    const head: HeadVerdict = {
+      decision: 'REJECT',
+      reasoning: secretText(),
+      codeChanges: [{ filePath: 'src/auth.ts', changes: secretText() }],
+    };
+
+    await writeDiscussionRound(date, sessionId, 'd001', round);
+    await writeDiscussionVerdict(date, sessionId, verdict);
+    await writeSuggestions(date, sessionId, [evidenceDoc]);
+    await writeModeratorReport(date, sessionId, report);
+    await writeHeadVerdict(date, sessionId, head);
+
+    const files = [
+      '.ca/sessions/2026-05-02/001/discussions/d001/round-1.md',
+      '.ca/sessions/2026-05-02/001/discussions/d001/verdict.md',
+      '.ca/sessions/2026-05-02/001/suggestions.md',
+      '.ca/sessions/2026-05-02/001/report.md',
+      '.ca/sessions/2026-05-02/001/result.md',
+    ];
+    const outputs = await Promise.all(files.map((file) => fs.readFile(file, 'utf-8')));
+
+    for (const output of outputs) {
+      expectNoRawSecrets(output);
+    }
+    expect(outputs.join('\n')).toContain('src/auth.ts');
+    expect(outputs.join('\n')).toContain('CRITICAL');
+    expect(outputs.join('\n')).toContain('REJECT');
+  });
+});
+
+describe('GitHub outward response redaction', () => {
+  it('redacts review body and inline comments before posting', async () => {
+    let capturedReview: unknown;
+    const mockOctokit = {
+      paginate: vi.fn().mockResolvedValue([]),
+      pulls: {
+        listReviews: vi.fn(),
+        createReview: vi.fn().mockImplementation((params: unknown) => {
+          capturedReview = params;
+          return Promise.resolve({ data: { id: 123, html_url: 'https://example.test/review/123' } });
+        }),
+      },
+      issues: {
+        createComment: vi.fn().mockResolvedValue({ data: { id: 1, html_url: 'https://example.test/comment/1' } }),
+      },
+    } as unknown as Octokit;
+
+    await postReview(
+      { token: 'token', owner: 'owner', repo: 'repo' },
+      7,
+      {
+        commit_id: 'abc123',
+        event: 'COMMENT',
+        body: `<!-- codeagora-v3 --> ${secretText()}`,
+        comments: [{ path: 'src/auth.ts', position: 1, side: 'RIGHT', body: `**CRITICAL** ${secretText()}` }],
+      },
+      mockOctokit,
+    );
+
+    const serialized = JSON.stringify(capturedReview);
+    expectNoRawSecrets(serialized);
+    expect(serialized).toContain('src/auth.ts');
+    expect(serialized).toContain('CRITICAL');
+  });
+});
+
+describe('MCP outward response redaction', () => {
+  it('redacts structured error details without breaking JSON structure', () => {
+    const response = mcpErrorResponse('TEST_SECRET', 'failure', {
+      file: 'src/auth.ts',
+      line: 12,
+      severity: 'CRITICAL',
+      token: secretText(),
+    });
+    const text = response.content[0]?.text ?? '';
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+
+    expectNoRawSecrets(text);
+    expect(parsed['status']).toBe('error');
+    expect(parsed['code']).toBe('TEST_SECRET');
+    expect((parsed['details'] as Record<string, unknown>)['file']).toBe('src/auth.ts');
+  });
+});

--- a/src/tests/result-cache-redaction.test.ts
+++ b/src/tests/result-cache-redaction.test.ts
@@ -1,0 +1,87 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { persistResultCache } from '@codeagora/core/pipeline/cache-manager.js';
+import type { PipelineResult } from '@codeagora/core/pipeline/orchestrator.js';
+
+const date = '2026-05-02';
+const sessionId = 'cache-redaction';
+const rawSecret = 'OPENAI_API_KEY=sk-test-secret';
+const rawBearer = 'Authorization: Bearer test-secret';
+const rawBareBearer = 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature';
+
+function expectNoRawSecrets(output: string): void {
+  expect(output).not.toContain('sk-test-secret');
+  expect(output).not.toContain('Bearer test-secret');
+  expect(output).not.toContain('eyJhbGciOiJIUzI1NiJ9.payload.signature');
+}
+
+describe('result cache redaction', () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-result-cache-'));
+    process.chdir(tmpRoot);
+    await fs.mkdir(path.join('.ca', 'sessions', date, sessionId), { recursive: true });
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('redacts secrets before persisting result.json', async () => {
+    const result: PipelineResult = {
+      sessionId,
+      date,
+      status: 'success',
+      summary: {
+        decision: 'NEEDS_HUMAN',
+        reasoning: `${rawSecret}\n${rawBearer}\n${rawBareBearer}`,
+        totalReviewers: 1,
+        forfeitedReviewers: 0,
+        severityCounts: { CRITICAL: 1 },
+        topIssues: [{ severity: 'CRITICAL', filePath: 'src/auth.ts', lineRange: [1, 1], title: 'Secret leak' }],
+        totalDiscussions: 1,
+        resolved: 1,
+        escalated: 0,
+      },
+      evidenceDocs: [{
+        issueTitle: 'Secret leak',
+        problem: rawSecret,
+        evidence: [rawBearer, rawBareBearer],
+        severity: 'CRITICAL',
+        suggestion: rawSecret,
+        filePath: 'src/auth.ts',
+        lineRange: [1, 1],
+      }],
+      discussions: [{
+        discussionId: 'd001',
+        filePath: 'src/auth.ts',
+        lineRange: [1, 1],
+        finalSeverity: 'CRITICAL',
+        reasoning: rawBearer,
+        consensusReached: true,
+        rounds: 1,
+      }],
+      roundsPerDiscussion: {
+        d001: [{
+          round: 1,
+          moderatorPrompt: rawSecret,
+          supporterResponses: [{ supporterId: 's1', response: rawBareBearer, stance: 'agree' }],
+        }],
+      },
+    };
+
+    await persistResultCache(date, sessionId, 'cache-key', result, true);
+
+    const persisted = await fs.readFile(path.join('.ca', 'sessions', date, sessionId, 'result.json'), 'utf-8');
+    expectNoRawSecrets(persisted);
+    expect(persisted).toContain('OPENAI_API_KEY=[REDACTED]');
+    expect(persisted).toContain('Authorization: Bearer [REDACTED]');
+    expect(persisted).toContain('Bearer [REDACTED]');
+  });
+});

--- a/src/tests/utils-path-validation.test.ts
+++ b/src/tests/utils-path-validation.test.ts
@@ -3,11 +3,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
 import path from 'path';
-import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
+import { validateDiffPath, validatePathWithinRoot } from '@codeagora/shared/utils/path-validation.js';
 
 describe('validateDiffPath', () => {
-  // 1. Normal absolute path — success
   it('accepts a normal absolute path /tmp/review.diff', () => {
     const result = validateDiffPath('/tmp/review.diff');
     expect(result.success).toBe(true);
@@ -16,7 +17,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 2. Normal absolute path — success
   it('accepts a normal absolute path /home/user/project/changes.diff', () => {
     const result = validateDiffPath('/home/user/project/changes.diff');
     expect(result.success).toBe(true);
@@ -25,7 +25,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 3. Path traversal '../../../etc/passwd' — error
   it('rejects path traversal ../../../etc/passwd', () => {
     const result = validateDiffPath('../../../etc/passwd');
     expect(result.success).toBe(false);
@@ -34,7 +33,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 4. Path traversal 'foo/../../etc/shadow' — error
   it('rejects path traversal foo/../../etc/shadow', () => {
     const result = validateDiffPath('foo/../../etc/shadow');
     expect(result.success).toBe(false);
@@ -43,7 +41,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 5. Null byte injection — error
   it('rejects null byte injection /tmp/file\\x00.diff', () => {
     const result = validateDiffPath('/tmp/file\x00.diff');
     expect(result.success).toBe(false);
@@ -52,7 +49,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 6. allowedRoots ['/tmp'] + '/tmp/review.diff' — success
   it('accepts path within allowedRoots', () => {
     const result = validateDiffPath('/tmp/review.diff', { allowedRoots: ['/tmp'] });
     expect(result.success).toBe(true);
@@ -61,7 +57,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 7. allowedRoots ['/tmp'] + '/home/user/file.diff' — error (outside allowed roots)
   it('rejects path outside allowedRoots', () => {
     const result = validateDiffPath('/home/user/file.diff', { allowedRoots: ['/tmp'] });
     expect(result.success).toBe(false);
@@ -70,7 +65,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 8. Relative path 'review.diff' → resolve succeeds
   it('resolves relative path and accepts it when valid', () => {
     const result = validateDiffPath('review.diff');
     expect(result.success).toBe(true);
@@ -80,7 +74,6 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 9. Empty string — error
   it('rejects empty string', () => {
     const result = validateDiffPath('');
     expect(result.success).toBe(false);
@@ -89,12 +82,58 @@ describe('validateDiffPath', () => {
     }
   });
 
-  // 10. allowedRoots empty array [] — rejects all paths
   it('rejects all paths when allowedRoots is empty array', () => {
     const result = validateDiffPath('/tmp/review.diff', { allowedRoots: [] });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error).toBeTruthy();
+    }
+  });
+});
+
+describe('validatePathWithinRoot', () => {
+  it('accepts real files under the root', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'path-root-'));
+    try {
+      await fs.writeFile(path.join(root, 'review.diff'), 'diff --git a/a b/a');
+
+      const result = await validatePathWithinRoot('review.diff', root);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(await fs.realpath(path.join(root, 'review.diff')));
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects traversal before resolving files', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'path-root-'));
+    try {
+      const result = await validatePathWithinRoot('../../.env', root);
+
+      expect(result.success).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinks that resolve outside the root', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'path-root-'));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'path-outside-'));
+    try {
+      await fs.writeFile(path.join(outside, 'secret.diff'), 'secret');
+      await fs.symlink(path.join(outside, 'secret.diff'), path.join(root, 'linked.diff'));
+
+      const result = await validatePathWithinRoot('linked.diff', root);
+
+      expect(result.success).toBe(false);
+    } finally {
+      await Promise.all([
+        fs.rm(root, { recursive: true, force: true }),
+        fs.rm(outside, { recursive: true, force: true }),
+      ]);
     }
   });
 });


### PR DESCRIPTION
## Summary

Implements the P4-P6 production-readiness track as a non-publishing RC gate set:

- P4: adds deterministic, provider-free benchmark validation via `pnpm bench:ci` and wires it into CI/release gates.
- P5: hardens path and secret boundaries for config loading, GitHub Action diff reads, persisted review artifacts, GitHub review posting, and MCP responses.
- P6: adds RC smoke/package verification, MCP onboarding, package-driven MCP server versioning, and release-readiness docs/checklists.

## Detailed Changes

### P4: deterministic benchmark gate

- Added `bench:ci` to run fixture schema validation and phase-2 reference validation without live providers.
- Updated the phase-2 benchmark reference notes to describe the 20-fixture offline RC contract.
- Added CI coverage so the benchmark gate runs on the Node 20 job.
- Updated benchmark docs to distinguish required offline gates from optional live `bench-out*` evidence artifacts.

### P5: security and abuse boundaries

- Added `validatePathWithinRoot()` with realpath containment checks to reject traversal and symlink escapes.
- Applied explicit `configPath` validation against the active repo root before config file reads.
- Added GitHub Action `diff` input validation before all file IO and pipeline execution.
- Extended redaction for `Authorization: Bearer ...` secrets.
- Redacted persisted L1/L2/L3 review artifacts before writing them to session storage.
- Redacted GitHub review bodies, inline comments, file-level comments, and retry/bisection payloads before posting.
- Redacted MCP compact/raw review responses and structured error details.
- Added large-diff security-priority regression coverage so security-sensitive chunks stay ahead of docs/noise when outputs are capped.

### P6: RC smoke, packaging, and onboarding

- Added `release:rc-smoke` as a local, non-publishing release-candidate smoke command.
- Added package dry-run verification for root CLI package and MCP package contents.
- Updated the release workflow to run `pnpm bench:ci` and `pnpm release:rc-smoke` before publish-capable steps.
- Rebuilt `dist/action.js` for the GitHub Action changes.
- Added MCP package-local onboarding in `packages/mcp/README.md` and included it in MCP package files.
- Changed MCP server version reporting to read from `packages/mcp/package.json` instead of a hard-coded string.
- Added `docs/RELEASE_CHECKLIST.md` and `docs/RC_READINESS_P4_P6.md` with RC guardrails and evidence summary.
- Refreshed `.env.example` with placeholder-only provider, GitHub, benchmark, and MCP environment guidance.
- Ignored `.sisyphus/` local planning/evidence artifacts.

## Verification

Local verification completed:

- `pnpm typecheck` passed
- `pnpm build` passed
- `pnpm bench:ci` passed (`20 fixture(s) validated`)
- `pnpm test` passed (`204 passed | 1 skipped`, `3408 passed | 21 skipped`)
- `pnpm release:rc-smoke` passed
  - workspace build passed
  - `pnpm build:action` passed
  - package dry-run contents verified
  - CLI `--help` smoke passed
  - MCP initialize + `tools/list` smoke passed
- `pnpm exec node scripts/verify-package-contents.mjs` passed (`root files: 12`, `mcp files: 3`)
- LSP diagnostics were clean for all changed TS source/test files.

Evidence logs were captured locally under `.sisyphus/evidence/`; these are intentionally ignored and not committed.

## Release Safety

This PR does not publish packages, create tags, create GitHub Releases, promote npm dist-tags, or ship marketplace artifacts. It only adds deterministic gates, package dry-run checks, security hardening, docs, and local smoke automation.