### PR TITLE
[codex] use full evidence in review outputs

### DIFF
--- a/packages/cli/src/formatters/annotated-output.ts
+++ b/packages/cli/src/formatters/annotated-output.ts
@@ -2,8 +2,7 @@
  * Annotated Output Formatter
  * Shows diff with inline issue annotations after relevant lines.
  *
- * Note: uses summary.topIssues (top 5 only) as the evidence source for v1.
- * Full EvidenceDocument list would require passing all docs from the pipeline.
+ * The dispatcher passes full pipeline evidence documents when available.
  */
 
 import pc from 'picocolors';

--- a/packages/cli/src/formatters/review-output.ts
+++ b/packages/cli/src/formatters/review-output.ts
@@ -605,8 +605,12 @@ function toEvidenceDoc(issue: {
 // Unified dispatcher
 // ============================================================================
 
+function fullEvidenceDocs(result: PipelineResult, override?: EvidenceDocument[]): EvidenceDocument[] {
+  return override ?? result.evidenceDocs ?? (result.summary?.topIssues.map(toEvidenceDoc) ?? []);
+}
+
 function formatSarif(result: PipelineResult): string {
-  const docs: EvidenceDocument[] = result.summary?.topIssues.map(toEvidenceDoc) ?? [];
+  const docs = fullEvidenceDocs(result);
   const report = buildSarifReport(docs, result.sessionId ?? 'unknown', result.date ?? 'unknown');
   return serializeSarif(report);
 }
@@ -614,9 +618,9 @@ function formatSarif(result: PipelineResult): string {
 /**
  * Format a PipelineResult using the requested output format.
  *
- * For the 'annotated' format, pass diffContent and evidenceDocs via options.
- * v1 limitation: if evidenceDocs is not provided, falls back to summary.topIssues
- * which only contains up to 5 issues.
+ * For the 'annotated' format, pass diffContent via options.
+ * The formatter uses the full pipeline evidenceDocs list when available and
+ * falls back to summary.topIssues only for legacy/minimal results.
  */
 export function formatOutput(
   result: PipelineResult,
@@ -634,9 +638,7 @@ export function formatOutput(
       return formatGithub(result);
     case 'annotated': {
       const diff = options?.diffContent ?? '';
-      // Use provided evidenceDocs; fall back to topIssues mapped explicitly to EvidenceDocument[]
-      const docs: EvidenceDocument[] = options?.evidenceDocs ??
-        (result.summary?.topIssues.map(toEvidenceDoc) ?? []);
+      const docs = fullEvidenceDocs(result, options?.evidenceDocs);
       return formatAnnotated(diff, docs);
     }
     case 'html':

--- a/packages/mcp/src/tests/format-parity.test.ts
+++ b/packages/mcp/src/tests/format-parity.test.ts
@@ -39,3 +39,44 @@ describe('CLI/MCP JSON formatting parity', () => {
     expect(mcpJson.schemaVersion).toBe('codeagora.review.v1');
   });
 });
+
+describe('CLI/MCP SARIF formatting parity', () => {
+  it('uses full evidenceDocs through both surfaces', async () => {
+    const result = {
+      ...makePipelineResult(),
+      summary: {
+        ...makePipelineResult().summary!,
+        topIssues: [
+          { severity: 'WARNING', filePath: 'src/top.ts', lineRange: [1, 1] as [number, number], title: 'Top issue only' },
+        ],
+      },
+      evidenceDocs: [
+        {
+          issueTitle: 'Full issue A',
+          problem: 'A',
+          evidence: ['A'],
+          severity: 'WARNING',
+          suggestion: 'Fix A',
+          filePath: 'src/a.ts',
+          lineRange: [1, 1] as [number, number],
+        },
+        {
+          issueTitle: 'Full issue B',
+          problem: 'B',
+          evidence: ['B'],
+          severity: 'CRITICAL',
+          suggestion: 'Fix B',
+          filePath: 'src/b.ts',
+          lineRange: [2, 2] as [number, number],
+        },
+      ],
+    } as PipelineResult;
+
+    const cliSarif = JSON.parse(formatOutput(result, 'sarif'));
+    const mcpSarif = JSON.parse(await formatReviewResult(result, 'sarif'));
+
+    expect(cliSarif.runs[0].results).toHaveLength(2);
+    expect(mcpSarif.runs[0].results).toEqual(cliSarif.runs[0].results);
+    expect(JSON.stringify(cliSarif)).not.toContain('Top issue only');
+  });
+});

--- a/src/tests/cli-output-formats.test.ts
+++ b/src/tests/cli-output-formats.test.ts
@@ -253,4 +253,63 @@ describe('formatOutput() dispatcher', () => {
     expect(output).toContain('<?xml');
     expect(output).toContain('<testsuites>');
   });
+
+  it('uses full evidenceDocs for SARIF instead of summary.topIssues', () => {
+    const result = makeSuccessResult({
+      summary: {
+        ...makeSuccessResult().summary!,
+        topIssues: [
+          { severity: 'CRITICAL', filePath: 'src/auth/login.ts', lineRange: [10, 12], title: 'SQL injection vulnerability' },
+        ],
+      },
+      evidenceDocs: [
+        makeEvidenceDoc({ issueTitle: 'First issue', filePath: 'src/one.ts', lineRange: [1, 1] }),
+        makeEvidenceDoc({ issueTitle: 'Second issue', filePath: 'src/two.ts', lineRange: [2, 2] }),
+        makeEvidenceDoc({ issueTitle: 'Third issue', filePath: 'src/three.ts', lineRange: [3, 3] }),
+      ],
+    });
+
+    const sarif = JSON.parse(formatOutput(result, 'sarif'));
+
+    expect(sarif.runs[0].results).toHaveLength(3);
+    expect(sarif.runs[0].results.map((r: { message: { text: string } }) => r.message.text)).toEqual([
+      'First issue',
+      'Second issue',
+      'Third issue',
+    ]);
+  });
+
+  it('uses full evidenceDocs for annotated output instead of summary.topIssues', () => {
+    const diff = `diff --git a/src/one.ts b/src/one.ts
+--- a/src/one.ts
++++ b/src/one.ts
+@@ -1,1 +1,2 @@
+ const one = 1;
++const two = 2;
+diff --git a/src/two.ts b/src/two.ts
+--- a/src/two.ts
++++ b/src/two.ts
+@@ -1,1 +1,2 @@
+ const a = 1;
++const b = 2;
+`;
+    const result = makeSuccessResult({
+      summary: {
+        ...makeSuccessResult().summary!,
+        topIssues: [
+          { severity: 'CRITICAL', filePath: 'src/one.ts', lineRange: [2, 2], title: 'Top issue only' },
+        ],
+      },
+      evidenceDocs: [
+        makeEvidenceDoc({ issueTitle: 'Full first issue', filePath: 'src/one.ts', lineRange: [2, 2] }),
+        makeEvidenceDoc({ issueTitle: 'Full second issue', filePath: 'src/two.ts', lineRange: [2, 2] }),
+      ],
+    });
+
+    const annotated = formatOutput(result, 'annotated', { diffContent: diff });
+
+    expect(annotated).toContain('Full first issue');
+    expect(annotated).toContain('Full second issue');
+    expect(annotated).not.toContain('Top issue only');
+  });
 });


### PR DESCRIPTION
## Summary

Make CLI and MCP review output formats use the full `evidenceDocs` list instead of truncating through `summary.topIssues`.

- use full pipeline evidence for CLI SARIF output
- use full pipeline evidence for annotated output, with topIssues retained only as a legacy fallback
- keep MCP SARIF behavior aligned because MCP delegates to the CLI formatter
- add regression coverage for full-evidence SARIF and annotated output

## Validation

- pnpm typecheck
- pnpm lint
- pnpm vitest run src/tests/cli-output-formats.test.ts packages/mcp/src/tests/format-parity.test.ts src/tests/annotated-output.test.ts src/tests/github-sarif.test.ts packages/github/src/tests/sarif.test.ts packages/mcp/src/tests/post-actions.test.ts
- pnpm test

## Notes

This PR is based directly on `origin/main`, independent of #534 and #535.