### PR TITLE
Prepare beta readiness workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
       - run: pnpm test --no-file-parallelism
       - run: pnpm bench:ci
 
-      # Non-publishing RC gate: package dry-runs, CLI help, MCP tools/list, Action bundle.
-      - name: Release candidate smoke
-        run: pnpm release:rc-smoke
+      # Non-publishing beta gate: package dry-runs, CLI help, MCP tools/list, Action bundle.
+      - name: Beta smoke
+        run: pnpm release:beta-smoke
 
       # Publish review package
       - name: Publish @codeagora/review

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Every PR gets inline review comments, a summary verdict, and a commit status che
 | [Extensions](docs/EXTENSIONS.md) | MCP and desktop direction |
 | [Product Surface Plan](docs/PRODUCT_SURFACE_AND_LIGHTWEIGHT_PLAN.md) | Current surfaces and lightweight roadmap |
 | [Production Readiness Roadmap](docs/PRODUCTION_READINESS_ROADMAP.md) | Gates for production-ready CLI, GitHub Action, and MCP releases |
+| [Beta Readiness](docs/BETA_READINESS_P4_P6.md) | P4-P6 beta gates, smoke checks, and release guardrails |
 | [Agent Contract](docs/AGENT_CONTRACT.md) | Stable JSON, NDJSON, exit codes, and MCP output semantics |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Common errors and fixes, exit codes |
 | [FAQ](docs/FAQ.md) | Frequently asked questions |
@@ -200,7 +201,7 @@ pnpm dev review path/to/diff.patch
 
 ## Benchmarks
 
