### PR TITLE
Prepare 0.1.0-beta.0 release

### DIFF
--- a/.github/workflows/npm-dist-tags.yml
+++ b/.github/workflows/npm-dist-tags.yml
@@ -20,6 +20,7 @@ on:
         type: choice
         options:
           - alpha
+          - beta
           - legacy
           - latest
 
@@ -38,6 +39,16 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Guard dist-tag safety
+        run: |
+          if [ "$TAG" = "latest" ] && [[ "$VERSION" == *-* ]]; then
+            echo "::error::Prerelease versions must not be assigned the latest dist-tag"
+            exit 1
+          fi
+        env:
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ inputs.tag }}
 
       - name: Add npm dist-tag
         run: pnpm dist-tag add "${PACKAGE}@${VERSION}" "${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,22 @@ jobs:
       - name: Beta smoke
         run: pnpm release:beta-smoke
 
-      # Publish review package
+      # Publish review package. Prereleases must not become npm latest.
       - name: Publish @codeagora/review
         id: publish-core
         continue-on-error: true
-        run: npm publish --access public
+        run: |
+          PUBLISH_TAG=$(node -e "const { readFileSync } = require('node:fs'); const version = JSON.parse(readFileSync('package.json', 'utf8')).version; process.stdout.write(version.includes('-') ? 'beta' : 'latest');")
+          npm publish --access public --tag "$PUBLISH_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @codeagora/mcp
         id: publish-mcp
         continue-on-error: true
-        run: cd packages/mcp && npm publish --access public
+        run: |
+          PUBLISH_TAG=$(node -e "const { readFileSync } = require('node:fs'); const version = JSON.parse(readFileSync('packages/mcp/package.json', 'utf8')).version; process.stdout.write(version.includes('-') ? 'beta' : 'latest');")
+          cd packages/mcp && npm publish --access public --tag "$PUBLISH_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.1.0-beta.0 (planned)
+
+### Beta Release Readiness
+- Promote the supported release line from alpha readiness to `0.1.0-beta.0` across workspace package metadata.
+- Keep CLI, GitHub Action, and MCP as the supported beta surfaces for broader user feedback.
+
+### Release Safety
+- Publish prerelease packages with an explicit `beta` npm dist-tag in the tag-triggered release workflow.
+- Add manual npm dist-tag safeguards so prerelease versions cannot be promoted to `latest`.
+
+### Verification
+- Required gates: `pnpm typecheck`, `pnpm test --no-file-parallelism`, `pnpm bench:ci`, and `pnpm release:beta-smoke`.
+- Final `v0.1.0-beta.0` tag push and npm publication remain explicit release approval steps.
+
 ## 0.1.0-alpha.1 (2026-04-29)
 
 ### Product Surface Reset

--- a/docs/BETA_READINESS_P4_P6.md
+++ b/docs/BETA_READINESS_P4_P6.md
@@ -2,7 +2,7 @@
 
 Updated: 2026-05-02
 
-This document summarizes the beta-readiness gates added for the production-readiness P4-P6 track. The scope is intentionally limited to deterministic validation, security hardening, documentation, and non-publishing beta smoke checks. It does not perform npm publishing, GitHub release creation, tagging, dist-tag updates, or marketplace distribution.
+This document summarizes the beta-readiness gates added for the production-readiness P4-P6 track. The current target is `0.1.0-beta.0`. Readiness validation is intentionally separated from irreversible release operations: final tag creation, GitHub Release creation, npm publishing, npm dist-tag promotion, and marketplace distribution remain explicit approval stops.
 
 ## P4: Benchmark Gate
 
@@ -59,13 +59,13 @@ It verifies:
 - CLI `--help` smoke
 - MCP initialize plus `tools/list` smoke
 
-The release workflow runs the deterministic benchmark gate and beta smoke before publish-capable steps. The checklist in `docs/RELEASE_CHECKLIST.md` documents manual guardrails for actual release operations.
+The release workflow runs the deterministic benchmark gate and beta smoke before publish-capable steps. It also computes npm publish tags from package versions so prereleases publish under `beta` rather than `latest`. The checklist in `docs/RELEASE_CHECKLIST.md` documents manual guardrails for actual release operations.
 
 MCP onboarding is now package-local in `packages/mcp/README.md`, and the MCP server version is sourced from `packages/mcp/package.json` rather than a hard-coded string.
 
 ## Beta Positioning
 
