### PR TITLE
fix(github): support unauthenticated PR fetch

### DIFF
--- a/docs/for-agents/rc-evidence/rc3-real-repo-qa.md
+++ b/docs/for-agents/rc-evidence/rc3-real-repo-qa.md
@@ -145,7 +145,7 @@ Every meaningful false positive or annoying low-value pattern should become an
 | JSON output contract pollution | RC blocker | Logger/progress lines appeared before JSON in successful `--output json --quiet` runs | Runtime owner | Ensure machine output formats write only the requested format to stdout; move logs to stderr or structured channels. | Rerun one baseline artifact and parse with `jq` without manual normalization | open |
 | Low-confidence high-severity noise | RC blocker | R3-02 emitted CRITICAL/HARSHLY_CRITICAL findings at `4%` to `18%` confidence | Quality owner | Tune L3 triage and confidence/severity interaction before quality claims. | Rerun R3-02 after rc.4 tuning | open |
 | Invalid final location | RC blocker | R3-02 emitted `unknown:0` final finding | Quality owner | Filter or quarantine findings with invalid file/line grounding. | Regression fixture for invalid final locations | open |
-| Direct PR mode requires `GITHUB_TOKEN` | Known surface blocker | First `pnpm dev review --pr <id>` attempts failed with `GitHub token is required` | Runtime owner | Set `GITHUB_TOKEN` before direct `--pr` runs, or continue using local patch inputs for baseline evidence. | Direct `--pr` run for one sample | open |
+| Direct PR mode requires `GITHUB_TOKEN` | Known surface blocker | First `pnpm dev review --pr <id>` attempts failed with `GitHub token is required` | Runtime owner | Read-only public PR fetch now works without a token; posting/private runs still require `GITHUB_TOKEN` or GitHub App auth. | Direct `--pr` read-only run for one sample | open |
 
 ## Known Limits
 
@@ -153,7 +153,7 @@ Every meaningful false positive or annoying low-value pattern should become an
 - The selected samples are historical merged or closed PRs. Live posting behavior is not proven by these samples; Action posting remains covered by separate live Action smoke evidence.
 - Provider/model set is fixed for the baseline: OpenRouter low-cost diverse from `benchmarks/.ca/config.low-cost-diverse.json`.
 - `OPENROUTER_API_KEY` was made available through the local CodeAgora credential store for the successful rerun. The key value is intentionally not recorded here.
-- Direct GitHub PR mode was not proven because this environment still has no `GITHUB_TOKEN`; patch-file input is the rc.3 baseline surface.
+- Direct GitHub PR mode can fetch public PR diffs without a token; posting and private-repo access still require `GITHUB_TOKEN` or GitHub App auth.
 
 ## Owner Checklist
 
@@ -187,7 +187,9 @@ work, but it is not good enough for quality claims: R3-02 and R3-04 show noisy
 `NEEDS_HUMAN` behavior, low-confidence high-severity findings, and at least one
 invalid final location. Successful JSON output also had logger/progress prelude
 lines before the JSON object and required artifact normalization before `jq`
-could parse it.
+could parse it. Direct public PR fetching is now read-only and no longer blocked
+by missing `GITHUB_TOKEN`; posting/private access still needs token or GitHub
+App auth.
 
 Next action: start rc.4 false-positive/noise reduction by fixing the JSON stdout
 contract, filtering invalid final locations, and calibrating low-confidence

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Command } from 'commander';
+import type { Octokit } from '@octokit/rest';
 import path from 'path';
 import fs from 'fs/promises';
 import ora from 'ora';
@@ -12,12 +13,11 @@ import { runPipeline } from '@codeagora/core/pipeline/orchestrator.js';
 import { dryRun, formatDryRunText } from '@codeagora/core/pipeline/dryrun.js';
 import { loadConfig } from '@codeagora/core/config/loader.js';
 import { ProgressEmitter } from '@codeagora/core/pipeline/progress.js';
-import { parsePrUrl, createGitHubConfig } from '@codeagora/github/client.js';
+import { parsePrUrl, createGitHubConfig, createOctokit, createAppOctokit, type GitHubConfig } from '@codeagora/github/client.js';
 import { fetchPrDiff } from '@codeagora/github/pr-diff.js';
 import { buildDiffPositionIndex } from '@codeagora/github/diff-parser.js';
 import { mapToGitHubReview } from '@codeagora/github/mapper.js';
 import { postReview, setCommitStatus } from '@codeagora/github/poster.js';
