### PR TITLE
chore(release): bump beta to 0.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 0.1.0-beta.0 (planned)
+## 0.1.0-beta.1 (planned)
 
 ### Beta Release Readiness
-- Promote the supported release line from alpha readiness to `0.1.0-beta.0` across workspace package metadata.
+- Promote the supported release line from alpha readiness to `0.1.0-beta.1` across workspace package metadata.
 - Keep CLI, GitHub Action, and MCP as the supported beta surfaces for broader user feedback; desktop remains a private preview outside the beta support claim.
 
 ### Release Safety
@@ -12,7 +12,7 @@
 
 ### Verification
 - Required gates: `pnpm typecheck`, `pnpm test --no-file-parallelism`, `pnpm bench:ci`, and `pnpm release:beta-smoke`.
-- Final `v0.1.0-beta.0` tag push and npm publication remain explicit release approval steps.
+- Final `v0.1.0-beta.1` tag push and npm publication remain explicit release approval steps.
 
 ## 0.1.0-alpha.1 (2026-04-29)
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bssm-oss/CodeAgora@v0.1.0-beta.0
+      - uses: bssm-oss/CodeAgora@v0.1.0-beta.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
@@ -163,7 +163,7 @@ jobs:
 
 Every PR gets inline review comments, a summary verdict, and a commit status check. Add `review:skip` label to any PR to bypass.
 
-Note: Use the `v0.1.0-beta.0` Action tag for the scoped beta package line; `v2` belongs to the legacy `codeagora@2.x` line. The Action defaults to `.ca/config.json` in the repo root. You can override this via the `config-path` input (CLI flag wins, then the `CONFIG_PATH` env). `fail-on-reject` defaults to `true` (Action exits with code 1 on REJECT). The `review:skip` label is caller-owned and will not be modified by the Action. Any degraded/skipped run surfaces `degraded` and `degraded-reason` outputs.
+Note: Use the `v0.1.0-beta.1` Action tag for the scoped beta package line; `v2` belongs to the legacy `codeagora@2.x` line. The Action defaults to `.ca/config.json` in the repo root. You can override this via the `config-path` input (CLI flag wins, then the `CONFIG_PATH` env). `fail-on-reject` defaults to `true` (Action exits with code 1 on REJECT). The `review:skip` label is caller-owned and will not be modified by the Action. Any degraded/skipped run surfaces `degraded` and `degraded-reason` outputs.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -368,7 +368,7 @@ closed.
 
 ### Align README and Action versioning
 
-**Finding:** README examples still show `uses: bssm-oss/CodeAgora@v2` while the current package line is `@codeagora/review@0.1.0-beta.0` and docs position `codeagora@2.x` as legacy.
+**Finding:** README examples still show `uses: bssm-oss/CodeAgora@v2` while the current package line is `@codeagora/review@0.1.0-beta.1` and docs position `codeagora@2.x` as legacy.
 
 **Surface:** README, Action onboarding, release notes.
 

--- a/docs/BETA_READINESS_P4_P6.md
+++ b/docs/BETA_READINESS_P4_P6.md
@@ -2,7 +2,7 @@
 
 Updated: 2026-05-04
 
-This document summarizes the beta-readiness gates added for the production-readiness P4-P6 track. The current target is `0.1.0-beta.0`. Readiness validation is intentionally separated from irreversible release operations: final tag creation, GitHub Release creation, npm publishing, npm dist-tag promotion, and marketplace distribution remain explicit approval stops.
+This document summarizes the beta-readiness gates added for the production-readiness P4-P6 track. The current target is `0.1.0-beta.1`. Readiness validation is intentionally separated from irreversible release operations: final tag creation, GitHub Release creation, npm publishing, npm dist-tag promotion, and marketplace distribution remain explicit approval stops.
 
 ## P4: Benchmark Gate
 

