### PR TITLE
fix(ci): avoid GitHub Models context limit

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -44,31 +44,50 @@ jobs:
         if: steps.fork-check.outputs.skip != 'true' && steps.key-check.outputs.skip != 'true'
         run: |
           mkdir -p .ca
-          cat > .ca/config.json << 'CONF'
+          if [ -n "${OPENROUTER_API_KEY:-}" ]; then
+            PROVIDER="openrouter"
+            REVIEWER_MODEL="qwen/qwen3-coder-30b-a3b-instruct"
+            SUPPORTER_MODEL="baidu/ernie-4.5-21b-a3b-thinking"
+            HEAD_MODEL="deepseek/deepseek-v3.2"
+          elif [ -n "${GROQ_API_KEY:-}" ]; then
+            PROVIDER="groq"
+            REVIEWER_MODEL="llama-3.3-70b-versatile"
+            SUPPORTER_MODEL="llama-3.3-70b-versatile"
+            HEAD_MODEL="llama-3.3-70b-versatile"
+          else
+            PROVIDER="github-models"
+            REVIEWER_MODEL="gpt-4o-mini"
+            SUPPORTER_MODEL="gpt-4o-mini"
+            HEAD_MODEL="gpt-4o-mini"
+          fi
+
+          cat > .ca/config.json << CONF
           {
             "mode": "pragmatic",
             "language": "en",
             "reviewers": [
-              { "id": "r1", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 },
-              { "id": "r2", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 },
-              { "id": "r3", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 }
+              { "id": "r1", "model": "$REVIEWER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 },
+              { "id": "r2", "model": "$REVIEWER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 }
             ],
             "supporters": {
               "pool": [
-                { "id": "s1", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 }
+                { "id": "s1", "model": "$SUPPORTER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 }
               ],
               "pickCount": 1,
               "pickStrategy": "random",
-              "devilsAdvocate": { "id": "da", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 },
+              "devilsAdvocate": { "id": "da", "model": "$SUPPORTER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 },
               "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
               "personaAssignment": "random"
             },
-            "moderator": { "model": "gpt-4o-mini", "backend": "api", "provider": "github-models" },
-            "discussion": { "maxRounds": 2, "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null }, "codeSnippetRange": 10 },
-            "head": { "backend": "api", "model": "gpt-4o-mini", "provider": "github-models", "enabled": true },
+            "moderator": { "model": "$HEAD_MODEL", "backend": "api", "provider": "$PROVIDER" },
+            "discussion": { "maxRounds": 1, "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null }, "codeSnippetRange": 5 },
+            "head": { "backend": "api", "model": "$HEAD_MODEL", "provider": "$PROVIDER", "enabled": true },
             "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
           }
           CONF
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
 
       - name: CodeAgora Review
         if: steps.fork-check.outputs.skip != 'true' && steps.key-check.outputs.skip != 'true'
@@ -76,7 +95,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-reject: 'true'
-          max-diff-lines: '5000'
+          max-diff-lines: ${{ secrets.OPENROUTER_API_KEY != '' && '2500' || '800' }}
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -44,50 +44,29 @@ jobs:
         if: steps.fork-check.outputs.skip != 'true' && steps.key-check.outputs.skip != 'true'
         run: |
           mkdir -p .ca
-          if [ -n "${OPENROUTER_API_KEY:-}" ]; then
-            PROVIDER="openrouter"
-            REVIEWER_MODEL="qwen/qwen3-coder-30b-a3b-instruct"
-            SUPPORTER_MODEL="baidu/ernie-4.5-21b-a3b-thinking"
-            HEAD_MODEL="deepseek/deepseek-v3.2"
-          elif [ -n "${GROQ_API_KEY:-}" ]; then
-            PROVIDER="groq"
-            REVIEWER_MODEL="llama-3.3-70b-versatile"
-            SUPPORTER_MODEL="llama-3.3-70b-versatile"
-            HEAD_MODEL="llama-3.3-70b-versatile"
-          else
-            PROVIDER="github-models"
-            REVIEWER_MODEL="gpt-4o-mini"
-            SUPPORTER_MODEL="gpt-4o-mini"
-            HEAD_MODEL="gpt-4o-mini"
-          fi
-
-          cat > .ca/config.json << CONF
+          cat > .ca/config.json << 'CONF'
           {
             "mode": "pragmatic",
             "language": "en",
             "reviewers": [
-              { "id": "r1", "model": "$REVIEWER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 },
-              { "id": "r2", "model": "$REVIEWER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 }
+              { "id": "r1", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 }
             ],
             "supporters": {
               "pool": [
-                { "id": "s1", "model": "$SUPPORTER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 }
+                { "id": "s1", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 }
               ],
               "pickCount": 1,
               "pickStrategy": "random",
-              "devilsAdvocate": { "id": "da", "model": "$SUPPORTER_MODEL", "backend": "api", "provider": "$PROVIDER", "enabled": true, "timeout": 120 },
+              "devilsAdvocate": { "id": "da", "model": "gpt-4o-mini", "backend": "api", "provider": "github-models", "enabled": true, "timeout": 120 },
               "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
               "personaAssignment": "random"
             },
-            "moderator": { "model": "$HEAD_MODEL", "backend": "api", "provider": "$PROVIDER" },
+            "moderator": { "model": "gpt-4o-mini", "backend": "api", "provider": "github-models" },
             "discussion": { "maxRounds": 1, "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null }, "codeSnippetRange": 5 },
-            "head": { "backend": "api", "model": "$HEAD_MODEL", "provider": "$PROVIDER", "enabled": true },
+            "head": { "backend": "api", "model": "gpt-4o-mini", "provider": "github-models", "enabled": true },
             "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
           }
           CONF
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
 
       - name: CodeAgora Review
         if: steps.fork-check.outputs.skip != 'true' && steps.key-check.outputs.skip != 'true'
@@ -95,7 +74,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-reject: 'true'
-          max-diff-lines: ${{ secrets.OPENROUTER_API_KEY != '' && '2500' || '800' }}
+          max-diff-lines: '250'
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ jobs:
 
 Every PR gets inline review comments, a summary verdict, and a commit status check. Add `review:skip` label to any PR to bypass.
 
+For GitHub Models, fork PR handling, provider secrets, permissions, and context-limit tuning, see the [GitHub Actions setup guide](docs/for-users/GITHUB_ACTIONS_SETUP.md).
+
 Note: Use the `v0.1.0-rc.3` Action tag for the scoped prerelease package line; `v2` belongs to the legacy `codeagora@2.x` line. The Action defaults to `.ca/config.json` in the repo root. You can override this via the `config-path` input (CLI flag wins, then the `CONFIG_PATH` env). `fail-on-reject` defaults to `true` (Action exits with code 1 on REJECT). The `review:skip` label is caller-owned and will not be modified by the Action. Any degraded/skipped run surfaces `degraded` and `degraded-reason` outputs.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ CodeAgora docs are organized by audience.
 | [`for-users/CLI_REFERENCE.md`](./for-users/CLI_REFERENCE.md) | CLI commands and options. |
 | [`for-users/CONFIGURATION.md`](./for-users/CONFIGURATION.md) | CodeAgora configuration. |
 | [`for-users/PROVIDERS.md`](./for-users/PROVIDERS.md) | Provider setup and status. |
+| [`for-users/GITHUB_ACTIONS_SETUP.md`](./for-users/GITHUB_ACTIONS_SETUP.md) | Step-by-step GitHub Actions setup guide. |
 | [`for-users/5_GITHUB_INTEGRATION.md`](./for-users/5_GITHUB_INTEGRATION.md) | GitHub Action and PR integration. |
 | [`for-users/TROUBLESHOOTING.md`](./for-users/TROUBLESHOOTING.md) | Common failures and fixes. |
 

--- a/docs/for-users/GITHUB_ACTIONS_SETUP.md
+++ b/docs/for-users/GITHUB_ACTIONS_SETUP.md
@@ -1,0 +1,271 @@
+# GitHub Actions Setup Guide
+
+This guide shows the recommended ways to run CodeAgora on pull requests.
+
+Use this when you want PR inline comments, a summary verdict, and a commit status check from the `bssm-oss/CodeAgora` GitHub Action.
+
+## Quick start: GitHub Models only
+
+This is the lowest-friction setup for same-repository PRs. It uses the workflow `GITHUB_TOKEN` and does not require external provider secrets.
+
+### 1. Add `.ca/config.json`
+
+```json
+{
+  "mode": "pragmatic",
+  "language": "en",
+  "reviewers": [
+    {
+      "id": "r1",
+      "model": "gpt-4o-mini",
+      "backend": "api",
+      "provider": "github-models",
+      "enabled": true,
+      "timeout": 120
+    }
+  ],
+  "supporters": {
+    "pool": [
+      {
+        "id": "s1",
+        "model": "gpt-4o-mini",
+        "backend": "api",
+        "provider": "github-models",
+        "enabled": true,
+        "timeout": 120
+      }
+    ],
+    "pickCount": 1,
+    "pickStrategy": "random",
+    "devilsAdvocate": {
+      "id": "da",
+      "model": "gpt-4o-mini",
+      "backend": "api",
+      "provider": "github-models",
+      "enabled": true,
+      "timeout": 120
+    },
+    "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
+    "personaAssignment": "random"
+  },
+  "moderator": { "model": "gpt-4o-mini", "backend": "api", "provider": "github-models" },
+  "discussion": {
+    "maxRounds": 1,
+    "registrationThreshold": {
+      "HARSHLY_CRITICAL": 1,
+      "CRITICAL": 1,
+      "WARNING": 2,
+      "SUGGESTION": null
+    },
+    "codeSnippetRange": 5
+  },
+  "head": {
+    "backend": "api",
+    "model": "gpt-4o-mini",
+    "provider": "github-models",
+    "enabled": true
+  },
+  "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
+}
+```
+
+The compact one-reviewer setup is intentional for GitHub Models because some models have small request limits. For larger PRs, keep `max-diff-lines` conservative or use an external provider with a larger context window.
+
+### 2. Add `.github/workflows/codeagora-review.yml`
+
+```yaml
+name: CodeAgora Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+  models: read
+
+jobs:
+  review:
+    if: >-
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'review:skip')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: CodeAgora Review
+        uses: bssm-oss/CodeAgora@v0.1.0-rc.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-reject: 'true'
+          max-diff-lines: '250'
+```
+
+### 3. Open or update a PR
+
+The Action posts:
+
+- inline comments for confirmed findings
+- a summary review with the final verdict
+- a commit status check
+
+Add a `review:skip` label to skip CodeAgora for a PR.
+
+## External provider setup
+
+Use this when you need a larger context window, higher throughput, or provider-specific models.
+
+### 1. Add provider secrets
+
+In the target repository, open **Settings > Secrets and variables > Actions > New repository secret**.
+
+Common secrets:
+
+| Provider | Secret |
+|---|---|
+| Groq | `GROQ_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Anthropic | `ANTHROPIC_API_KEY` |
+| Google | `GOOGLE_API_KEY` |
+
+See [Providers](./PROVIDERS.md) for the full provider list.
+
+### 2. Use matching provider config
+
+Example with Groq:
+
+```json
+{
+  "mode": "pragmatic",
+  "language": "en",
+  "reviewers": [
+    { "id": "r1", "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 },
+    { "id": "r2", "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 }
+  ],
+  "supporters": {
+    "pool": [
+      { "id": "s1", "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 }
+    ],
+    "pickCount": 1,
+    "pickStrategy": "random",
+    "devilsAdvocate": { "id": "da", "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq", "enabled": true, "timeout": 120 },
+    "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
+    "personaAssignment": "random"
+  },
+  "moderator": { "model": "llama-3.3-70b-versatile", "backend": "api", "provider": "groq" },
+  "discussion": { "maxRounds": 1, "codeSnippetRange": 5 },
+  "head": { "backend": "api", "model": "llama-3.3-70b-versatile", "provider": "groq", "enabled": true },
+  "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
+}
+```
+
+### 3. Pass the secret to the Action
+
+```yaml
+- name: CodeAgora Review
+  uses: bssm-oss/CodeAgora@v0.1.0-rc.3
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    fail-on-reject: 'true'
+    max-diff-lines: '2500'
+  env:
+    GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+```
+
+## Action inputs
+
+| Input | Default | Description |
+|---|---:|---|
+| `github-token` | required | Token used to fetch the PR diff, post review comments, and set commit status. Usually `${{ secrets.GITHUB_TOKEN }}`. |
+| `config-path` | `.ca/config.json` | Path to the CodeAgora config relative to the repository root. |
+| `fail-on-reject` | `true` | When `true`, the Action exits non-zero if the final verdict is `REJECT`. |
+| `max-diff-lines` | `5000` | Skips the review when the PR diff exceeds this many lines. Use `0` for unlimited. |
+| `post-results` | `true` | When `false`, runs without posting PR comments/status. |
+
+## Required permissions
+
+Use these permissions for normal PR review posting:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+```
+
+Add this when using `provider: "github-models"`:
+
+```yaml
+  models: read
+```
+
+`issues: write` is optional for workflows that manage labels themselves. CodeAgora does not mutate the `review:skip` label.
+
+## Fork PRs
+
+Repository secrets are not available to untrusted fork PRs. For public repos, prefer one of these patterns:
+
+- skip CodeAgora for fork PRs and let maintainers run it after review
+- require maintainer approval before running workflows from forks
+- use GitHub Models with only the workflow token if your repository policy allows it
+
+Example fork guard:
+
+```yaml
+- name: Check fork PR secrets
+  id: fork-check
+  if: github.event.pull_request.head.repo.full_name != github.repository
+  run: |
+    echo "::warning::Fork PR detected — secrets are unavailable. Skipping review."
+    echo "skip=true" >> "$GITHUB_OUTPUT"
+```
+
+Then add this condition to later steps:
+
+```yaml
+if: steps.fork-check.outputs.skip != 'true'
+```
+
+## Choosing `max-diff-lines`
+
+Use a smaller limit for smaller context windows:
+
+| Setup | Suggested `max-diff-lines` |
+|---|---:|
+| GitHub Models `gpt-4o-mini` | `250`–`800` |
+| Groq / OpenRouter compact config | `1000`–`2500` |
+| Larger-context provider models | start with `2500`, then tune upward |
+
+If you see provider errors like “request body too large” or context-limit failures, reduce `max-diff-lines`, reduce reviewer count, reduce `discussion.maxRounds`, or split the PR.
+
+## Outputs
+
+The Action exposes these outputs for downstream workflow steps:
+
+| Output | Meaning |
+|---|---|
+| `verdict` | `ACCEPT`, `REJECT`, `NEEDS_HUMAN`, or `SKIPPED` |
+| `review-url` | URL of the posted GitHub review when available |
+| `session-id` | CodeAgora session ID for audit/debugging |
+| `degraded` | `true` when the run was degraded or skipped |
+| `degraded-reason` | Stable reason code such as `diff-too-large`, `missing-provider-secrets`, or `config-load-failed` |
+| `head-sha` | PR head SHA reviewed by CodeAgora |
+| `base-sha` | PR base SHA used for diff acquisition |
+
+## Troubleshooting checklist
+
+1. **Config not found**: commit `.ca/config.json` or set `config-path`.
+2. **Missing provider secret**: add the matching secret and pass it through `env:`.
+3. **GitHub Models fails**: make sure `permissions.models: read` is set and keep the diff/config small.
+4. **Fork PR skipped**: expected when secrets are unavailable to forked PRs.
+5. **Diff too large**: split the PR or raise `max-diff-lines` only if your provider can handle it.
+6. **Action blocks merge**: set `fail-on-reject: 'false'` if you want review results without a required failure gate.
+
+For more details, see the [GitHub integration spec](./5_GITHUB_INTEGRATION.md) and [Troubleshooting](./TROUBLESHOOTING.md).

--- a/docs/for-users/TROUBLESHOOTING.md
+++ b/docs/for-users/TROUBLESHOOTING.md
@@ -48,6 +48,8 @@ agora review path/to/my.diff
 
 ## GitHub Actions
 
+For a complete setup checklist, recommended workflow snippets, provider secrets, permissions, and context-limit guidance, see [GitHub Actions Setup Guide](./GITHUB_ACTIONS_SETUP.md).
+
 ### Fork PR review skipped
 Fork PRs don't have access to repository secrets. The review will be skipped with a warning. Options:
 1. Ask the maintainer to run the review manually

--- a/packages/desktop/src/api/desktop-fallbacks.ts
+++ b/packages/desktop/src/api/desktop-fallbacks.ts
@@ -1,7 +1,6 @@
 import type {
   SessionSummary,
   SessionDetail,
-  SeverityCounts,
   RepoInfo,
   ProviderStatus,
   McpStatus,
@@ -9,8 +8,6 @@ import type {
   EvidenceStatus,
   DesktopCommandContract,
   ReviewRunSnapshot,
-  SessionCostSummary,
-  TopIssue,
 } from './desktop-bridge.types.js';
 
 /** Stub session data used when running outside Tauri context. */


### PR DESCRIPTION
## Summary
- Make the CodeAgora Review workflow prefer OpenRouter when `OPENROUTER_API_KEY` is configured.
- Fall back to Groq, then GitHub Models only when no external provider key exists.
- Reduce review topology/context for CI and lower fallback max diff size to avoid GitHub Models 8k-token request failures.
- Include the desktop fallback unused-import lint fix so CI stays green on this branch.

## Validation
- yq e '.' .github/workflows/review.yml >/dev/null
- pnpm lint

Refs #554 #555 #556 #557 #558 #559