### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/bench-fn.yml
+++ b/.github/workflows/bench-fn.yml
@@ -32,11 +32,11 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bench-out
           path: bench-out/

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -16,13 +16,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/npm-dist-tags.yml
+++ b/.github/workflows/npm-dist-tags.yml
@@ -31,11 +31,11 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.30.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR by size
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/provider-health.yml
+++ b/.github/workflows/provider-health.yml
@@ -12,11 +12,11 @@ jobs:
   health-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -102,7 +102,7 @@ jobs:
 
       - name: Create issue on failure
         if: steps.health.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const date = new Date().toISOString().slice(0, 10);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -68,6 +68,6 @@ jobs:
           echo "All packages published successfully"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -35,7 +35,7 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.fork-check.outputs.skip != 'true' && steps.key-check.outputs.skip != 'true'
         with:
           fetch-depth: 0

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 

--- a/docs/5_GITHUB_INTEGRATION.md
+++ b/docs/5_GITHUB_INTEGRATION.md
@@ -190,12 +190,12 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10
 
@@ -460,7 +460,7 @@ upload is enabled:
 
 ```yaml
 - name: Upload SARIF artifact
-  uses: actions/upload-artifact@v4
+  uses: actions/upload-artifact@v7
   with:
     name: codeagora-sarif
     path: /tmp/codeagora-results.sarif

--- a/packages/shared/src/data/github-actions-template.yml
+++ b/packages/shared/src/data/github-actions-template.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Pin to SHA for production use. Major tags used here for readability.
-      - uses: actions/checkout@v4  # Consider SHA pinning for production
+      - uses: actions/checkout@v6  # Consider SHA pinning for production
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4  # Consider SHA pinning for production
+      - uses: actions/setup-node@v6  # Consider SHA pinning for production
         with:
           node-version: '20'
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Post review comment
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/src/tests/cli-init-ci.test.ts
+++ b/src/tests/cli-init-ci.test.ts
@@ -73,8 +73,8 @@ describe('writeGitHubWorkflow()', () => {
 
     const filePath = path.join(tmpDir, '.github', 'workflows', 'codeagora-review.yml');
     const content = await fs.readFile(filePath, 'utf-8');
-    expect(content).toContain('actions/checkout@v4');
-    expect(content).toContain('actions/setup-node@v4');
+    expect(content).toContain('actions/checkout@v6');
+    expect(content).toContain('actions/setup-node@v6');
   });
 
   it('does not overwrite existing workflow when force is false', async () => {

--- a/src/tests/github-actions-runtime.test.ts
+++ b/src/tests/github-actions-runtime.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+
+const checkedFiles = [
+  'action.yml',
+  'packages/shared/src/data/github-actions-template.yml',
+  ...fs
+    .readdirSync(path.join(repoRoot, '.github', 'workflows'))
+    .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+    .map((file) => path.join('.github', 'workflows', file)),
+];
+
+const deprecatedNode20ActionPins = [
+  'actions/checkout@v4',
+  'actions/setup-node@v4',
+  'pnpm/action-setup@v4',
+  'actions/github-script@v7',
+  'actions/upload-artifact@v4',
+  'softprops/action-gh-release@v2',
+];
+
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf-8');
+}
+
+describe('GitHub Actions runtime readiness', () => {
+  it('does not pin workflows or generated templates to Node 20 JavaScript action majors', () => {
+    for (const file of checkedFiles) {
+      const content = readText(file);
+      for (const pin of deprecatedNode20ActionPins) {
+        expect(content, `${file} should not contain deprecated action pin ${pin}`).not.toContain(pin);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Update repository workflows, generated templates, and the composite action to Node 24-ready action majors.
- Add a regression test that blocks known Node 20 JavaScript action pins from returning.
- Keep the package runtime and CI matrix on Node 20/22; this only updates the JavaScript action runtimes.

## Updated Actions
- `actions/checkout@v6`
- `actions/setup-node@v6`
- `pnpm/action-setup@v6`
- `actions/github-script@v9`
- `actions/upload-artifact@v7`
- `softprops/action-gh-release@v3`

## Verification
- `pnpm vitest run src/tests/github-actions-runtime.test.ts src/tests/cli-init-ci.test.ts`
- `yq '.' action.yml >/dev/null && yq '.' packages/shared/src/data/github-actions-template.yml >/dev/null && yq '.' .github/workflows/*.yml >/dev/null`
- `pnpm typecheck`
- `pnpm test --no-file-parallelism`
- `pnpm bench:ci`
- `pnpm build:action`
- `pnpm release:beta-smoke`
- `GIT_MASTER=1 git diff --check`

## Safety
- No release tag or npm publish was performed.
- Node install versions remain unchanged so Node >=20 support is preserved.