--- a/docs/NPM_PACKAGE_RESTART.md
+++ b/docs/NPM_PACKAGE_RESTART.md
@@ -90,7 +90,7 @@ Recommended sequence:
 ```txt
 @codeagora/review@0.1.0-alpha.0  first package rename / surface cleanup prerelease
 @codeagora/review@0.1.0-alpha.1  desktop scaffold and docs
-@codeagora/review@0.1.0-beta.0   CLI/GitHub/MCP stabilization
+@codeagora/review@0.1.0-beta.1   CLI/GitHub/MCP stabilization
 @codeagora/review@0.1.0          first public review-focused release
 @codeagora/review@0.2.0          desktop MVP
 @codeagora/review@0.3.0          opencode / agent workflow expansion

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,12 +1,12 @@
 # Beta Release Checklist
 
-This checklist verifies `0.1.0-beta.0` release readiness and keeps publish operations behind an explicit final approval stop.
+This checklist verifies `0.1.0-beta.1` release readiness and keeps publish operations behind an explicit final approval stop.
 
 ## Scope Guardrails
 
 The beta readiness gate itself does not create GitHub tags, create GitHub Releases, publish npm packages, promote npm dist-tags, publish to marketplaces, or promote the GitHub Action release ref. Those operations are intentionally separate from readiness verification.
 
-Before the final `v0.1.0-beta.0` tag is pushed, confirm the intended package versions, dist-tags, package contents, and npm token availability. Prerelease packages must publish under the `beta` npm dist-tag, never `latest`.
+Before the final `v0.1.0-beta.1` tag is pushed, confirm the intended package versions, dist-tags, package contents, and npm token availability. Prerelease packages must publish under the `beta` npm dist-tag, never `latest`.
 
 ## Release Surfaces
 
@@ -27,7 +27,7 @@ Before the final `v0.1.0-beta.0` tag is pushed, confirm the intended package ver
 9. Run the GitHub Action smoke path through `pnpm build:action` and the release smoke script.
 10. Confirm `.github/workflows/release.yml` computes a prerelease publish tag and runs npm publish with `--tag beta` for beta versions.
 11. Confirm `.github/workflows/npm-dist-tags.yml` offers `beta` and blocks assigning prerelease versions to `latest`.
-12. Review README, CLI docs, MCP onboarding, `.env.example`, and Action docs for current install and secret requirements, including `bssm-oss/CodeAgora@v0.1.0-beta.0` for beta Action examples rather than legacy `@v2` or stable-looking refs.
+12. Review README, CLI docs, MCP onboarding, `.env.example`, and Action docs for current install and secret requirements, including `bssm-oss/CodeAgora@v0.1.0-beta.1` for beta Action examples rather than legacy `@v2` or stable-looking refs.
 13. Confirm release workflow publish jobs require the `npm-publish` environment, npm provenance, npm version preflight, and uploaded release evidence artifacts.
 14. Open the PR and verify remote checks: CI Node 20/22, CodeAgora review or documented provider-only skip, and PR size label.
 15. Confirm P6 beta readiness only after P4 deterministic benchmark gates and P5 security abuse gates pass.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/review",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "type": "module",
   "description": "Multi-LLM code review pipeline — parallel reviewers, structured debate, consensus verdict",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/cli",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -651,7 +651,7 @@ function isKorean(): boolean {
 // GitHub Actions workflow
 // ============================================================================
 
-const CODEAGORA_ACTION_REF = 'bssm-oss/CodeAgora@v0.1.0-beta.0';
+const CODEAGORA_ACTION_REF = 'bssm-oss/CodeAgora@v0.1.0-beta.1';
 
 /**
  * Write the GitHub Actions workflow template to {baseDir}/.github/workflows/codeagora-review.yml.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/core",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/desktop",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "private": true,
   "type": "module",
   "description": "CodeAgora desktop app scaffold — human-facing local UI for sessions, config, and review runs",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "codeagora-desktop"
-version = "0.1.0-beta.0"
+version = "0.1.0-beta.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codeagora-desktop"
-version = "0.1.0-beta.0"
+version = "0.1.0-beta.1"
 edition = "2021"
 
 [build-dependencies]

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodeAgora",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "identifier": "dev.codeagora.desktop",
   "build": {
     "beforeBuildCommand": "pnpm --filter @codeagora/desktop build",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/github",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/mcp",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "CodeAgora MCP server — Claude Code integration for AI-powered code review",
   "type": "module",
   "license": "MIT",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeagora/shared",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/shared/src/data/github-actions-template.yml
+++ b/packages/shared/src/data/github-actions-template.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6  # Consider SHA pinning for production
 
       - name: Run CodeAgora review
-        uses: bssm-oss/CodeAgora@v0.1.0-beta.0
+        uses: bssm-oss/CodeAgora@v0.1.0-beta.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-reject: 'true'

--- a/src/tests/cli-init-ci.test.ts
+++ b/src/tests/cli-init-ci.test.ts
@@ -59,7 +59,7 @@ describe('writeGitHubWorkflow()', () => {
 
     const filePath = path.join(tmpDir, '.github', 'workflows', 'codeagora-review.yml');
     const content = await fs.readFile(filePath, 'utf-8');
-    expect(content).toContain('uses: bssm-oss/CodeAgora@v0.1.0-beta.0');
+    expect(content).toContain('uses: bssm-oss/CodeAgora@v0.1.0-beta.1');
     expect(content).not.toContain('bssm-oss/CodeAgora@v2');
     expect(content).not.toContain('npx codeagora');
   });
@@ -103,7 +103,7 @@ describe('writeGitHubWorkflow()', () => {
 
     const content = await fs.readFile(workflowPath, 'utf-8');
     expect(content).not.toBe('existing content');
-    expect(content).toContain('uses: bssm-oss/CodeAgora@v0.1.0-beta.0');
+    expect(content).toContain('uses: bssm-oss/CodeAgora@v0.1.0-beta.1');
   });
 });
 
@@ -248,6 +248,6 @@ describe('runInit() with ci: true', () => {
 
     expect(result.created).toContain(workflowPath);
     const content = await fs.readFile(workflowPath, 'utf-8');
-    expect(content).toContain('uses: bssm-oss/CodeAgora@v0.1.0-beta.0');
+    expect(content).toContain('uses: bssm-oss/CodeAgora@v0.1.0-beta.1');
   });
 });

--- a/src/tests/release-beta-safety.test.ts
+++ b/src/tests/release-beta-safety.test.ts
@@ -32,7 +32,7 @@ describe('beta release safety', () => {
     const rootVersion = readPackageVersion('package.json');
     const mcpVersion = readPackageVersion('packages/mcp/package.json');
 
-    expect(rootVersion).toBe('0.1.0-beta.0');
+    expect(rootVersion).toBe('0.1.0-beta.1');
     expect(mcpVersion).toBe(rootVersion);
   });
 


### PR DESCRIPTION
## Summary
- bump workspace, MCP, desktop, Action examples, and release docs to 0.1.0-beta.1
- update release/version safety tests for the beta.1 line

## Verification
- npm view @codeagora/review@0.1.0-beta.1 version -> not published (404)
- npm view @codeagora/mcp@0.1.0-beta.1 version -> not published (404)
- pnpm build
- pnpm vitest run src/tests/release-beta-safety.test.ts src/tests/cli-init-ci.test.ts src/tests/github-actions-runtime.test.ts
- pnpm typecheck
- pnpm lint
- pnpm bench:ci
- pnpm test --no-file-parallelism
- pnpm build:action && node --check dist/action.js
- pnpm exec node scripts/verify-package-contents.mjs
- pnpm release:beta-smoke