-import { createAppOctokit } from '@codeagora/github/client.js';
 import { t } from '@codeagora/shared/i18n/index.js';
 import { formatOutput, type OutputFormat } from '../formatters/review-output.js';
 import { parseReviewerOption, readStdin } from '../options/review-options.js';
@@ -68,6 +68,22 @@ export function hasGitHubAppAuth(): boolean {
   const privateKey = process.env['CODEAGORA_APP_PRIVATE_KEY'];
   const privateKeyPath = process.env['CODEAGORA_APP_PRIVATE_KEY_PATH'];
   return Boolean(appId && (privateKey || privateKeyPath));
+}
+
+export async function createPrFetchOctokit(
+  ghConfig: GitHubConfig,
+  options: { postReview: boolean },
+): Promise<Octokit | undefined> {
+  if (ghConfig.token || !hasGitHubAppAuth()) return undefined;
+
+  const appKit = await createAppOctokit(ghConfig.owner, ghConfig.repo);
+  if (!appKit && options.postReview) {
+    throw new Error(
+      'GitHub App auth is configured but installation auth could not be initialized for this repository. Check CODEAGORA_APP_ID and private key settings, and ensure the App is installed on the repo.'
+    );
+  }
+
+  return appKit ?? undefined;
 }
 
 export function emitReviewStartupDiagnostics(
@@ -159,6 +175,7 @@ async function reviewAction(diffPath: string | undefined, options: ReviewOptions
     // Handle --pr: fetch diff from GitHub
     let resolvedPath: string;
     let prContext: { owner: string; repo: string; prNumber: number; headSha: string; diff: string } | undefined;
+    let prOctokit: Octokit | undefined;
 
     if (options.pr) {
       const parsed = parsePrUrl(options.pr);
@@ -179,7 +196,8 @@ async function reviewAction(diffPath: string | undefined, options: ReviewOptions
       }
 
       if (!options.quiet) console.error(t('cli.info.fetchingPR', { prNumber: String(ghConfig.prNumber) }));
-      const prInfo = await fetchPrDiff(ghConfig, ghConfig.prNumber);
+      prOctokit = await createPrFetchOctokit(ghConfig, { postReview: Boolean(options.postReview) });
+      const prInfo = await fetchPrDiff(ghConfig, ghConfig.prNumber, prOctokit);
 
       const tmpDir = path.join(process.cwd(), '.ca');
       await fs.mkdir(tmpDir, { recursive: true });
@@ -189,13 +207,12 @@ async function reviewAction(diffPath: string | undefined, options: ReviewOptions
       resolvedPath = stdinTmpPath;
 
       // Save PR context for --post-review
-      const { createOctokit } = await import('@codeagora/github/client.js');
-      const kit = createOctokit(ghConfig);
-      const { data: prData } = await kit.pulls.get({
+      const kit = prOctokit ?? createOctokit(ghConfig);
+      const prData = prOctokit && prInfo.headSha ? { head: { sha: prInfo.headSha } } : (await kit.pulls.get({
         owner: ghConfig.owner,
         repo: ghConfig.repo,
         pull_number: ghConfig.prNumber,
-      });
+      })).data;
       prContext = {
         owner: ghConfig.owner,
         repo: ghConfig.repo,
@@ -485,10 +502,9 @@ async function reviewAction(diffPath: string | undefined, options: ReviewOptions
           ? new Map(Object.entries(result.supporterModelMap))
           : undefined,
       });
-      const appKit = await createAppOctokit(prContext.owner, prContext.repo);
-      if (appKit && !options.quiet) console.error(t('cli.info.usingAppAuth'));
-      const postResult = await postReview(ghConfig, prContext.prNumber, review, appKit ?? undefined);
-      await setCommitStatus(ghConfig, prContext.headSha, postResult.verdict, postResult.reviewUrl, appKit ?? undefined);
+      if (prOctokit && !options.quiet) console.error(t('cli.info.usingAppAuth'));
+      const postResult = await postReview(ghConfig, prContext.prNumber, review, prOctokit);
+      await setCommitStatus(ghConfig, prContext.headSha, postResult.verdict, postResult.reviewUrl, prOctokit);
       if (!options.quiet) console.error(t('cli.info.reviewPosted', { url: postResult.reviewUrl }));
     }
 

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -63,6 +63,13 @@ interface ReviewStartupDiagnostics {
   contextLines: number;
 }
 
+export function hasGitHubAppAuth(): boolean {
+  const appId = process.env['CODEAGORA_APP_ID'];
+  const privateKey = process.env['CODEAGORA_APP_PRIVATE_KEY'];
+  const privateKeyPath = process.env['CODEAGORA_APP_PRIVATE_KEY_PATH'];
+  return Boolean(appId && (privateKey || privateKeyPath));
+}
+
 export function emitReviewStartupDiagnostics(
   diagnostics: ReviewStartupDiagnostics,
   machineReadableStdout: boolean,
@@ -117,6 +124,13 @@ async function reviewAction(diffPath: string | undefined, options: ReviewOptions
 
     if (options.postReview && !options.pr) {
       console.error('--post-review requires --pr to specify the target PR');
+      process.exit(2);
+    }
+
+    if (options.postReview && !process.env['GITHUB_TOKEN'] && !hasGitHubAppAuth()) {
+      console.error(
+        '--post-review requires GITHUB_TOKEN or GitHub App auth (CODEAGORA_APP_ID + CODEAGORA_APP_PRIVATE_KEY or CODEAGORA_APP_PRIVATE_KEY_PATH)'
+      );
       process.exit(2);
     }
 

--- a/packages/cli/src/tests/cli-review.test.ts
+++ b/packages/cli/src/tests/cli-review.test.ts
@@ -1016,6 +1016,40 @@ describe('review command — action handler', () => {
       delete process.env['CODEAGORA_APP_PRIVATE_KEY_PATH'];
       expect(hasGitHubAppAuth()).toBe(false);
     });
+
+    it('createPrFetchOctokit uses GitHub App auth when token is absent', async () => {
+      const { createPrFetchOctokit } = await import('../commands/review.js');
+      const { createAppOctokit } = await import('@codeagora/github/client.js');
+      const appKit = { pulls: { get: vi.fn() } } as never;
+
+      process.env['CODEAGORA_APP_ID'] = '123';
+      process.env['CODEAGORA_APP_PRIVATE_KEY'] = 'key';
+      vi.mocked(createAppOctokit).mockResolvedValue(appKit);
+
+      const result = await createPrFetchOctokit({ token: '', owner: 'acme', repo: 'api' }, { postReview: true });
+
+      expect(result).toBe(appKit);
+      expect(createAppOctokit).toHaveBeenCalledWith('acme', 'api');
+
+      delete process.env['CODEAGORA_APP_ID'];
+      delete process.env['CODEAGORA_APP_PRIVATE_KEY'];
+    });
+
+    it('createPrFetchOctokit fails posting when configured GitHub App auth cannot initialize', async () => {
+      const { createPrFetchOctokit } = await import('../commands/review.js');
+      const { createAppOctokit } = await import('@codeagora/github/client.js');
+
+      process.env['CODEAGORA_APP_ID'] = '123';
+      process.env['CODEAGORA_APP_PRIVATE_KEY'] = 'key';
+      vi.mocked(createAppOctokit).mockResolvedValue(null);
+
+      await expect(
+        createPrFetchOctokit({ token: '', owner: 'acme', repo: 'api' }, { postReview: true })
+      ).rejects.toThrow(/installation auth could not be initialized/i);
+
+      delete process.env['CODEAGORA_APP_ID'];
+      delete process.env['CODEAGORA_APP_PRIVATE_KEY'];
+    });
   });
 });
 

--- a/packages/cli/src/tests/cli-review.test.ts
+++ b/packages/cli/src/tests/cli-review.test.ts
@@ -999,6 +999,23 @@ describe('review command — action handler', () => {
       const isInvalid = postReview && !pr;
       expect(isInvalid).toBe(false);
     });
+
+    it('hasGitHubAppAuth allows app id plus key or key path', async () => {
+      const { hasGitHubAppAuth } = await import('../commands/review.js');
+
+      delete process.env['GITHUB_TOKEN'];
+      process.env['CODEAGORA_APP_ID'] = '123';
+      process.env['CODEAGORA_APP_PRIVATE_KEY'] = 'key';
+      expect(hasGitHubAppAuth()).toBe(true);
+
+      delete process.env['CODEAGORA_APP_PRIVATE_KEY'];
+      process.env['CODEAGORA_APP_PRIVATE_KEY_PATH'] = '/tmp/key.pem';
+      expect(hasGitHubAppAuth()).toBe(true);
+
+      delete process.env['CODEAGORA_APP_ID'];
+      delete process.env['CODEAGORA_APP_PRIVATE_KEY_PATH'];
+      expect(hasGitHubAppAuth()).toBe(false);
+    });
   });
 });
 