-Beta means the CLI, GitHub Action, and MCP package are ready for broader user feedback on the supported surfaces, while APIs, release automation, benchmark thresholds, and provider behavior may still change before a stable release. Actual npm publishing, GitHub release creation, tag creation, and dist-tag promotion remain separate approval steps.
+Beta means the CLI, GitHub Action, and MCP package are ready for broader user feedback on the supported surfaces, while APIs, benchmark thresholds, and provider behavior may still change before a stable release. Actual npm publishing, GitHub release creation, tag creation, and dist-tag promotion remain separate approval steps, and prerelease npm publishes must use the `beta` dist-tag.
 
 ## Verification Evidence
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,10 +1,12 @@
 # Beta Release Checklist
 
-This checklist verifies P4-P6 beta readiness without publishing anything.
+This checklist verifies `0.1.0-beta.0` release readiness and keeps publish operations behind an explicit final approval stop.
 
 ## Scope Guardrails
 
-The beta gate does not perform npm publish, npm dist-tag promotion, GitHub tag creation, GitHub Release creation, marketplace publication, or Action release promotion. Those operations remain out of scope until a separate release approval.
+The beta readiness gate itself does not create GitHub tags, create GitHub Releases, publish npm packages, promote npm dist-tags, publish to marketplaces, or promote the GitHub Action release ref. Those operations are intentionally separate from readiness verification.
+
+Before the final `v0.1.0-beta.0` tag is pushed, confirm the intended package versions, dist-tags, package contents, and npm token availability. Prerelease packages must publish under the `beta` npm dist-tag, never `latest`.
 
 ## Release Surfaces
 
@@ -14,19 +16,21 @@ The beta gate does not perform npm publish, npm dist-tag promotion, GitHub tag c
 
 ## Beta Gates
 
-1. Confirm package version consistency between release notes, root `package.json`, and `packages/mcp/package.json`.
+1. Confirm package version consistency between release notes, root `package.json`, workspace package manifests, desktop metadata, and `packages/mcp/package.json`.
 2. Run `pnpm typecheck`.
-3. Run `pnpm test`.
+3. Run `pnpm test --no-file-parallelism`.
 4. Run `pnpm build`.
 5. Run `pnpm bench:ci` to validate deterministic benchmark schema/reference gates without live providers.
 6. Run `pnpm release:beta-smoke` to validate local package and Action smoke behavior without publishing.
 7. Run root package pack dry-run and confirm runtime files for `codeagora`/`agora` are included while tests, `.env`, `bench-out*`, and `.sisyphus/evidence` are excluded.
 8. Run `pnpm --filter @codeagora/mcp pack --dry-run` and confirm `dist/index.js`, `package.json`, and `README.md` are included while tests and secrets are excluded.
 9. Run the GitHub Action smoke path through `pnpm build:action` and the release smoke script.
-10. Review README, CLI docs, MCP onboarding, `.env.example`, and Action docs for current install and secret requirements.
-11. Open the PR and verify remote checks: CI Node 20/22, CodeAgora review, and PR size label.
-12. Confirm P6 beta readiness only after P4 deterministic benchmark gates and P5 security abuse gates pass.
+10. Confirm `.github/workflows/release.yml` computes a prerelease publish tag and runs npm publish with `--tag beta` for beta versions.
+11. Confirm `.github/workflows/npm-dist-tags.yml` offers `beta` and blocks assigning prerelease versions to `latest`.
+12. Review README, CLI docs, MCP onboarding, `.env.example`, and Action docs for current install and secret requirements.
+13. Open the PR and verify remote checks: CI Node 20/22, CodeAgora review or documented provider-only skip, and PR size label.
+14. Confirm P6 beta readiness only after P4 deterministic benchmark gates and P5 security abuse gates pass.
 
 ## Evidence
 
-Capture command output under `.sisyphus/evidence/` for typecheck, test, build, `bench:ci`, `release:beta-smoke`, root package dry-run, MCP package dry-run, and security regression tests.
+Capture command output under `.sisyphus/evidence/` for typecheck, test, build, `bench:ci`, `release:beta-smoke`, root package dry-run, MCP package dry-run, release-safety tests, and security regression tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/review",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "type": "module",
   "description": "Multi-LLM code review pipeline — parallel reviewers, structured debate, consensus verdict",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/cli",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/core",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/desktop",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "private": true,
   "type": "module",
   "description": "CodeAgora desktop app scaffold — human-facing local UI for sessions, config, and review runs",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "codeagora-desktop"
