### PR TITLE
[codex] tighten core review correctness

### DIFF
--- a/packages/core/src/l0/index.ts
+++ b/packages/core/src/l0/index.ts
@@ -81,6 +81,11 @@ export interface ResolveResult {
   autoCount: number;
 }
 
+function reviewerGroupPairCount(reviewerCount: number, groupCount: number): number {
+  if (reviewerCount === 0 || groupCount === 0) return 0;
+  return Math.max(reviewerCount, groupCount);
+}
+
 /**
  * Resolve reviewer entries into concrete ReviewerInputs.
  * Static reviewers pass through unchanged.
@@ -177,8 +182,9 @@ export async function resolveReviewers(
 
   // Build ReviewerInputs with selectionMeta for auto reviewers
   const inputs: ReviewerInput[] = [];
-  for (let i = 0; i < allConfigs.length; i++) {
-    const config = allConfigs[i];
+  const inputCount = reviewerGroupPairCount(allConfigs.length, fileGroups.length);
+  for (let i = 0; i < inputCount; i++) {
+    const config = allConfigs[i % allConfigs.length];
     const group = fileGroups[i % fileGroups.length];
 
     const selectionEntry = selection.selections.find(
@@ -211,8 +217,10 @@ function buildInputs(
   configs: AgentConfig[],
   fileGroups: Array<{ name: string; diffContent: string; prSummary: string }>
 ): ReviewerInput[] {
-  return configs.map((config, i) => {
+  const inputCount = reviewerGroupPairCount(configs.length, fileGroups.length);
+  return Array.from({ length: inputCount }, (_, i) => {
     const group = fileGroups[i % fileGroups.length];
+    const config = configs[i % configs.length];
     return {
       config,
       groupName: group.name,

--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -281,6 +281,7 @@ async function executeReviewerWithGuards(
 
       if (useGuards) cb.recordSuccess(provider!, config.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+      for (const doc of evidenceDocs) doc.reviewerId = config.id;
       // #467: apply model-specific calibration multiplier to each doc's
       // confidence before it enters hallucination filter / corroboration.
       const reviewContext = { calibrateReviewerConfidence: input.calibrateReviewerConfidence };
@@ -381,6 +382,7 @@ async function executeReviewerWithGuards(
 
       if (useFallbackGuards) cb.recordSuccess(fallbackProvider!, fb.model);
       const evidenceDocs = parseEvidenceResponse(response, diffFilePaths);
+      for (const doc of evidenceDocs) doc.reviewerId = config.id;
       // #467: calibrate using the FALLBACK model's tier, not the primary's,
       // since the output came from the fallback.
       const fbConfig = { ...config, model: fb.model, provider: fb.provider } as ReviewerConfig;

--- a/packages/core/src/l2/threshold.ts
+++ b/packages/core/src/l2/threshold.ts
@@ -133,18 +133,23 @@ function groupByLocation(docs: EvidenceDocument[]): LocationGroup[] {
 }
 
 function countBySeverity(docs: EvidenceDocument[]): Record<Severity, number> {
-  const counts: Record<Severity, number> = {
-    HARSHLY_CRITICAL: 0,
-    CRITICAL: 0,
-    WARNING: 0,
-    SUGGESTION: 0,
+  const reviewersBySeverity: Record<Severity, Set<string>> = {
+    HARSHLY_CRITICAL: new Set(),
+    CRITICAL: new Set(),
+    WARNING: new Set(),
+    SUGGESTION: new Set(),
   };
 
-  for (const doc of docs) {
-    counts[doc.severity]++;
-  }
+  docs.forEach((doc, index) => {
+    reviewersBySeverity[doc.severity].add(doc.reviewerId ?? `finding:${index}`);
+  });
 
-  return counts;
+  return {
+    HARSHLY_CRITICAL: reviewersBySeverity.HARSHLY_CRITICAL.size,
+    CRITICAL: reviewersBySeverity.CRITICAL.size,
+    WARNING: reviewersBySeverity.WARNING.size,
+    SUGGESTION: reviewersBySeverity.SUGGESTION.size,
+  };
 }
 
 function severityRank(severity: Severity): number {

--- a/packages/core/src/pipeline/confidence.ts
+++ b/packages/core/src/pipeline/confidence.ts
@@ -66,7 +66,8 @@ export function computeL1Confidence(
     d.filePath === doc.filePath &&
     Math.abs(d.lineRange[0] - doc.lineRange[0]) <= 5
   );
-  const agreeing = coLocated.length;
+  const reviewerIds = coLocated.map((d) => d.reviewerId).filter((id): id is string => Boolean(id));
+  const agreeing = reviewerIds.length > 0 ? new Set(reviewerIds).size : coLocated.length;
   const agreementRate = Math.min(100, Math.round((agreeing / activeReviewers) * 100));
 
   let base: number;

--- a/packages/core/src/pipeline/stage-executors.ts
+++ b/packages/core/src/pipeline/stage-executors.ts
@@ -277,6 +277,7 @@ export async function executeL3Verdict(
         reasoning: `Promoted from unconfirmed queue: ${doc.issueTitle}`,
         consensusReached: false,
         rounds: 0,
+        ...(doc.confidence != null && { avgConfidence: doc.confidence }),
       });
     }
     moderatorReport.summary.escalated += promoted.length;

--- a/packages/core/src/tests/l0-reviewer-resolution.test.ts
+++ b/packages/core/src/tests/l0-reviewer-resolution.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { resolveReviewers } from '../l0/index.js';
+import type { ReviewerEntry } from '../types/config.js';
+
+const reviewers: ReviewerEntry[] = [
+  { id: 'r1', backend: 'codex', model: 'test', enabled: true, timeout: 120 },
+  { id: 'r2', backend: 'codex', model: 'test', enabled: true, timeout: 120 },
+];
+
+const fileGroups = [
+  { name: 'group-a', diffContent: 'diff-a', prSummary: 'A' },
+  { name: 'group-b', diffContent: 'diff-b', prSummary: 'B' },
+  { name: 'group-c', diffContent: 'diff-c', prSummary: 'C' },
+];
+
+describe('resolveReviewers', () => {
+  it('covers every file group when there are more groups than reviewers', async () => {
+    const result = await resolveReviewers(reviewers, fileGroups);
+
+    expect(result.reviewerInputs).toHaveLength(3);
+    expect(result.reviewerInputs.map((input) => input.groupName)).toEqual([
+      'group-a',
+      'group-b',
+      'group-c',
+    ]);
+    expect(result.reviewerInputs.map((input) => input.config.id)).toEqual(['r1', 'r2', 'r1']);
+  });
+});

--- a/packages/core/src/tests/l2-threshold.test.ts
+++ b/packages/core/src/tests/l2-threshold.test.ts
@@ -123,11 +123,19 @@ describe('applyThreshold — WARNING severity', () => {
   });
 
   it('registers WARNING with two reviewers on the same location', () => {
-    const doc1 = makeDoc({ severity: 'WARNING', filePath: 'src/a.ts', lineRange: [1, 5] });
-    const doc2 = makeDoc({ severity: 'WARNING', filePath: 'src/a.ts', lineRange: [1, 5] });
+    const doc1 = makeDoc({ severity: 'WARNING', filePath: 'src/a.ts', lineRange: [1, 5], reviewerId: 'r1' });
+    const doc2 = makeDoc({ severity: 'WARNING', filePath: 'src/a.ts', lineRange: [1, 5], reviewerId: 'r2' });
     const { discussions } = applyThreshold([doc1, doc2], defaultSettings);
     expect(discussions).toHaveLength(1);
     expect(discussions[0].severity).toBe('WARNING');
+  });
+
+  it('does not register WARNING when duplicate findings come from the same reviewer', () => {
+    const doc1 = makeDoc({ severity: 'WARNING', filePath: 'src/a.ts', lineRange: [1, 5], reviewerId: 'r1' });
+    const doc2 = makeDoc({ severity: 'WARNING', filePath: 'src/a.ts', lineRange: [2, 6], reviewerId: 'r1' });
+    const { discussions, unconfirmed } = applyThreshold([doc1, doc2], defaultSettings);
+    expect(discussions).toHaveLength(0);
+    expect(unconfirmed).toHaveLength(2);
   });
 
   it('assigns sequential Discussion IDs starting from d001', () => {

--- a/packages/core/src/tests/parser-bilingual.test.ts
+++ b/packages/core/src/tests/parser-bilingual.test.ts
@@ -487,6 +487,18 @@ describe('computeL1Confidence — corroboration scoring (#432)', () => {
     expect(result).toBeLessThanOrEqual(100); // invariant
   });
 
+  it('counts duplicate co-located findings from one reviewer as one agreeing reviewer', () => {
+    const doc = makeDoc('src/foo.ts', 10, 80);
+    doc.reviewerId = 'r1';
+    const allDocs = [
+      { ...makeDoc('src/foo.ts', 10), reviewerId: 'r1' },
+      { ...makeDoc('src/foo.ts', 11), reviewerId: 'r1' },
+      { ...makeDoc('src/foo.ts', 12), reviewerId: 'r1' },
+    ];
+    const result = computeL1Confidence(doc, allDocs, 1, 100);
+    expect(result).toBe(70);
+  });
+
   it('excludes rule-source docs from agreeing count', () => {
     const doc: EvidenceDocument = {
       issueTitle: 'Test', problem: 'p', evidence: [], severity: 'WARNING',

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -50,6 +50,8 @@ export const EvidenceDocumentSchema = z.object({
   suggestion: z.string(),
   filePath: z.string(),
   lineRange: z.tuple([z.number(), z.number()]),
+  /** L1 reviewer that produced this finding. Used for independent-agreement counts. */
+  reviewerId: z.string().optional(),
   source: z.enum(['llm', 'rule']).optional(),
   /**
    * @deprecated Use `confidenceTrace.final` for all downstream reads. The

--- a/packages/shared/src/utils/diff.ts
+++ b/packages/shared/src/utils/diff.ts
@@ -179,8 +179,8 @@ export function extractFileListFromDiff(diffContent: string): string[] {
   const sections = diffContent.split(/(?=^diff --git )/m);
 
   for (const section of sections) {
-    // Match: diff --git a/path/to/file.ts b/path/to/file.ts
-    const match = section.match(/^diff --git a\/(.+?) b\//m);
+    // Match the new-file side. For renames, findings should point at b/new.
+    const match = section.match(/^diff --git a\/.+? b\/(.+)$/m);
     if (match) {
       files.push(match[1]);
     }

--- a/src/tests/l3-verdict.test.ts
+++ b/src/tests/l3-verdict.test.ts
@@ -215,6 +215,24 @@ describe('makeHeadVerdict()', () => {
 
       expect(verdict.reasoning.toLowerCase()).toContain('consensus');
     });
+
+    it('routes very low-confidence critical discussions to human review instead of reject', async () => {
+      const report = makeReport({
+        discussions: [
+          makeVerdict({
+            discussionId: 'd-low-confidence',
+            finalSeverity: 'CRITICAL',
+            consensusReached: false,
+            avgConfidence: 10,
+          }),
+        ],
+      });
+
+      const verdict = await makeHeadVerdict(report);
+
+      expect(verdict.decision).toBe('NEEDS_HUMAN');
+      expect(verdict.questionsForHuman?.[0]).toContain('d-low-confidence');
+    });
   });
 });
 

--- a/src/tests/orchestrator-branches.test.ts
+++ b/src/tests/orchestrator-branches.test.ts
@@ -288,6 +288,7 @@ describe('Orchestrator Branches', () => {
       suggestion: 'Use parameterized queries',
       filePath: 'auth.ts',
       lineRange: [10, 10] as [number, number],
+      confidence: 10,
     };
 
     (scanUnconfirmedQueue as Mock).mockReturnValue({
@@ -321,6 +322,7 @@ describe('Orchestrator Branches', () => {
     expect(promotedDiscussion.discussionId).toBe('promoted-auth.ts:10');
     expect(promotedDiscussion.finalSeverity).toBe('CRITICAL');
     expect(promotedDiscussion.consensusReached).toBe(false);
+    expect(promotedDiscussion.avgConfidence).toBe(10);
 
     // Summary should be updated
     expect(reportArg.summary.escalated).toBe(1);

--- a/src/tests/utils-diff.test.ts
+++ b/src/tests/utils-diff.test.ts
@@ -112,10 +112,9 @@ describe('extractFileListFromDiff', () => {
     expect(result).toEqual(['benchmarks/golden-bugs/example/diff.patch']);
   });
 
-  it('extracts the "a/" path from a renamed-file diff header', () => {
-    // The regex captures the a/ side: a/src/old-name.ts
+  it('extracts the "b/" path from a renamed-file diff header', () => {
     const result = extractFileListFromDiff(RENAMED_FILE_DIFF);
-    expect(result).toEqual(['src/old-name.ts']);
+    expect(result).toEqual(['src/new-name.ts']);
   });
 });
 


### PR DESCRIPTION
## Summary

Fix the highest-risk core review correctness issues found during the multi-agent pass.

- ensure every file group receives L1 coverage even when there are more groups than enabled reviewers
- attach reviewer provenance to L1 evidence documents
- count independent reviewers, not duplicate findings, for confidence agreement and L2 registration thresholds
- preserve promoted unconfirmed finding confidence when routing to L3 so low-confidence CRITICAL findings go to human review instead of hard reject
- extract renamed diff file paths from the `b/` side so downstream parsing and hallucination filtering target the new path

## Validation

- pnpm typecheck
- pnpm lint
- pnpm vitest run packages/core/src/tests/l0-reviewer-resolution.test.ts packages/core/src/tests/l2-threshold.test.ts packages/core/src/tests/parser-bilingual.test.ts src/tests/utils-diff.test.ts src/tests/l3-verdict.test.ts src/tests/orchestrator-branches.test.ts
- pnpm vitest run src/tests/confidence.test.ts packages/core/src/tests/confidence-witness.test.ts src/tests/pipeline-chunk-parallel.test.ts src/tests/e2e-mock-scenarios.test.ts src/tests/critical-core-errors-orchestrator.test.ts packages/core/src/tests/hallucination-filter.test.ts
- pnpm test

## Notes

This PR is based directly on `origin/main`, independent of #534.