--- a/packages/github/src/client.ts
+++ b/packages/github/src/client.ts
@@ -11,9 +11,11 @@ import { validateDiffPath } from '@codeagora/shared/utils/path-validation.js';
 
 /**
  * Create a reusable Octokit instance from a GitHubConfig.
+ * Read-only PR fetches can use an unauthenticated client; posting still
+ * requires a token or GitHub App installation auth.
  */
 export function createOctokit(config: GitHubConfig): Octokit {
-  return new Octokit({ auth: config.token });
+  return config.token ? new Octokit({ auth: config.token }) : new Octokit({});
 }
 
 /**
@@ -144,10 +146,11 @@ export function parseGitRemote(
  * Create a GitHubConfig with PR number from the provided options.
  *
  * Resolution order:
- * - token: options.token ?? process.env.GITHUB_TOKEN
+ * - token: options.token ?? process.env.GITHUB_TOKEN ?? ''
  * - owner/repo/prNumber: parsed from prUrl if provided, else remoteUrl + prNumber
  *
- * Throws if token is missing or if required fields cannot be resolved.
+ * Read-only PR diff fetches can proceed without a token; posting requires
+ * token or GitHub App auth.
  */
 export function createGitHubConfig(options: {
   token?: string;
@@ -155,12 +158,7 @@ export function createGitHubConfig(options: {
   remoteUrl?: string;
   prNumber?: number;
 }): GitHubConfig & { prNumber: number } {
-  const token = options.token ?? process.env['GITHUB_TOKEN'];
-  if (!token) {
-    throw new Error(
-      'GitHub token is required. Pass --token or set the GITHUB_TOKEN environment variable.'
-    );
-  }
+  const token = options.token ?? process.env['GITHUB_TOKEN'] ?? '';
 
   if (options.prUrl) {
     const parsed = parsePrUrl(options.prUrl);

--- a/packages/mcp/src/tests/tool-handlers.test.ts
+++ b/packages/mcp/src/tests/tool-handlers.test.ts
@@ -8,6 +8,7 @@
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MCP_ERROR_CODES } from '@codeagora/shared/contracts/stable.js';
@@ -23,6 +24,27 @@ type ToolHandler = (params: Record<string, unknown>) => Promise<{
 
 function parseToolJson(result: { content: Array<{ text: string }> }): Record<string, unknown> {
   return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function resolveToolDir() {
+  const candidates = [
+    path.resolve(testDir, '..', 'tools'),
+    path.join(process.cwd(), 'src', 'tools'),
+    path.join(process.cwd(), 'packages', 'mcp', 'src', 'tools'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Try next candidate.
+    }
+  }
+
+  throw new Error(`Unable to locate tools directory from ${testDir}`);
 }
 
 function createServerStub() {
@@ -477,7 +499,7 @@ describe('stable MCP error contract', () => {
   });
 
   it('keeps tool implementations off ad-hoc text and unversioned error bodies', async () => {
-    const toolDir = path.join(process.cwd(), 'packages', 'mcp', 'src', 'tools');
+    const toolDir = await resolveToolDir();
     const entries = await fs.readdir(toolDir);
     const toolFiles = entries.filter((entry) => entry.endsWith('.ts') && !entry.startsWith('shared-'));
 

--- a/src/tests/github-integration.test.ts
+++ b/src/tests/github-integration.test.ts
@@ -17,10 +17,12 @@ const mockListComments = vi.fn();
 const mockUpdateComment = vi.fn();
 const mockPullsGet = vi.fn();
 const mockPaginate = vi.fn();
+const mockOctokitCtor = vi.hoisted(() => vi.fn());
 
 vi.mock('@octokit/rest', () => {
   return {
-    Octokit: vi.fn().mockImplementation(() => ({
+    Octokit: mockOctokitCtor.mockImplementation((options?: { auth?: string }) => ({
+      options,
       pulls: {
         get: mockPullsGet,
       },
@@ -111,6 +113,7 @@ describe('parseGitRemote', () => {
 describe('createGitHubConfig', () => {
   beforeEach(() => {
     delete process.env['GITHUB_TOKEN'];
+    mockOctokitCtor.mockClear();
   });
 
   it('creates config from token + prUrl', () => {
@@ -138,10 +141,9 @@ describe('createGitHubConfig', () => {
     expect(config.token).toBe('env_token');
   });
 
-  it('throws when no token is available', () => {
-    expect(() =>
-      createGitHubConfig({ prUrl: 'https://github.com/acme/api/pull/1' })
-    ).toThrow(/token/i);
+  it('allows missing token for read-only PR fetches', () => {
+    const config = createGitHubConfig({ prUrl: 'https://github.com/acme/api/pull/1' });
+    expect(config).toEqual({ token: '', owner: 'acme', repo: 'api', prNumber: 1 });
   });
 
   it('throws when prUrl is invalid', () => {
@@ -154,6 +156,22 @@ describe('createGitHubConfig', () => {
     expect(() =>
       createGitHubConfig({ token: 'ghp_test' })
     ).toThrow();
+  });
+
+  it('creates unauthenticated Octokit when token is empty', async () => {
+    const { createOctokit } = await import('@codeagora/github/client.js');
+
+    createOctokit({ token: '', owner: 'acme', repo: 'api' });
+
+    expect(mockOctokitCtor).toHaveBeenCalledWith({});
+  });
+
+  it('creates authenticated Octokit when token is present', async () => {
+    const { createOctokit } = await import('@codeagora/github/client.js');
+
+    createOctokit({ token: 'ghp_test', owner: 'acme', repo: 'api' });
+
+    expect(mockOctokitCtor).toHaveBeenCalledWith({ auth: 'ghp_test' });
   });
 });
 

--- a/src/tests/github-integration.test.ts
+++ b/src/tests/github-integration.test.ts
@@ -16,6 +16,7 @@ const mockCreateComment = vi.fn();
 const mockListComments = vi.fn();
 const mockUpdateComment = vi.fn();
 const mockPullsGet = vi.fn();
+const mockAppsGetRepoInstallation = vi.fn();
 const mockPaginate = vi.fn();
 const mockOctokitCtor = vi.hoisted(() => vi.fn());
 
@@ -23,6 +24,9 @@ vi.mock('@octokit/rest', () => {
   return {
     Octokit: mockOctokitCtor.mockImplementation((options?: { auth?: string }) => ({
       options,
+      apps: {
+        getRepoInstallation: mockAppsGetRepoInstallation,
+      },
       pulls: {
         get: mockPullsGet,
       },
@@ -113,7 +117,11 @@ describe('parseGitRemote', () => {
 describe('createGitHubConfig', () => {
   beforeEach(() => {
     delete process.env['GITHUB_TOKEN'];
+    delete process.env['CODEAGORA_APP_ID'];
+    delete process.env['CODEAGORA_APP_PRIVATE_KEY'];
+    delete process.env['CODEAGORA_APP_PRIVATE_KEY_PATH'];
     mockOctokitCtor.mockClear();
+    mockAppsGetRepoInstallation.mockReset();
   });
 
   it('creates config from token + prUrl', () => {
@@ -172,6 +180,25 @@ describe('createGitHubConfig', () => {
     createOctokit({ token: 'ghp_test', owner: 'acme', repo: 'api' });
 
     expect(mockOctokitCtor).toHaveBeenCalledWith({ auth: 'ghp_test' });
+  });
+
+  it('creates app-authenticated Octokit when app env is set and token is absent', async () => {
+    const { createAppOctokit } = await import('@codeagora/github/client.js');
+
+    process.env['CODEAGORA_APP_ID'] = '123';
+    process.env['CODEAGORA_APP_PRIVATE_KEY'] = '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----';
+    mockAppsGetRepoInstallation.mockResolvedValue({ data: { id: 88 } });
+
+    await createAppOctokit('acme', 'api');
+
+    expect(mockOctokitCtor).toHaveBeenNthCalledWith(1, {
+      authStrategy: expect.any(Function),
+      auth: { appId: 123, privateKey: process.env['CODEAGORA_APP_PRIVATE_KEY'] },
+    });
+    expect(mockOctokitCtor).toHaveBeenNthCalledWith(2, {
+      authStrategy: expect.any(Function),
+      auth: { appId: 123, privateKey: process.env['CODEAGORA_APP_PRIVATE_KEY'], installationId: 88 },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- allow read-only public PR fetches without GITHUB_TOKEN
- use GitHub App installation auth for PR diff/head lookup and posting when no token is present
- rebuild the tracked GitHub Action bundle
- fix MCP package-local test cwd resolution

## Verification
- pnpm test -- packages/cli/src/tests/cli-review.test.ts src/tests/github-integration.test.ts
- pnpm --filter @codeagora/mcp test
- pnpm typecheck
- pnpm build
- pnpm build:action
- pnpm bench:ci
- action-related regression tests