### PR TITLE
CodeAgora RC PR workflow smoke

### DIFF
--- a/docs/rc-pr-workflow-smoke-fixture.md
+++ b/docs/rc-pr-workflow-smoke-fixture.md
@@ -1,0 +1,5 @@
+# RC PR Workflow Smoke Fixture
+
+Temporary documentation-only change used to verify the CodeAgora PR workflow after the `0.1.0-rc.0` release.
+
+This branch is intended to be closed after checks complete and should not be merged.


### PR DESCRIPTION
Temporary PR to smoke the CodeAgora PR workflow after v0.1.0-rc.0. This is docs-only and will be closed after evidence capture.