-Golden-bug fixtures under `benchmarks/golden-bugs/` drive the false-negative and FP-regression framework (see #472). The current deterministic RC gate covers 20 fixtures: 14 recall cases and 6 FP-regression cases.
+Golden-bug fixtures under `benchmarks/golden-bugs/` drive the false-negative and FP-regression framework (see #472). The current deterministic beta gate covers 20 fixtures: 14 recall cases and 6 FP-regression cases.
 
 **Required offline gate** (fast, no API calls):
 

--- a/docs/BETA_READINESS_P4_P6.md
+++ b/docs/BETA_READINESS_P4_P6.md
@@ -1,8 +1,8 @@
-# P4-P6 RC Readiness Summary
+# P4-P6 Beta Readiness Summary
 
 Updated: 2026-05-02
 
-This document summarizes the release-candidate readiness gates added for the production-readiness P4-P6 track. The scope is intentionally limited to deterministic validation, security hardening, documentation, and non-publishing RC smoke checks. It does not perform npm publishing, GitHub release creation, tagging, dist-tag updates, or marketplace distribution.
+This document summarizes the beta-readiness gates added for the production-readiness P4-P6 track. The scope is intentionally limited to deterministic validation, security hardening, documentation, and non-publishing beta smoke checks. It does not perform npm publishing, GitHub release creation, tagging, dist-tag updates, or marketplace distribution.
 
 ## P4: Benchmark Gate
 
@@ -12,7 +12,7 @@ The required benchmark gate is now deterministic and provider-free:
 pnpm bench:ci
 ```
 
-The gate validates the golden-bug fixture schema and the phase-2 quality reference. CI runs this gate on Node 20 so release readiness does not depend on live LLM providers or quota availability.
+The gate validates the golden-bug fixture schema and the phase-2 quality reference. CI runs this gate on Node 20 so beta readiness does not depend on live LLM providers or quota availability.
 
 Current reference contract:
 
@@ -42,12 +42,12 @@ Bearer-token style secrets are included in the shared redaction contract.
 
 Large-diff prioritization is also regression-tested so security findings stay ahead of low-priority comments when inline review output is capped.
 
-## P6: RC Smoke And Onboarding
+## P6: Beta Smoke And Onboarding
 
-The RC smoke command is non-publishing by design:
+The beta smoke command is non-publishing by design:
 
 ```bash
-pnpm release:rc-smoke
+pnpm release:beta-smoke
 ```
 
 It verifies:
@@ -59,9 +59,13 @@ It verifies:
 - CLI `--help` smoke
 - MCP initialize plus `tools/list` smoke
 
-The release workflow runs the deterministic benchmark gate and RC smoke before publish-capable steps. The checklist in `docs/RELEASE_CHECKLIST.md` documents manual guardrails for actual release operations.
+The release workflow runs the deterministic benchmark gate and beta smoke before publish-capable steps. The checklist in `docs/RELEASE_CHECKLIST.md` documents manual guardrails for actual release operations.
 
 MCP onboarding is now package-local in `packages/mcp/README.md`, and the MCP server version is sourced from `packages/mcp/package.json` rather than a hard-coded string.
+
+## Beta Positioning
+
+Beta means the CLI, GitHub Action, and MCP package are ready for broader user feedback on the supported surfaces, while APIs, release automation, benchmark thresholds, and provider behavior may still change before a stable release. Actual npm publishing, GitHub release creation, tag creation, and dist-tag promotion remain separate approval steps.
 
 ## Verification Evidence
 
@@ -72,17 +76,17 @@ pnpm typecheck
 pnpm build
 pnpm bench:ci
 pnpm test
-pnpm release:rc-smoke
+pnpm release:beta-smoke
 pnpm exec node scripts/verify-package-contents.mjs
 ```
 
-Observed results:
+Observed results on merged `main`:
 
 - `pnpm typecheck`: passed
-- `pnpm build`: passed
+- `pnpm build`: passed via beta smoke
 - `pnpm bench:ci`: passed; 20 fixtures validated
-- `pnpm test`: 204 files passed, 1 skipped; 3408 tests passed, 21 skipped
-- `pnpm release:rc-smoke`: passed; package dry-run, CLI smoke, MCP smoke all passed
+- `pnpm test`: 205 files passed, 1 skipped; 3411 tests passed, 21 skipped
+- `pnpm release:beta-smoke`: passed; package dry-run, CLI smoke, MCP smoke all passed
 - `verify-package-contents`: passed; root files 12, MCP files 3
 
-Evidence logs are stored under `.sisyphus/evidence/` for local audit and are not required release artifacts.
+Evidence logs may be stored under `.sisyphus/evidence/` for local audit and are not required release artifacts.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -94,7 +94,7 @@ agora sessions prune --days 30               # Delete old
 
 ## `agora metrics`
 
-Generate local quality/cost artifacts without a web dashboard. For release-candidate benchmark gates, use `pnpm bench:ci` for provider-free schema/reference validation and `pnpm bench:fn:compare` to compare precomputed candidate and baseline result directories.
+Generate local quality/cost artifacts without a web dashboard. For beta benchmark gates, use `pnpm bench:ci` for provider-free schema/reference validation and `pnpm bench:fn:compare` to compare precomputed candidate and baseline result directories.
 
 ```bash
 agora metrics benchmark --results ./bench-out-l3-20-20260428

--- a/docs/PRODUCTION_READINESS_ROADMAP.md
+++ b/docs/PRODUCTION_READINESS_ROADMAP.md
@@ -212,9 +212,9 @@ Add a human-facing local UI only after the core product can stand on its own.
 - Desktop config editing round-trips through the same schemas used by CLI and MCP.
 - Desktop does not change review outcomes compared with CLI for the same diff/config.
 
-## Release Candidate Gate
+## Beta Gate
 
-A production release candidate requires all of the following:
+A beta release requires all of the following:
 
 - Phase 0 through Phase 6 acceptance gates complete.
 - `pnpm typecheck`, `pnpm build`, `pnpm test`, and action bundle build pass on clean checkout.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,10 +1,10 @@
-# Release Candidate Checklist
+# Beta Release Checklist
 
-This checklist verifies P4-P6 release-candidate readiness without publishing anything.
+This checklist verifies P4-P6 beta readiness without publishing anything.
 
 ## Scope Guardrails
 
-The RC gate does not perform npm publish, npm dist-tag promotion, GitHub tag creation, GitHub Release creation, marketplace publication, or Action release promotion. Those operations remain out of scope until a separate release approval.
+The beta gate does not perform npm publish, npm dist-tag promotion, GitHub tag creation, GitHub Release creation, marketplace publication, or Action release promotion. Those operations remain out of scope until a separate release approval.
 
 ## Release Surfaces
 
@@ -12,21 +12,21 @@ The RC gate does not perform npm publish, npm dist-tag promotion, GitHub tag cre
 2. MCP package: `@codeagora/mcp`, including the `codeagora-mcp` binary and package-local onboarding.
 3. GitHub Action: repo-native composite Action backed by `dist/action.js`.
 
-## RC Gates
+## Beta Gates
 
 1. Confirm package version consistency between release notes, root `package.json`, and `packages/mcp/package.json`.
 2. Run `pnpm typecheck`.
 3. Run `pnpm test`.
 4. Run `pnpm build`.
 5. Run `pnpm bench:ci` to validate deterministic benchmark schema/reference gates without live providers.
-6. Run `pnpm release:rc-smoke` to validate local package and Action smoke behavior without publishing.
+6. Run `pnpm release:beta-smoke` to validate local package and Action smoke behavior without publishing.
 7. Run root package pack dry-run and confirm runtime files for `codeagora`/`agora` are included while tests, `.env`, `bench-out*`, and `.sisyphus/evidence` are excluded.
 8. Run `pnpm --filter @codeagora/mcp pack --dry-run` and confirm `dist/index.js`, `package.json`, and `README.md` are included while tests and secrets are excluded.
 9. Run the GitHub Action smoke path through `pnpm build:action` and the release smoke script.
 10. Review README, CLI docs, MCP onboarding, `.env.example`, and Action docs for current install and secret requirements.
 11. Open the PR and verify remote checks: CI Node 20/22, CodeAgora review, and PR size label.
-12. Confirm P6 RC readiness only after P4 deterministic benchmark gates and P5 security abuse gates pass.
+12. Confirm P6 beta readiness only after P4 deterministic benchmark gates and P5 security abuse gates pass.
 
 ## Evidence
 
-Capture command output under `.sisyphus/evidence/` for typecheck, test, build, `bench:ci`, `release:rc-smoke`, root package dry-run, MCP package dry-run, and security regression tests.
+Capture command output under `.sisyphus/evidence/` for typecheck, test, build, `bench:ci`, `release:beta-smoke`, root package dry-run, MCP package dry-run, and security regression tests.

--- a/docs/golden-bug-benchmark-report-2026-04-27.md
+++ b/docs/golden-bug-benchmark-report-2026-04-27.md
@@ -25,7 +25,7 @@ The final confirmed low-cost diverse aggregate reached full benchmark coverage o
 
 No API key values were inspected or recorded. Only key presence and behavior were validated during the run.
 
-Current RC note: this historical live-run report remains benchmark evidence, but required CI now uses the deterministic 20-fixture offline gate: `pnpm bench:ci`, which runs fixture schema validation and `benchmarks/references/phase2-quality-gate.json` reference validation without provider keys. New `bench-out*` live result directories should remain uncommitted and be uploaded as workflow artifacts when needed.
+Current beta note: this historical live-run report remains benchmark evidence, but required CI now uses the deterministic 20-fixture offline gate: `pnpm bench:ci`, which runs fixture schema validation and `benchmarks/references/phase2-quality-gate.json` reference validation without provider keys. New `bench-out*` live result directories should remain uncommitted and be uploaded as workflow artifacts when needed.
 
 ## Benchmark Scope
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:coverage": "vitest run --coverage",
     "dev": "pnpm --filter @codeagora/cli dev",
     "build:action": "node scripts/build-action.mjs",
-    "release:rc-smoke": "node scripts/rc-smoke.mjs",
+    "release:beta-smoke": "node scripts/beta-smoke.mjs",
     "bench:fn": "tsx scripts/bench-fn.ts",
     "bench:fn:run": "tsx scripts/bench-fn-run.ts",
     "bench:fn:compare": "tsx scripts/bench-fn-compare.ts",

--- a/scripts/beta-smoke.mjs
+++ b/scripts/beta-smoke.mjs
@@ -162,7 +162,7 @@ async function smokeMcpServer() {
   });
 
   const messages = [
-    { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'codeagora-rc-smoke', version: '0.0.0' } } },
+    { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'codeagora-beta-smoke', version: '0.0.0' } } },
     { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
     { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
   ];
@@ -193,4 +193,4 @@ if (!help.includes('CodeAgora') && !help.includes('agora')) {
 console.log('OK: CLI help smoke passed');
 
 await smokeMcpServer();
-console.log('OK: release candidate smoke passed');
+console.log('OK: beta smoke passed');

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -17,10 +17,14 @@ try {
   version = pkg.version;
 } catch {}
 
-const isRC = version.includes('rc');
+const prereleaseLabel = version.includes('beta')
+  ? `${red}${bold}(Beta)${reset}`
+  : version.includes('rc')
+    ? `${red}${bold}(Release Candidate)${reset}`
+    : '';
 
 console.log('');
-console.log(`  ${cyan}${bold}CodeAgora${reset} ${dim}v${version}${isRC ? ` ${red}${bold}(Release Candidate)${reset}` : ''}${reset}`);
+console.log(`  ${cyan}${bold}CodeAgora${reset} ${dim}v${version}${prereleaseLabel ? ` ${prereleaseLabel}` : ''}${reset}`);
 console.log(`  ${dim}Multi-LLM collaborative code review${reset}`);
 console.log('');
 console.log(`  ${green}Get started:${reset}`);

--- a/src/tests/package-contents.test.ts
+++ b/src/tests/package-contents.test.ts
@@ -2,11 +2,11 @@ import fs from 'fs';
 import { describe, expect, it } from 'vitest';
 
 describe('release package content verification', () => {
-  it('has package-content verification wired into rc smoke', () => {
+  it('has package-content verification wired into beta smoke', () => {
     const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8')) as { scripts: Record<string, string> };
-    const smoke = fs.readFileSync('scripts/rc-smoke.mjs', 'utf-8');
+    const smoke = fs.readFileSync('scripts/beta-smoke.mjs', 'utf-8');
 
-    expect(pkg.scripts['release:rc-smoke']).toBe('node scripts/rc-smoke.mjs');
+    expect(pkg.scripts['release:beta-smoke']).toBe('node scripts/beta-smoke.mjs');
     expect(smoke).toContain('scripts/verify-package-contents.mjs');
   });
 


### PR DESCRIPTION
## Summary
- Replaces the active release smoke path with `release:beta-smoke` and updates the tag release workflow to run it before publish-capable steps.
- Renames the P4-P6 readiness summary to beta terminology and updates checklist, roadmap, README, CLI, and benchmark docs to match.
- Adds beta prerelease labeling to the postinstall banner without changing publish/tag behavior.

## Verification
- Fast-forwarded local `main` to merge commit `15e7c8329dcdaa0b8050c9198c2d91650f38e5c8`.
- `pnpm typecheck`: passed
- `pnpm bench:ci`: passed
- `pnpm release:beta-smoke`: passed
- `pnpm test`: 205 files passed, 1 skipped; 3411 tests passed, 21 skipped
- `pnpm vitest run src/tests/package-contents.test.ts`: passed
- `node --check scripts/beta-smoke.mjs`: passed
- `node --check scripts/postinstall.cjs`: passed
- `rg` audit confirmed obsolete active RC smoke/readiness references were removed.

## Release Side Effects
None. This PR does not publish packages, create tags, create GitHub releases, promote dist-tags, or modify marketplace distribution.