-version = "0.1.0-alpha.1"
+version = "0.1.0-beta.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codeagora-desktop"
-version = "0.1.0-alpha.1"
+version = "0.1.0-beta.0"
 edition = "2021"
 
 [build-dependencies]

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodeAgora",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "identifier": "dev.codeagora.desktop",
   "build": {
     "beforeBuildCommand": "pnpm --filter @codeagora/desktop build",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/github",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ CodeAgora MCP server for Claude Code, Cursor, and other MCP-compatible clients.
 
 ## Install
 
-Release-candidate local smoke uses a packed tarball instead of publishing:
+Beta local smoke uses a packed tarball instead of publishing:
 
 ```bash
 pnpm --filter @codeagora/mcp build
@@ -30,7 +30,7 @@ npx -y @codeagora/mcp
 }
 ```
 
-For local RC validation, point your client at the built workspace binary instead:
+For local beta validation, point your client at the built workspace binary instead:
 
 ```json
 {
@@ -73,4 +73,4 @@ Deterministic benchmark CI gates such as `pnpm bench:ci` do not require live pro
 - If the server exits immediately, run `pnpm --filter @codeagora/mcp build` and confirm `packages/mcp/dist/index.js` exists.
 - If review tools return missing-provider errors, set the provider key for the configured reviewer backend.
 - If `repo_path` is rejected, pass a real directory inside the current repository boundary. Symlinks and paths outside the repo are intentionally rejected.
-- If a client cannot find the command, use an absolute `node` path and an absolute `dist/index.js` path for local RC smoke.
+- If a client cannot find the command, use an absolute `node` path and an absolute `dist/index.js` path for local beta smoke.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/mcp",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "description": "CodeAgora MCP server — Claude Code integration for AI-powered code review",
   "type": "module",
   "license": "MIT",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/shared",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/tests/release-beta-safety.test.ts
+++ b/src/tests/release-beta-safety.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import { describe, expect, it } from 'vitest';
+
+function readText(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function readPackageVersion(filePath: string): string {
+  const manifest = JSON.parse(readText(filePath)) as { version: string };
+  return manifest.version;
+}
+
+describe('beta release safety', () => {
+  it('publishes prerelease packages with an explicit beta dist-tag', () => {
+    const workflow = readText('.github/workflows/release.yml');
+
+    expect(workflow).toContain('PUBLISH_TAG=$(node -e');
+    expect(workflow).toContain("version.includes('-') ? 'beta' : 'latest'");
+    expect(workflow).toContain('npm publish --access public --tag "$PUBLISH_TAG"');
+    expect(workflow).toContain('cd packages/mcp && npm publish --access public --tag "$PUBLISH_TAG"');
+  });
+
+  it('allows manual beta dist-tagging but blocks prereleases from latest', () => {
+    const workflow = readText('.github/workflows/npm-dist-tags.yml');
+
+    expect(workflow).toContain('          - beta');
+    expect(workflow).toContain('Prerelease versions must not be assigned the latest dist-tag');
+    expect(workflow).toContain('if [ "$TAG" = "latest" ] && [[ "$VERSION" == *-* ]]; then');
+  });
+
+  it('keeps public package versions aligned for beta', () => {
+    const rootVersion = readPackageVersion('package.json');
+    const mcpVersion = readPackageVersion('packages/mcp/package.json');
+
+    expect(rootVersion).toBe('0.1.0-beta.0');
+    expect(mcpVersion).toBe(rootVersion);
+  });
+});


### PR DESCRIPTION
## Summary
- Bump CodeAgora workspace metadata from `0.1.0-alpha.1` to `0.1.0-beta.0` for the beta release line.
- Harden release automation so prerelease npm publishes use the `beta` dist-tag instead of `latest`.
- Add regression coverage and release checklist docs for beta publish/tag guardrails.

## Verification
- `pnpm typecheck`
- `pnpm vitest run src/tests/release-beta-safety.test.ts src/tests/package-contents.test.ts src/tests/mcp-version.test.ts`
- `pnpm test --no-file-parallelism`
- `pnpm bench:ci`
- `pnpm release:beta-smoke`
- `yq '.' .github/workflows/release.yml >/dev/null && yq '.' .github/workflows/npm-dist-tags.yml >/dev/null`
- root/MCP publish-tag computation both returned `beta`
- `GIT_MASTER=1 git diff --check`

## Release Safety
- No Git tag was created.
- No npm package was published.
- Final `v0.1.0-beta.0` tag push and publish remain explicit approval steps after this PR is green.