### PR TITLE
Improve rc.6 setup guidance across CLI, MCP, and GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ outputs:
       Stable reason code for degraded or skipped mode.
       Values include missing-github-token, missing-provider-secrets, fork-missing-provider-secrets,
       posting-disabled, diff-too-large, config-load-failed, stale-head-sha,
-      github-post-failed, and sarif-write-failed.
+      github-post-failed, and sarif-write-failed. Check the Action logs for a short why/next-step hint.
       Always set if degraded is true.
     value: ${{ steps.review.outputs.degraded-reason }}
 

--- a/docs/for-agents/rc-evidence/rc6-setup-smoke.md
+++ b/docs/for-agents/rc-evidence/rc6-setup-smoke.md
@@ -1,0 +1,101 @@
+<!-- Parent: ../PRODUCTION_READINESS_ROADMAP.md -->
+
+# RC.6 Setup And Usability Smoke
+
+Generated: 2026-06-05
+
+## Purpose
+
+`0.1.0-rc.6` is the setup and usability hardening pass for CodeAgora's stable
+surfaces: CLI, GitHub Action, and MCP. Desktop remains private preview.
+
+This note is the evidence ledger for closing the current dirty worktree without
+expanding product scope.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Repo | `/Users/justn/Workspaces/orgs/bssm-oss/main/justn-hyeok/CodeAgora` |
+| Mode | Source checkout, dirty local rc.6 worktree |
+| Package manager | pnpm |
+| Session | `codex:019e94e9-9f27-7980-8e65-5b08833539ff` |
+| Stable surfaces in scope | CLI, GitHub Action, MCP |
+| Explicitly private preview | Desktop |
+
+## Dirty-Cluster Ownership
+
+The boundary check was performed before any rc.6 source edits in this
+start-work session. Existing dirty files were treated as user/prior-agent work
+until classified.
+
+| Cluster | Files | Classification | Reason | Required verification |
+| --- | --- | --- | --- | --- |
+| CLI first-run UX | `packages/cli/src/commands/doctor.ts`, `packages/cli/src/commands/register-init.ts`, `packages/cli/src/commands/review.ts`, `packages/cli/src/formatters/review-output.ts`, `packages/cli/src/tests/register-init.test.ts`, `src/tests/cli-commands.test.ts`, `src/tests/cli-error-handling.test.ts`, `src/tests/review-output-advanced.test.ts` | `rc6-owned` | Adds human-readable next steps for init, doctor, dry-run JSON stability, review footer, and matching tests. No intended JSON/NDJSON contract expansion beyond stripping text-only readiness from dry-run JSON. | `pnpm vitest run packages/cli/src/tests/register-init.test.ts src/tests/cli-commands.test.ts src/tests/cli-error-handling.test.ts src/tests/review-output-advanced.test.ts src/tests/cli-output-formats.test.ts src/tests/cli-review-options.test.ts`; tmux clean-repo CLI smoke. |
+| Core dry-run preflight | `packages/core/src/pipeline/dryrun.ts`, `src/tests/pipeline-dryrun.test.ts` | `rc6-owned` | Adds `ready`/`blocked`/`risky` readiness classification and next actions for human text output. | `pnpm vitest run src/tests/pipeline-dryrun.test.ts`; tmux dry-run blocked/ready/risky transcript. |
+| MCP agent retry guidance | `packages/mcp/src/tools/*.ts`, `packages/mcp/src/tests/tool-handlers.test.ts`, `packages/mcp/src/tests/tools.test.ts`, `packages/mcp/README.md` | `rc6-owned` | Improves tool descriptions, `repo_path` descriptions, invalid diff guidance, structured error details, and README examples without renaming tools or removing existing fields. | `pnpm vitest run packages/mcp/src/tests/tool-handlers.test.ts packages/mcp/src/tests/tools.test.ts`; MCP startup/tools-list or package smoke plus invalid `repo_path` artifact. |
+| GitHub Action degraded guidance | `packages/github/src/action.ts`, `packages/github/src/action-policy.ts`, `packages/github/src/poster.ts`, `packages/github/src/tests/github-poster.test.ts`, `src/tests/github-action-parse-args.test.ts`, `action.yml`, `dist/action.js` | `rc6-owned` | Adds actionable warning messages and stable degraded-reason help while keeping Action inputs/outputs stable; bundle appears intentionally regenerated. | `pnpm vitest run src/tests/github-action-parse-args.test.ts packages/github/src/tests/github-poster.test.ts`; `pnpm build:action`; docs/action wording review. |
+| User docs | `docs/for-users/5_GITHUB_INTEGRATION.md`, `docs/for-users/GITHUB_ACTIONS_SETUP.md`, `docs/for-users/PROVIDERS.md`, `docs/for-users/TROUBLESHOOTING.md`, `docs/for-users/EXTENSIONS.md` | `rc6-owned` | Documents Action degraded reasons, provider setup, MCP retry guidance, and companion agent workflow boundaries for the setup/recovery theme. | Docs mismatch review against Action/MCP source and current `@rc` path. |
+| Desktop fallback and i18n copy | `packages/desktop/src/api/desktop-fallbacks.ts`, `packages/shared/src/i18n/locales/en.json`, `packages/shared/src/i18n/locales/ko.json` | `rc6-owned-with-private-preview-boundary` | Desktop fallback demo data and localized error hints support private-preview/local UX; this must not become a stable desktop release claim. | If behavior remains touched, run `pnpm rc:desktop-gate`; otherwise document as private-preview evidence. |
+| RC.6 roadmap draft | `ROADMAP-for-rc6.md` | `split-later` | Useful planning input, but `.omo/plans/codeagora-current-work-and-completion-plan.md` is the active execution plan. Avoid creating two normative rc.6 roadmaps unless folded deliberately. | Leave unstaged or fold later into release/evidence docs by explicit decision. |
+| Demo review JSON examples | `examples/mock-review-result.json`, `examples/review-result-demo.json` | `split-later` | Useful desktop/MCP demo artifacts, but not required to close first-run CLI/GitHub/MCP usability unless a later desktop/private-preview smoke needs them. | Leave untouched for now; decide during desktop/i18n scope step. |
+| Init-deep scoped guidance | `AGENTS.md`, `packages/AGENTS.md`, `packages/mcp/AGENTS.md`, `packages/desktop/AGENTS.md`, `scripts/AGENTS.md`, `benchmarks/AGENTS.md`, `packages/core/src/pipeline/analyzers/AGENTS.md`, `packages/desktop/src/AGENTS.md`, `packages/desktop/src-tauri/AGENTS.md` | `planning/tooling-owned` | Created by the preceding `omo:init-deep` task, not rc.6 product implementation. Keep separate from rc.6 release evidence and staging decisions. | `git diff --check` already passed for this cluster during init-deep. |
+| Start-work state | `.omo/boulder.json`, `.omo/start-work/ledger.jsonl`, `.omo/plans/codeagora-current-work-and-completion-plan.md` | `planning/tooling-owned` | Required by `omo:start-work` to track checkboxes and continuation state. | Boulder state has `codex:` session id; ledger entries appended per completed checkbox. |
+
+## Scope Decision
+
+Proceed with rc.6 usability hardening for CLI, dry-run, MCP, GitHub Action, and
+supporting user docs. Keep desktop as private-preview evidence only. Do not start
+rc.7 team automation, rc.8 stable promotion, new product surfaces, or L0-L3
+review semantics changes in this work session.
+
+## Evidence To Fill
+
+- CLI success path: PASS.
+  - Automated: `pnpm vitest run packages/cli/src/tests/register-init.test.ts src/tests/cli-commands.test.ts src/tests/cli-error-handling.test.ts src/tests/review-output-advanced.test.ts src/tests/cli-output-formats.test.ts src/tests/cli-review-options.test.ts`
+  - Result: 7 test files passed, 165 tests passed.
+  - Manual source-mode smoke: `.omo/ulw-loop/evidence/rc6-cli-first-run.txt`.
+  - Observable: clean temp repo created `.ca/config.json`, `agora init --yes` printed `Next steps`, `agora doctor` grouped warnings/ready checks and printed `Next steps`, and `agora review --dry-run change.patch` exited 0.
+- CLI failure recovery path: PASS.
+  - Observable: dry-run with missing `GROQ_API_KEY` reported `Readiness: blocked`, reason `blocked: no usable provider credentials`, and next action `export GROQ_API_KEY=<your-key> for groq`.
+  - Note: an initial `pnpm dev` smoke was intentionally retained as `.omo/ulw-loop/evidence/rc6-cli-first-run-pnpm-dev-failed.txt`; it showed `pnpm --filter @codeagora/cli dev` runs with `packages/cli` as cwd, so source-mode QA uses the direct `tsx .../packages/cli/src/index.ts` entrypoint to preserve the temp repo cwd.
+- Dry-run preflight: PASS.
+  - Automated: `pnpm vitest run src/tests/pipeline-dryrun.test.ts`
+  - Result: 2 test files passed, 25 tests passed; readiness classification and next-action coverage are pinned in the dry-run test suite.
+  - Manual tmux smoke: `.omo/ulw-loop/evidence/rc6-dry-run-preflight.txt`.
+  - Observable: empty diff returned `Empty diff — nothing to review.` with exit 2; `agora review --dry-run ready.patch` printed `Pipeline Dry Run Report`, `Readiness: blocked`, the reason `blocked: no usable provider credentials`, and next actions including `agora doctor`, `agora review --staged`, `agora review --quick <diff.patch>`, and `export GROQ_API_KEY=<your-key> for groq`.
+  - Hung/long-command probe: `.omo/ulw-loop/evidence/rc6-dry-run-preflight-hung-init.txt` captured an overly broad smoke that stalled after re-running `init --yes` following auto-config; the passing smoke narrowed the surface to dry-run behavior and all tmux/temp resources were cleaned up.
+- MCP startup/tool/retry guidance: PASS.
+  - Automated: `pnpm vitest run packages/mcp/src/tests/tool-handlers.test.ts packages/mcp/src/tests/tools.test.ts`
+  - Result: 2 test files passed, 68 tests passed.
+  - Build: `pnpm --filter @codeagora/mcp build`
+  - Manual tmux smoke: `.omo/ulw-loop/evidence/rc6-mcp-retry-guidance.txt`.
+  - Observable: stdio server initialized as `codeagora` `0.1.0-rc.5`; `tools/list` exposed updated tool descriptions and `repo_path` schema guidance; invalid `repo_path: "/etc"` returned `INVALID_REPO_PATH`, `isError: true`, and next steps to omit `repo_path`, pass the exact repository root, or keep paths inside the MCP boundary.
+- GitHub Action setup/degraded guidance: PASS.
+  - Automated: `pnpm vitest run src/tests/github-action-parse-args.test.ts packages/github/src/tests/github-poster.test.ts packages/github/src/tests/critical-github-errors.test.ts`
+  - Result: 3 test files passed, 48 tests passed.
+  - Bundle: `pnpm build:action` completed with `dist/action.js built (0 errors, 0 warnings)`.
+  - Manual/docs review: `.omo/ulw-loop/evidence/rc6-action-guidance.txt`.
+  - Observable: source, generated `dist/action.js`, `action.yml`, and user docs all mention the stable degraded reasons and why/next-step guidance for missing token, missing provider secrets, fork secret limits, disabled posting, oversized diff, config load failure, stale head, posting failure, and SARIF write failure.
+- Desktop private-preview note: PARTIAL PASS, private-preview only.
+  - Scope decision: `packages/desktop/src/api/desktop-fallbacks.ts` is kept as private-preview fallback/demo support, not as a stable desktop launch claim.
+  - Gate attempt: `pnpm rc:desktop-gate`.
+  - Result: after `cargo clean` fixed stale Rust target artifacts, approved rerun passed desktop typecheck, smoke, `tauri:check`, app e2e, macOS webdriver e2e, and evidence manifest generation.
+  - Evidence: `.omo/ulw-loop/evidence/rc6-desktop-private-preview.txt`; manifest at `.sisyphus/evidence/desktop-evidence-manifest.json`.
+  - Known limit: final `bundle:smoke` failed during DMG bundling after producing `CodeAgora.app` and an intermediate `rw.*.dmg`; this remains a private-preview packaging blocker and does not change the stable CLI/GitHub Action/MCP scope.
+- Package smoke status: PASS with rerun note.
+  - Final gate: `pnpm typecheck` passed.
+  - Final gate: `pnpm build:action` passed.
+  - Final gate: `env npm_config_cache=/private/tmp/codeagora-npm-cache pnpm release:beta-smoke` passed after network approval.
+  - Rerun note: the first default-cache attempt failed because `/Users/justn/.npm` contained root-owned cache files; the isolated-cache sandbox attempt then reached `npm install` but failed with registry `ENOTFOUND`; the approved network rerun passed package dry-run contents, CLI help/init/runtime smoke, MCP tools/config/dry-run/review_quick smoke, root postinstall smoke, and tarball-installed CLI/MCP smokes.
+- Docs mismatch table:
+  | Area | Result |
+  | --- | --- |
+  | CLI init/doctor/dry-run guidance | Source tests and tmux transcripts match the new next-step wording. |
+  | MCP `repo_path` guidance | README/schema/tool output all tell agents to omit `repo_path`, pass the exact repo root, or stay inside the boundary. |
+  | GitHub Action degraded reasons | Source, generated `dist/action.js`, `action.yml`, and user docs list the stable degraded reasons and next-step guidance. |
+  | Desktop | Evidence manifest explicitly marks `releaseChannel` as `private-preview`, `publicDesktopLaunch` as `false`, and signing/notarization/updater as deferred/disabled. |
+- Known limits and next RC:
+  - Desktop remains private preview. The final DMG bundle step failed during `bundle_dmg.sh` after `.app` creation and an intermediate `rw.*.dmg`; do not treat desktop as stable release evidence until this packaging blocker is closed.
+  - `pnpm dev` is not a clean temp-repo CLI smoke because `pnpm --filter @codeagora/cli dev` uses `packages/cli` as cwd; source-mode QA used the direct `tsx .../packages/cli/src/index.ts` entrypoint and release smoke covered tarball-installed CLI behavior.
+  - Next required RC work remains rc.4/rc.5 evidence reconciliation, then rc.7 real/sandbox team automation trial before rc.8 stable-candidate decisions.

--- a/docs/for-users/5_GITHUB_INTEGRATION.md
+++ b/docs/for-users/5_GITHUB_INTEGRATION.md
@@ -263,11 +263,33 @@ github-post-failed
 sarif-write-failed
 ```
 
+Action logs now pair each stable reason with a short why + next step. Common fixes:
+
+| Reason | What it usually means | Next step |
+|---|---|---|
+| `missing-github-token` | The Action cannot post review/status updates. | Pass `github-token` (usually `${{ secrets.GITHUB_TOKEN }}`) or disable posting explicitly. |
+| `missing-provider-secrets` | The config needs a provider secret that is not present. | Add the required provider secret(s) or switch the config to GitHub Models. |
+| `fork-missing-provider-secrets` | Fork PR secrets are unavailable. | Use a same-repository PR, GitHub Models, or a fork gate before running CodeAgora. |
+| `posting-disabled` | Posting was turned off by workflow input. | Set `post-results: 'true'` if you want PR comments and status checks. |
+| `diff-too-large` | The diff exceeded `max-diff-lines`. | Lower the PR size, raise `max-diff-lines`, or split the PR. |
+| `config-load-failed` | The config path or JSON/YAML file could not be read. | Fix `.ca/config.json` or `config-path` and rerun. |
+| `stale-head-sha` | The PR head changed before posting. | Rerun the workflow on the updated commit SHA. |
+| `github-post-failed` | GitHub rejected a posting operation. | Check token scopes and the Action log, then rerun. |
+| `sarif-write-failed` | The SARIF file path was not writable/safe. | Use a writable SARIF path or export SARIF elsewhere. |
+
 ### 3.2 How the Action Gets the Diff
 
 **PR diff (preferred):** `gh pr diff {number}` returns the unified diff of all files changed in the PR. This is the same diff a reviewer sees in the GitHub UI, and it strips binary files automatically.
 
 **Local fallback:** if GitHub API diff retrieval fails, the action falls back to local `git diff` using the pull request base and head SHAs. This fallback requires a `pull_request` event context and an earlier `actions/checkout` step.
+
+### 3.2.1 Agent CLI and Companion Action Notes
+
+CodeAgora supports CLI reviewer backends such as Claude Code and Codex when those CLIs are installed and authenticated on the runner. The CodeAgora GitHub Action itself does not install or log in to those CLIs; it runs the bundled `dist/action.js` runtime and delegates reviewer execution to the configured backend.
+
+For OAuth-based Claude Code automation, use `anthropics/claude-code-action@v1` as a separate companion workflow/step with `claude_code_oauth_token`. That companion action can post its own PR feedback, while CodeAgora continues to provide the multi-reviewer verdict, sessions, SARIF, and stable Action outputs.
+
+Do not run OAuth-backed companion agent workflows on untrusted fork PRs unless your repository has an explicit approval/gating policy, because GitHub Actions secrets are not available to those runs.
 
 ### 3.3 Comment Deduplication
 

--- a/docs/for-users/EXTENSIONS.md
+++ b/docs/for-users/EXTENSIONS.md
@@ -32,3 +32,5 @@ Exposes the full CodeAgora pipeline as an MCP server compatible with Claude Code
 Provider keys are only needed for live review tools. `dry_run`, `tools/list`, and config reads should start without API keys.
 
 `review_quick` runs L1 only for fast feedback. `review_full` runs the complete L1 > L2 > L3 pipeline. `review_pr` reviews a GitHub PR by URL or number. `repo_path` is accepted by review tools plus `explain_session`, `get_stats`, `config_get`, and `config_set`; it lets the MCP server operate inside a specific checked-out repository while still rejecting paths outside the current repository boundary. Failures return MCP `isError: true` with JSON `{ "status": "error", "code": string, "message": string, "details"?: object }`.
+
+For the current workspace, omit `repo_path`. For another target repository inside the server cwd or detected git boundary, pass the exact repository root, for example `{ "repo_path": "/absolute/path/to/repository", "staged": true }`. If a review or dry-run tool reports that no diff is available, retry with a unified `diff` string or stage files and pass `{ "staged": true }`.

--- a/docs/for-users/GITHUB_ACTIONS_SETUP.md
+++ b/docs/for-users/GITHUB_ACTIONS_SETUP.md
@@ -181,10 +181,10 @@ Example with Groq:
 
 ## Claude Code / Codex companion workflows
 
-CodeAgora already supports CLI reviewers such as Claude Code (`claude`) and Codex (`codex`) through `backend: "cli"`, but the GitHub Action does not install or authenticate those CLIs. In GitHub Actions, choose one of these patterns:
+CodeAgora already supports CLI reviewers such as Claude Code and Codex through concrete CLI backend values like `backend: "claude"` or `backend: "codex"`, but the GitHub Action does not install or authenticate those CLIs. In GitHub Actions, choose one of these patterns:
 
 1. **CodeAgora Action with API/GitHub Models reviewers** — recommended default for rc.6.
-2. **CodeAgora Action with CLI reviewers** — install and authenticate the CLI on the runner before running CodeAgora.
+2. **CodeAgora Action with CLI reviewers** — install and authenticate the configured CLI backend on the runner before running CodeAgora. If your moderator/supporters still use API providers, keep the matching provider secrets configured too.
 3. **Companion agent workflow** — run Claude Code or Codex as a separate GitHub Action alongside CodeAgora.
 
 For Claude Code OAuth, use the official Claude Code Action. Generate the token locally with `claude setup-token`, save it as `CLAUDE_CODE_OAUTH_TOKEN`, then reference it from the workflow:

--- a/docs/for-users/GITHUB_ACTIONS_SETUP.md
+++ b/docs/for-users/GITHUB_ACTIONS_SETUP.md
@@ -179,6 +179,54 @@ Example with Groq:
     GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
 ```
 
+## Claude Code / Codex companion workflows
+
+CodeAgora already supports CLI reviewers such as Claude Code (`claude`) and Codex (`codex`) through `backend: "cli"`, but the GitHub Action does not install or authenticate those CLIs. In GitHub Actions, choose one of these patterns:
+
+1. **CodeAgora Action with API/GitHub Models reviewers** — recommended default for rc.6.
+2. **CodeAgora Action with CLI reviewers** — install and authenticate the CLI on the runner before running CodeAgora.
+3. **Companion agent workflow** — run Claude Code or Codex as a separate GitHub Action alongside CodeAgora.
+
+For Claude Code OAuth, use the official Claude Code Action. Generate the token locally with `claude setup-token`, save it as `CLAUDE_CODE_OAUTH_TOKEN`, then reference it from the workflow:
+
+```yaml
+name: Claude Companion Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this PR for correctness, security, API contract issues,
+            and maintainability risks. Keep findings concise.
+          claude_args: |
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"
+```
+
+This is separate from CodeAgora's reviewer config. CodeAgora still owns its consensus verdict, session artifacts, and stable Action outputs; Claude Code or Codex can provide an additional agentic review/commenting lane.
+
+Fork PRs cannot read repository secrets such as `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY`. Keep the same fork guard pattern used for CodeAgora before running companion agent workflows.
+
 ## Action inputs
 
 | Input | Default | Description |
@@ -232,6 +280,18 @@ Then add this condition to later steps:
 ```yaml
 if: steps.fork-check.outputs.skip != 'true'
 ```
+
+When CodeAgora itself reports a degraded/skipped run, use the `degraded-reason` output and the logs together:
+
+- `missing-github-token`: pass `github-token` or disable posting
+- `missing-provider-secrets`: add the provider secret or switch to GitHub Models
+- `fork-missing-provider-secrets`: use a same-repository PR or a fork gate
+- `posting-disabled`: set `post-results: 'true'`
+- `diff-too-large`: lower the PR size, raise `max-diff-lines`, or split the PR
+- `config-load-failed`: fix `.ca/config.json` or `config-path`
+- `stale-head-sha`: rerun on the updated commit SHA
+- `github-post-failed`: check permissions/token scopes and rerun
+- `sarif-write-failed`: use a writable SARIF path or export SARIF elsewhere
 
 ## Choosing `max-diff-lines`
 

--- a/docs/for-users/PROVIDERS.md
+++ b/docs/for-users/PROVIDERS.md
@@ -73,3 +73,19 @@ agora providers
 ```
 
 `agora init` auto-detects installed CLI tools and available API keys.
+
+## CLI Backends in GitHub Actions
+
+CLI backends such as Claude Code (`claude`) and Codex (`codex`) can run in CI, but CodeAgora does not install or authenticate those CLIs for you. If `.ca/config.json` uses `"backend": "cli"`, install and authenticate the matching CLI before running CodeAgora.
+
+For OAuth-based Claude Code automation in GitHub Actions, use the official Claude Code Action as a companion workflow or step. Its OAuth token is passed to that action, not to CodeAgora directly:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    prompt: |
+      Review this PR for correctness, security, and maintainability risks.
+```
+
+Use CodeAgora's CLI backend path when the runner already has the CLI installed and authenticated. Use the companion action path when you want Claude Code's own GitHub Action behavior, OAuth handling, tools, and PR automation.

--- a/docs/for-users/PROVIDERS.md
+++ b/docs/for-users/PROVIDERS.md
@@ -76,7 +76,7 @@ agora providers
 
 ## CLI Backends in GitHub Actions
 
-CLI backends such as Claude Code (`claude`) and Codex (`codex`) can run in CI, but CodeAgora does not install or authenticate those CLIs for you. If `.ca/config.json` uses `"backend": "cli"`, install and authenticate the matching CLI before running CodeAgora.
+CLI backends such as Claude Code (`"backend": "claude"`) and Codex (`"backend": "codex"`) can run in CI, but CodeAgora does not install or authenticate those CLIs for you. If `.ca/config.json` uses a concrete CLI backend, install and authenticate the matching CLI before running CodeAgora. If the same config keeps API-based moderator or supporter agents, keep those provider secrets configured too.
 
 For OAuth-based Claude Code automation in GitHub Actions, use the official Claude Code Action as a companion workflow or step. Its OAuth token is passed to that action, not to CodeAgora directly:
 

--- a/docs/for-users/TROUBLESHOOTING.md
+++ b/docs/for-users/TROUBLESHOOTING.md
@@ -85,6 +85,11 @@ The PR diff exceeds the configured limit (default: 5000 lines). Options:
 - `repo_path` is optional, but when provided it must point to a real directory inside the current repository checkout.
 - Symlinks and paths outside the repo are rejected on purpose so MCP tools do not read or write unrelated files.
 - If you only need the current workspace, omit `repo_path` and let the server use its current working directory.
+- When reviewing another target repository inside the server cwd or detected git boundary, pass the exact repository root, for example `{ "repo_path": "/absolute/path/to/repository", "staged": true }`.
+
+### "Either diff or staged=true is required"
+- Pass a unified diff string in `diff`, or stage files and retry with `{ "staged": true }`.
+- If the MCP client is already opened in the target repo, omit `repo_path`; otherwise include the exact repository root only when it is inside the server cwd or detected git boundary.
 
 ## Exit Codes
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -90,7 +90,7 @@ export async function runDoctor(baseDir: string): Promise<DoctorResult> {
   checks.push({
     name: '.ca/ directory',
     status: caExists ? 'pass' : 'fail',
-    message: caExists ? `.ca/ directory found` : `.ca/ directory missing — run 'agora init' to set up`,
+    message: caExists ? `.ca/ directory found` : `.ca/ directory missing — next: run 'agora init'`,
   });
 
   // 3. Config file existence
@@ -118,7 +118,7 @@ export async function runDoctor(baseDir: string): Promise<DoctorResult> {
     status: configExists ? 'pass' : 'fail',
     message: configExists
       ? `Config: ${configFile}`
-      : `Config file not found in .ca/ — run 'init' to create one`,
+      : `Config file not found in .ca/ — next: run 'agora init'`,
   });
 
   // 4. Config validity (only if config exists)
@@ -132,7 +132,7 @@ export async function runDoctor(baseDir: string): Promise<DoctorResult> {
         checks.push({
           name: 'Config validity',
           status: 'fail',
-          message: `Config errors: ${validation.errors.join('; ')}`,
+          message: `Config errors in ${configFile}: ${validation.errors.join('; ')} — next: fix these fields or rerun 'agora init --force'`,
         });
       } else {
         checks.push({
@@ -143,7 +143,11 @@ export async function runDoctor(baseDir: string): Promise<DoctorResult> {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      checks.push({ name: 'Config validity', status: 'fail', message: `Config load failed: ${msg}` });
+      checks.push({
+        name: 'Config validity',
+        status: 'fail',
+        message: `Config load failed for ${configFile}: ${msg} — next: fix syntax or rerun 'agora init --force'`,
+      });
     }
   }
 
@@ -157,7 +161,7 @@ export async function runDoctor(baseDir: string): Promise<DoctorResult> {
     checks.push({
       name: `${envVarName}`,
       status: isSet ? 'pass' : 'warn',
-      message: isSet ? `${envVarName}: set` : `${envVarName}: missing`,
+      message: isSet ? `${envVarName}: set` : `${envVarName}: missing — set with 'export ${envVarName}=<your-key>' or run 'agora providers'`,
     });
   }
 
@@ -195,6 +199,7 @@ export { getProviderEnvVar } from '@codeagora/shared/providers/env-vars.js';
 // ============================================================================
 
 const LIVE_CHECK_TIMEOUT_MS = 10_000;
+const DEFAULT_SETUP_ENV_VAR = 'GROQ_API_KEY';
 
 /**
  * Collect unique provider+model pairs from all enabled agents in config.
@@ -315,19 +320,44 @@ export function formatLiveCheckReport(liveChecks: LiveCheckResult[]): string {
 
 export function formatDoctorReport(result: DoctorResult): string {
   const lines: string[] = [];
-  for (const check of result.checks) {
-    const icon =
-      check.status === 'pass'
-        ? statusColor.pass('✓')
-        : check.status === 'fail'
-        ? statusColor.fail('✗')
-        : statusColor.warn('!');
-    lines.push(`${icon} ${check.message}`);
-  }
+  const failed = result.checks.filter((check) => check.status === 'fail');
+  const warnings = result.checks.filter((check) => check.status === 'warn');
+  const passed = result.checks.filter((check) => check.status === 'pass');
+
+  const appendChecks = (title: string, checks: DoctorCheck[]): void => {
+    if (checks.length === 0) return;
+    if (lines.length > 0) lines.push('');
+    lines.push(title);
+    lines.push('─'.repeat(title.length));
+    for (const check of checks) {
+      const icon =
+        check.status === 'pass'
+          ? statusColor.pass('✓')
+          : check.status === 'fail'
+          ? statusColor.fail('✗')
+          : statusColor.warn('!');
+      lines.push(`${icon} ${check.message}`);
+    }
+  };
+
+  appendChecks('Blocking issues', failed);
+  appendChecks('Warnings', warnings);
+  appendChecks('Ready checks', passed);
+
   lines.push('');
   lines.push(
     `Summary: ${statusColor.pass(String(result.summary.pass))} passed, ${statusColor.fail(String(result.summary.fail))} failed, ${statusColor.warn(String(result.summary.warn))} warnings`
   );
+
+  const nextSteps = getDoctorNextSteps(result);
+  if (nextSteps.length > 0) {
+    lines.push('');
+    lines.push('Next steps');
+    lines.push('──────────');
+    nextSteps.forEach((step, index) => {
+      lines.push(`${index + 1}. ${step}`);
+    });
+  }
 
   if (result.liveChecks && result.liveChecks.length > 0) {
     lines.push('');
@@ -335,4 +365,42 @@ export function formatDoctorReport(result: DoctorResult): string {
   }
 
   return lines.join('\n');
+}
+
+function getDoctorNextSteps(result: DoctorResult): string[] {
+  const steps: string[] = [];
+  const hasMissingSetup = result.checks.some(
+    (check) =>
+      check.status === 'fail' &&
+      (check.name === '.ca/ directory' || check.name === 'Config file')
+  );
+  const hasConfigValidityFailure = result.checks.some(
+    (check) => check.status === 'fail' && check.name === 'Config validity'
+  );
+  const providerChecks = result.checks.filter(
+    (check) =>
+      check.name === check.name.toUpperCase() &&
+      (check.message === `${check.name}: set` || check.message.startsWith(`${check.name}: missing`))
+  );
+  const hasAnyProviderKey = providerChecks.some((check) => check.status === 'pass');
+
+  if (hasMissingSetup) {
+    steps.push('Create project config: agora init');
+  }
+  if (hasConfigValidityFailure) {
+    steps.push('Fix the config field(s) shown above, then run: agora doctor');
+  }
+  if (providerChecks.length > 0 && !hasAnyProviderKey) {
+    steps.push(
+      `Set at least one provider key, for example: export ${DEFAULT_SETUP_ENV_VAR}=<your-key>; then run: agora doctor`
+    );
+  }
+  if (steps.length === 0 && result.summary.warn > 0) {
+    steps.push('Review the warnings above, then run: agora review --dry-run <diff.patch>');
+  }
+  if (steps.length === 0 && result.summary.fail === 0) {
+    steps.push('Run a preflight review: agora review --dry-run <diff.patch>');
+  }
+
+  return steps;
 }

--- a/packages/cli/src/commands/register-init.ts
+++ b/packages/cli/src/commands/register-init.ts
@@ -6,7 +6,22 @@
 import type { Command } from 'commander';
 import path from 'path';
 import fs from 'fs/promises';
-import { runInit, runInitInteractive, UserCancelledError } from './init.js';
+import { runInit, runInitInteractive, UserCancelledError, type InitResult } from './init.js';
+
+function printInitNextSteps(result: InitResult): void {
+  if (result.created.length === 0 && result.skipped.length > 0) {
+    console.log('\nNext steps:');
+    console.log('  1. Reuse existing config, or rerun with --force to regenerate it.');
+    console.log('  2. Check setup: agora doctor');
+    console.log('  3. Preflight a review: agora review --dry-run <diff.patch>');
+    return;
+  }
+
+  console.log('\nNext steps:');
+  console.log('  1. Check setup: agora doctor');
+  console.log('  2. Preflight a review: agora review --dry-run <diff.patch>');
+  console.log('  3. Run your first review: git diff | agora review');
+}
 
 export function registerInitCommand(program: Command): void {
   program
@@ -35,6 +50,7 @@ export function registerInitCommand(program: Command): void {
           for (const f of result.skipped) console.log(`  skipped: ${f} (already exists, use --force to overwrite)`);
           for (const w of result.warnings) console.warn(`  warning: ${w}`);
           if (result.created.length > 0) console.log('CodeAgora initialized successfully.');
+          printInitNextSteps(result);
           if (options.ci && result.created.some(f => f.includes('codeagora-review.yml'))) {
             console.log('Created: .github/workflows/codeagora-review.yml');
             console.log('  Add GROQ_API_KEY to your repository secrets:');
@@ -54,13 +70,11 @@ export function registerInitCommand(program: Command): void {
             const configPath = path.join(caDir, format === 'yaml' ? 'config.yaml' : 'config.json');
             await fs.writeFile(configPath, JSON.stringify(config, null, 2));
             console.log(`\u2713 Config created with ${existing.name} (${existing.envVar} detected)`);
-            console.log(`\nRun your first review:`);
-            console.log(`  git diff | agora review`);
+            printInitNextSteps({ created: [configPath], skipped: [], warnings: [] });
             return;
           }
           await runInlineSetup(process.cwd());
-          console.log(`\nRun your first review:`);
-          console.log(`  git diff | agora review`);
+          printInitNextSteps({ created: [path.join(process.cwd(), '.ca')], skipped: [], warnings: [] });
           console.log(`\nFor full customization: agora init --advanced`);
           return;
         }
@@ -83,6 +97,7 @@ export function registerInitCommand(program: Command): void {
         for (const f of result.skipped) console.log(`  skipped: ${f} (already exists, use --force to overwrite)`);
         for (const w of result.warnings) console.warn(`  warning: ${w}`);
         if (result.created.length > 0) console.log('CodeAgora initialized successfully.');
+        printInitNextSteps(result);
         if (options.ci && result.created.some(f => f.includes('codeagora-review.yml'))) {
           console.log('Created: .github/workflows/codeagora-review.yml');
           console.log('  Add GROQ_API_KEY to your repository secrets:');

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -11,6 +11,7 @@ import fs from 'fs/promises';
 import ora from 'ora';
 import { runPipeline } from '@codeagora/core/pipeline/orchestrator.js';
 import { dryRun, formatDryRunText } from '@codeagora/core/pipeline/dryrun.js';
+import type { DryRunResult } from '@codeagora/core/pipeline/dryrun.js';
 import { loadConfig } from '@codeagora/core/config/loader.js';
 import { ProgressEmitter } from '@codeagora/core/pipeline/progress.js';
 import { parsePrUrl, createGitHubConfig, createOctokit, createAppOctokit, type GitHubConfig } from '@codeagora/github/client.js';
@@ -101,6 +102,12 @@ export function emitReviewStartupDiagnostics(
   if (diagnostics.repoPath) writeLine(`  Context lines: ${diagnostics.contextLines}`);
   else if (diagnostics.contextLines > 0) writeLine('  Context: disabled (not a git repo)');
   writeLine('---');
+}
+
+export function formatDryRunJson(report: DryRunResult): string {
+  const stableReport: Record<string, unknown> = { ...report };
+  delete stableReport['readiness'];
+  return JSON.stringify(stableReport, null, 2);
 }
 
 // ============================================================================
@@ -345,7 +352,7 @@ async function reviewAction(diffPath: string | undefined, options: ReviewOptions
       const report = await dryRun(config, diffContent);
 
       if (options.output === 'json') {
-        console.log(JSON.stringify(report, null, 2));
+        console.log(formatDryRunJson(report));
         return;
       }
       console.log(formatDryRunText(report));

--- a/packages/cli/src/formatters/review-output.ts
+++ b/packages/cli/src/formatters/review-output.ts
@@ -35,16 +35,22 @@ export interface FormatOptions {
  */
 export function formatText(result: PipelineResult, options?: FormatOptions): string {
   const lines: string[] = [];
+  const sessionPath = `.ca/sessions/${result.date}/${result.sessionId}/`;
 
   if (result.status === 'error') {
     lines.push(t('review.failed', { error: result.error ?? 'unknown error' }));
     lines.push(dim(`  ${t('review.session', { date: result.date, sessionId: result.sessionId })}`));
+    lines.push(dim(`  Session path: ${sessionPath}`));
+    lines.push(dim('  Degraded output'));
+    lines.push(dim('  Follow-up: agora sessions'));
     return lines.join('\n');
   }
 
   if (!result.summary) {
     lines.push(t('review.complete'));
     lines.push(`  ${t('review.session', { date: result.date, sessionId: result.sessionId })}`);
+    lines.push(dim(`  Session path: ${sessionPath}`));
+    lines.push(dim('  Follow-up: agora sessions'));
     return lines.join('\n');
   }
 
@@ -208,6 +214,12 @@ export function formatText(result: PipelineResult, options?: FormatOptions): str
 
   // ── Session footer ──
   lines.push(dim(`  Session ${result.date}/${result.sessionId}`));
+  lines.push(dim(`  Session path: ${sessionPath}`));
+  if (s.forfeitedReviewers > 0) {
+    lines.push(dim(`  Partial review: ${s.forfeitedReviewers} reviewer(s) forfeited`));
+  }
+  lines.push(dim('  Follow-up: agora sessions'));
+  lines.push(dim(`  Explain: agora explain ${result.date}/${result.sessionId}`));
 
   return lines.join('\n');
 }

--- a/packages/cli/src/tests/register-init.test.ts
+++ b/packages/cli/src/tests/register-init.test.ts
@@ -29,7 +29,7 @@ describe('registerInitCommand', () => {
       warnings: [],
     });
 
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const program = new Command();
     registerInitCommand(program);
@@ -45,6 +45,33 @@ describe('registerInitCommand', () => {
       preset: 'budget',
     });
     expect(runInitInteractive).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith('\nNext steps:');
+    expect(logSpy).toHaveBeenCalledWith('  1. Check setup: agora doctor');
+    expect(logSpy).toHaveBeenCalledWith('  2. Preflight a review: agora review --dry-run <diff.patch>');
+    expect(logSpy).toHaveBeenCalledWith('  3. Run your first review: git diff | agora review');
+  });
+
+  it('prints reuse guidance when init skips existing files', async () => {
+    vi.spyOn(init, 'runInit').mockResolvedValue({
+      created: [],
+      skipped: ['/tmp/.ca/config.json'],
+      warnings: [],
+    });
+    vi.spyOn(init, 'runInitInteractive').mockResolvedValue({
+      created: [],
+      skipped: [],
+      warnings: [],
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const program = new Command();
+    registerInitCommand(program);
+
+    await program.parseAsync(['node', 'agora', 'init', '--yes']);
+
+    expect(logSpy).toHaveBeenCalledWith('  1. Reuse existing config, or rerun with --force to regenerate it.');
+    expect(logSpy).toHaveBeenCalledWith('  2. Check setup: agora doctor');
+    expect(logSpy).toHaveBeenCalledWith('  3. Preflight a review: agora review --dry-run <diff.patch>');
   });
 
   it('builds schema-valid generated groq config for non-interactive init paths', () => {

--- a/packages/core/src/pipeline/dryrun.ts
+++ b/packages/core/src/pipeline/dryrun.ts
@@ -22,6 +22,11 @@ export type { TokenUsage };
 // ============================================================================
 
 export interface DryRunResult {
+  readiness?: {
+    classification: 'ready' | 'blocked' | 'risky';
+    reasons: string[];
+    nextActions: string[];
+  };
   diffMetadata?: ChunkMetadata;
   config: {
     reviewerCount: number;
@@ -209,6 +214,14 @@ export async function dryRun(config: Config, diffContent: string): Promise<DryRu
     }
   }
 
+  const readiness = computeDryRunReadiness({
+    diffContent,
+    diffMetadata: chunkResult.metadata,
+    reviewers,
+    health,
+    warnings,
+  });
+
   return {
     config: {
       reviewerCount: reviewers.length,
@@ -225,10 +238,55 @@ export async function dryRun(config: Config, diffContent: string): Promise<DryRu
       estimatedL3Cost: formatCost(l3Cost),
       totalEstimatedCost,
     },
+    readiness,
     health,
     diffMetadata: chunkResult.metadata,
     warnings,
   };
+}
+
+function computeDryRunReadiness(params: {
+  diffContent: string;
+  diffMetadata?: ChunkMetadata;
+  reviewers: DryRunResult['reviewers'];
+  health: DryRunResult['health'];
+  warnings: string[];
+}): NonNullable<DryRunResult['readiness']> {
+  const nextActions = new Set<string>();
+  const reasons: string[] = [];
+  const reviewableFiles = params.diffMetadata?.includedFiles ?? [];
+  const availableProviders = params.health.filter((h) => h.status === 'available');
+  const hasWarnings = params.warnings.length > 0;
+  const hasUnknownHealth = params.health.some((h) => h.status === 'unknown');
+  const hasNoApiKey = params.health.some((h) => h.status === 'no-api-key');
+  const hasAnyReviewers = params.reviewers.length > 0;
+
+  if (!params.diffContent.trim()) reasons.push('blocked: empty diff');
+  if (params.diffMetadata && reviewableFiles.length === 0) reasons.push('blocked: no reviewable files');
+  if (!hasAnyReviewers) reasons.push('blocked: no reviewers configured');
+  if (params.health.length > 0 && availableProviders.length === 0) reasons.push('blocked: no usable provider credentials');
+  if (hasUnknownHealth) reasons.push('blocked: provider health unavailable');
+  if (hasWarnings) reasons.push(...params.warnings.map((warning) => `warning: ${warning}`));
+
+  nextActions.add('agora doctor');
+  nextActions.add('agora review --staged');
+  if (params.diffContent.trim()) nextActions.add('agora review --quick <diff.patch>');
+  if (hasNoApiKey) {
+    for (const h of params.health) {
+      if (h.status === 'no-api-key') {
+        nextActions.add(`export ${getProviderEnvVar(h.provider) ?? h.provider}=<your-key> for ${h.provider}`);
+      }
+    }
+  }
+
+  const hasBlockers = reasons.some((reason) => reason.startsWith('blocked:'));
+  const classification = hasBlockers ? 'blocked' : hasWarnings ? 'risky' : 'ready';
+
+  return { classification, reasons, nextActions: [...nextActions] };
+}
+
+function getProviderEnvVar(provider: string): string | undefined {
+  return PROVIDER_ENV_VARS[provider];
 }
 
 // ============================================================================
@@ -329,6 +387,23 @@ export function formatDryRunText(result: DryRunResult): string {
     lines.push('Warnings:');
     for (const w of result.warnings) {
       lines.push(`  ⚠ ${w}`);
+    }
+  }
+
+  if (result.readiness) {
+    lines.push('');
+    lines.push(`Readiness: ${result.readiness.classification}`);
+    if (result.readiness.reasons.length > 0) {
+      lines.push('Reasons:');
+      for (const reason of result.readiness.reasons) {
+        lines.push(`  - ${reason}`);
+      }
+    }
+    if (result.readiness.nextActions.length > 0) {
+      lines.push('Next actions:');
+      for (const action of result.readiness.nextActions) {
+        lines.push(`  - ${action}`);
+      }
     }
   }
 

--- a/packages/core/src/pipeline/dryrun.ts
+++ b/packages/core/src/pipeline/dryrun.ts
@@ -12,7 +12,7 @@ import {
   isDeclarativeReviewers,
   expandDeclarativeReviewers,
 } from '../config/loader.js';
-import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
+import { PROVIDER_ENV_VARS, getProviderEnvVar as resolveProviderEnvVar } from '@codeagora/shared/providers/env-vars.js';
 import { chunkDiffWithMetadata, type ChunkMetadata } from './chunker.js';
 
 export type { TokenUsage };
@@ -184,7 +184,9 @@ export async function dryRun(config: Config, diffContent: string): Promise<DryRu
   for (const r of reviewers) {
     if (!r.isAuto && r.provider !== 'unknown') seenProviders.add(r.provider);
   }
-  seenProviders.add(modProvider);
+  if (config.moderator.backend === 'api' || config.moderator.provider) {
+    seenProviders.add(modProvider);
+  }
   for (const s of enabledSupporters) {
     if (s.provider) seenProviders.add(s.provider);
   }
@@ -256,8 +258,8 @@ function computeDryRunReadiness(params: {
   const reasons: string[] = [];
   const reviewableFiles = params.diffMetadata?.includedFiles ?? [];
   const availableProviders = params.health.filter((h) => h.status === 'available');
+  const unknownProviders = params.health.filter((h) => h.status === 'unknown');
   const hasWarnings = params.warnings.length > 0;
-  const hasUnknownHealth = params.health.some((h) => h.status === 'unknown');
   const hasNoApiKey = params.health.some((h) => h.status === 'no-api-key');
   const hasAnyReviewers = params.reviewers.length > 0;
 
@@ -265,28 +267,28 @@ function computeDryRunReadiness(params: {
   if (params.diffMetadata && reviewableFiles.length === 0) reasons.push('blocked: no reviewable files');
   if (!hasAnyReviewers) reasons.push('blocked: no reviewers configured');
   if (params.health.length > 0 && availableProviders.length === 0) reasons.push('blocked: no usable provider credentials');
-  if (hasUnknownHealth) reasons.push('blocked: provider health unavailable');
+  if (unknownProviders.length > 0) {
+    const unknownReason = `provider health unavailable for ${unknownProviders.map((h) => h.provider).join(', ')}`;
+    reasons.push(availableProviders.length === 0 ? `blocked: ${unknownReason}` : `warning: ${unknownReason}`);
+  }
   if (hasWarnings) reasons.push(...params.warnings.map((warning) => `warning: ${warning}`));
 
   nextActions.add('agora doctor');
   nextActions.add('agora review --staged');
   if (params.diffContent.trim()) nextActions.add('agora review --quick <diff.patch>');
-  if (hasNoApiKey) {
+  if (hasNoApiKey || unknownProviders.length > 0) {
     for (const h of params.health) {
-      if (h.status === 'no-api-key') {
-        nextActions.add(`export ${getProviderEnvVar(h.provider) ?? h.provider}=<your-key> for ${h.provider}`);
+      if (h.status === 'no-api-key' || h.status === 'unknown') {
+        nextActions.add(`export ${resolveProviderEnvVar(h.provider)}=<your-key> for ${h.provider}`);
       }
     }
   }
 
   const hasBlockers = reasons.some((reason) => reason.startsWith('blocked:'));
-  const classification = hasBlockers ? 'blocked' : hasWarnings ? 'risky' : 'ready';
+  const hasRiskWarnings = reasons.some((reason) => reason.startsWith('warning:'));
+  const classification = hasBlockers ? 'blocked' : hasRiskWarnings ? 'risky' : 'ready';
 
   return { classification, reasons, nextActions: [...nextActions] };
-}
-
-function getProviderEnvVar(provider: string): string | undefined {
-  return PROVIDER_ENV_VARS[provider];
 }
 
 // ============================================================================

--- a/packages/desktop/src/api/desktop-fallbacks.ts
+++ b/packages/desktop/src/api/desktop-fallbacks.ts
@@ -10,9 +10,84 @@ import type {
   ReviewRunSnapshot,
 } from './desktop-bridge.types.js';
 
+const demoTopIssues = [
+  {
+    severity: 'CRITICAL',
+    filePath: 'packages/mcp/src/tools/review-pr.ts',
+    lineRange: [73, 73] as [number, number],
+    title: 'PR diff fetch can hang without an explicit timeout',
+    confidence: 72,
+  },
+  {
+    severity: 'WARNING',
+    filePath: 'packages/cli/src/commands/review.ts',
+    lineRange: [264, 291] as [number, number],
+    title: 'Zero-config setup may create config in an unexpected working directory',
+    confidence: 64,
+  },
+  {
+    severity: 'CRITICAL',
+    filePath: 'packages/core/src/pipeline/dryrun.ts',
+    lineRange: [196, 196] as [number, number],
+    title: 'Dry-run provider health can be mistaken for live review readiness',
+    confidence: 47,
+  },
+  {
+    severity: 'SUGGESTION',
+    filePath: 'docs/for-users/TROUBLESHOOTING.md',
+    lineRange: [1, 1] as [number, number],
+    title: 'Add a short MCP dry-run example',
+    confidence: 38,
+  },
+];
+
+const demoSession: SessionSummary = {
+  id: '2026-06-04/007',
+  date: '2026-06-04',
+  sessionId: '007',
+  status: 'completed',
+  decision: 'NEEDS_HUMAN',
+  reasoning: 'One blocking concern was confirmed by multiple reviewers, and one low-confidence critical finding needs human verification before merge.',
+  severityCounts: { HARSHLY_CRITICAL: 0, CRITICAL: 2, WARNING: 1, SUGGESTION: 1 },
+  topIssues: demoTopIssues.slice(0, 3),
+  updatedAt: '2026-06-04T12:00:00.000Z',
+};
+
+function demoSessionDetail(): SessionDetail {
+  return {
+    ...demoSession,
+    findings: demoTopIssues,
+    evidenceCount: 4,
+    discussionsCount: 2,
+    costSummary: {
+      known: true,
+      formattedTotalCost: '$0.1088',
+      totalCost: 0.1088,
+      callCount: 6,
+      totalTokens: 249744,
+      source: 'demo-result',
+    },
+    markdown: [
+      '# Review 2026-06-04/007',
+      '',
+      'Decision: NEEDS_HUMAN',
+      '',
+      demoSession.reasoning ?? '',
+      '',
+      '## Findings',
+      '',
+      '- [CRITICAL] packages/mcp/src/tools/review-pr.ts:73 — PR diff fetch can hang without an explicit timeout (72%)',
+      '- [WARNING] packages/cli/src/commands/review.ts:264 — Zero-config setup may create config in an unexpected working directory (64%)',
+      '- [CRITICAL] packages/core/src/pipeline/dryrun.ts:196 — Dry-run provider health can be mistaken for live review readiness (47%)',
+      '- [SUGGESTION] docs/for-users/TROUBLESHOOTING.md:1 — Add a short MCP dry-run example (38%)',
+    ].join('\n'),
+  };
+}
+
 /** Stub session data used when running outside Tauri context. */
 export function fallbackSessions(): SessionSummary[] {
   return [
+    demoSession,
     {
       id: '2026-04-27/001',
       date: '2026-04-27',
@@ -47,6 +122,7 @@ export function fallbackSessions(): SessionSummary[] {
 }
 
 export function fallbackSessionDetail(id: string, sessions: SessionSummary[]): SessionDetail {
+  if (id === demoSession.id) return demoSessionDetail();
   const session = sessions.find((item) => item.id === id) ?? sessions[0]!;
   return {
     ...session,

--- a/packages/github/src/action-policy.ts
+++ b/packages/github/src/action-policy.ts
@@ -140,6 +140,20 @@ export function isStaleHead(expectedHeadSha: string, currentHeadSha: string | un
   return Boolean(currentHeadSha && currentHeadSha !== expectedHeadSha);
 }
 
+export function formatActionWarning(reason: string, nextStep: string, context?: string): string {
+  const parts = [`CodeAgora ${reason}`];
+  if (context) parts.push(`Context: ${context}`);
+  parts.push(`Next step: ${nextStep}`);
+  return `::warning::${escapeWorkflowCommandMessage(parts.join(' | '))}`;
+}
+
+function escapeWorkflowCommandMessage(message: string): string {
+  return message
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A');
+}
+
 export async function validateActionDiffPath(
   diffPath: string,
   workspaceRoot: string = process.cwd(),

--- a/packages/github/src/action.ts
+++ b/packages/github/src/action.ts
@@ -18,7 +18,7 @@ import { createAppOctokit } from './client.js';
 import { fetchPrMetadata } from './pr-diff.js';
 import { buildSarifReport, serializeSarif } from './sarif.js';
 import { loadConfigFile } from '@codeagora/core/config/loader.js';
-import { determineActionPolicy, isStaleHead, parseActionInputs, validateActionDiffPath, validateActionOutputPath } from './action-policy.js';
+import { determineActionPolicy, formatActionWarning, isStaleHead, parseActionInputs, validateActionDiffPath, validateActionOutputPath } from './action-policy.js';
 import type { ActionDegradedReason } from '@codeagora/shared/contracts/stable.js';
 
 // ============================================================================
@@ -47,7 +47,11 @@ async function main(): Promise<void> {
   }
 
   if (!actionPolicy.shouldRunReview) {
-    console.log(`::warning::CodeAgora review skipped: ${actionPolicy.degradedReason ?? 'degraded'}`);
+    console.log(formatActionWarning(
+      actionPolicy.degradedReason ?? 'degraded',
+      getActionNextStep(actionPolicy.degradedReason ?? 'degraded'),
+      getActionContext(actionPolicy.degradedReason ?? 'degraded', inputs),
+    ));
     setActionOutput('verdict', actionPolicy.verdictOverride ?? 'SKIPPED');
     return;
   }
@@ -57,7 +61,11 @@ async function main(): Promise<void> {
     const diffContent = await fs.readFile(safeDiffPath, 'utf-8');
     const lineCount = diffContent.split('\n').length;
     if (lineCount > inputs.maxDiffLines) {
-      console.log(`::warning::Diff has ${lineCount} lines (limit: ${inputs.maxDiffLines}). Skipping review.`);
+      console.log(formatActionWarning(
+        'diff-too-large',
+        `Reduce the PR size or raise max-diff-lines if your reviewer/model can handle it.`,
+        `Diff lines=${lineCount}, limit=${inputs.maxDiffLines}`,
+      ));
       setActionDegraded('diff-too-large');
       setActionOutput('verdict', 'SKIPPED');
       return;
@@ -71,7 +79,11 @@ async function main(): Promise<void> {
   const configPath = inputs.configPath;
   const config = await loadConfigFile(configPath, { rootDir: process.cwd() }).catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
-    console.log(`::warning::Config load degraded: ${message}`);
+    console.log(formatActionWarning(
+      'config-load-failed',
+      `Fix the config path or file contents, then rerun the Action.`,
+      `configPath=${configPath}; ${redactActionMessage(message)}`,
+    ));
     setActionDegraded('config-load-failed');
     return null;
   });
@@ -143,7 +155,11 @@ async function main(): Promise<void> {
     console.log('::group::Posting review to GitHub');
     const currentPr = await fetchPrMetadata(ghConfig, inputs.pr, appKit ?? undefined);
     if (isStaleHead(inputs.sha, currentPr.headSha)) {
-      console.log(`::warning::PR head changed from ${inputs.sha} to ${currentPr.headSha}; skipping stale posting.`);
+      console.log(formatActionWarning(
+        'stale-head-sha',
+        'Rerun the workflow on the current PR HEAD SHA so comments and status target the latest commit.',
+        `expected=${inputs.sha}; current=${currentPr.headSha}`,
+      ));
       setActionDegraded('stale-head-sha');
       setActionOutput('verdict', 'SKIPPED');
       console.log('::endgroup::');
@@ -166,12 +182,20 @@ async function main(): Promise<void> {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      console.log(`::warning::GitHub posting degraded: ${message}`);
+      console.log(formatActionWarning(
+        'github-post-failed',
+        'Verify the token permissions and rerun; review computation completed but GitHub posting failed.',
+        redactActionMessage(message),
+      ));
       setActionDegraded('github-post-failed');
     }
     console.log('::endgroup::');
   } else {
-    console.log(`::warning::GitHub posting skipped: ${actionPolicy.degradedReason ?? 'posting-disabled'}`);
+    console.log(formatActionWarning(
+      actionPolicy.degradedReason ?? 'posting-disabled',
+      getActionNextStep(actionPolicy.degradedReason ?? 'posting-disabled'),
+      getActionContext(actionPolicy.degradedReason ?? 'posting-disabled', inputs),
+    ));
   }
 
   // Generate SARIF output — validate path to prevent traversal attacks
@@ -183,7 +207,11 @@ async function main(): Promise<void> {
     console.log(`SARIF report written to ${safeSarifPath}`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`::warning::SARIF output path rejected: ${message}`);
+    console.error(formatActionWarning(
+      'sarif-write-failed',
+      'Fix the SARIF path or permissions, then rerun if code scanning export is required.',
+      redactActionMessage(message),
+    ));
     setActionDegraded('sarif-write-failed');
   }
 
@@ -228,6 +256,50 @@ function setActionOutput(name: string, value: string): void {
 function setActionDegraded(reason: ActionDegradedReason): void {
   setActionOutput('degraded', 'true');
   setActionOutput('degraded-reason', reason);
+}
+
+function getActionContext(reason: string, inputs: { repo: string; pr: number; postResults: boolean }): string {
+  switch (reason) {
+    case 'missing-github-token':
+      return 'GITHUB_TOKEN was not provided to the Action.';
+    case 'missing-provider-secrets':
+      return 'No provider secret was available for the configured reviewers/supporters.';
+    case 'fork-missing-provider-secrets':
+      return `Fork PR ${inputs.repo}#${inputs.pr} cannot read repository secrets.`;
+    case 'posting-disabled':
+      return 'post-results=false disabled GitHub posting by configuration.';
+    default:
+      return `repo=${inputs.repo}; pr=${inputs.pr}`;
+  }
+}
+
+function getActionNextStep(reason: string): string {
+  switch (reason) {
+    case 'missing-github-token':
+      return 'Pass github-token (usually ${{ secrets.GITHUB_TOKEN }}) or disable posting explicitly.';
+    case 'missing-provider-secrets':
+      return 'Add the required provider secret(s) or switch the config to GitHub Models.';
+    case 'fork-missing-provider-secrets':
+      return 'Run on a same-repository PR, use GitHub Models, or gate fork PRs before CodeAgora.';
+    case 'posting-disabled':
+      return 'Set post-results=true if you want PR comments and status checks.';
+    case 'diff-too-large':
+      return 'Lower the diff size, raise max-diff-lines, or split the PR.';
+    case 'config-load-failed':
+      return 'Fix .ca/config.json or the configured config-path and rerun.';
+    case 'stale-head-sha':
+      return 'Rerun the workflow on the updated commit SHA.';
+    case 'github-post-failed':
+      return 'Check token scopes, branch protections, and permission warnings in the logs.';
+    case 'sarif-write-failed':
+      return 'Use a writable SARIF path or disable/export elsewhere in the workflow.';
+    default:
+      return 'Review the warning context and rerun after fixing the reported issue.';
+  }
+}
+
+function redactActionMessage(message: string): string {
+  return message.replace(/gh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]');
 }
 
 main().catch((err) => {

--- a/packages/github/src/poster.ts
+++ b/packages/github/src/poster.ts
@@ -45,6 +45,13 @@ function extractSeverityPriority(body: string): number {
   return 4; // unknown severity — lowest priority
 }
 
+function formatPostingWarning(reason: string, nextStep: string, context?: string): string {
+  const parts = [`[GitHub] ${reason}`];
+  if (context) parts.push(`context=${context}`);
+  parts.push(`next-step=${nextStep}`);
+  return parts.join(' | ');
+}
+
 /**
  * Check if an error is a 422 position/validation error.
  */
@@ -108,7 +115,11 @@ async function createReviewWithRateLimit(
     } catch (err: unknown) {
       if (is429Error(err) && attempt < MAX_RATE_LIMIT_RETRIES) {
         const delayMs = getRetryAfterMs(err) * (attempt + 1); // linear backoff multiplier
-        console.warn(`[GitHub] Rate limited (429). Retry ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES} after ${delayMs}ms`);
+        console.warn(formatPostingWarning(
+          'Rate limited (429) while posting review',
+          `Retrying automatically in ${delayMs}ms (${attempt + 1}/${MAX_RATE_LIMIT_RETRIES}).`,
+          'GitHub API temporarily rejected the request.',
+        ));
         await sleep(delayMs);
         continue;
       }
@@ -162,7 +173,11 @@ async function postReviewWithRetry(
     // restriction). Downgrade to COMMENT so the summary + inline findings
     // still land on the PR. Verdict still conveyed via the body.
     if (isApprovalPermissionError(err) && effectiveEvent === 'APPROVE') {
-      console.warn('[GitHub] GITHUB_TOKEN cannot approve PRs; downgrading APPROVE → COMMENT to preserve review body + inline comments.');
+      console.warn(formatPostingWarning(
+        'Approval permission blocked by GitHub Actions token',
+        'Keep the COMMENT fallback or use a token with approval permissions from a trusted context.',
+        'GitHub Actions tokens cannot submit APPROVE reviews on pull requests.',
+      ));
       effectiveEvent = 'COMMENT';
       try {
         const response = await createReviewWithRateLimit(kit, {
@@ -198,7 +213,11 @@ async function postReviewWithRetry(
       return response.data;
     }
 
-    console.warn(`[GitHub] 422 error with ${totalCount} inline comment(s). Retrying once without inline comments to avoid duplicate probe side effects.`);
+    console.warn(formatPostingWarning(
+      'GitHub rejected inline comment positions (422)',
+      'Rebase or refresh the diff; CodeAgora will post the summary without inline comments to avoid duplicates.',
+      `${totalCount} inline comment(s) could not be mapped to valid diff positions`,
+    ));
     const response = await createReviewWithRateLimit(kit, {
       owner: config.owner,
       repo: config.repo,
@@ -282,7 +301,12 @@ export async function postReview(
       issue_number: prNumber,
       body: comment.body,
     }).catch((err) => {
-      console.warn(`[GitHub] Failed to post file-level comment: ${err instanceof Error ? err.message : err}`);
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(formatPostingWarning(
+        'Failed to post a file-level PR comment',
+        'Check issue-comment permissions or rerun after resolving the GitHub API error.',
+        redactSecrets(message),
+      ));
     });
   }
 
@@ -329,7 +353,13 @@ export async function handleNeedsHuman(
       pull_number: prNumber,
       reviewers,
       team_reviewers: teams,
-    }).catch(() => { /* non-fatal: reviewers may not be collaborators */ });
+    }).catch(() => {
+      console.warn(formatPostingWarning(
+        'Could not request human reviewers',
+        'Add collaborators/teams or request reviewers manually.',
+        'Non-fatal permission or membership issue.',
+      ));
+    });
   }
 
   // Add label
@@ -339,7 +369,13 @@ export async function handleNeedsHuman(
     repo: config.repo,
     issue_number: prNumber,
     labels: [label],
-  }).catch(() => { /* non-fatal */ });
+  }).catch(() => {
+    console.warn(formatPostingWarning(
+      'Could not add the needs-human label',
+      'Add the label manually or grant issues:write permission.',
+      'Non-fatal label permission issue.',
+    ));
+  });
 }
 
 /**

--- a/packages/github/src/tests/github-poster.test.ts
+++ b/packages/github/src/tests/github-poster.test.ts
@@ -150,6 +150,7 @@ describe('postReview()', () => {
   it('falls back to summary-only review on 422 position error without duplicate probe reviews', async () => {
     const positionError = Object.assign(new Error('Unprocessable Entity'), { status: 422 });
     const octokit = makeOctokit();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // First call with inline comments → 422.
     // Second call posts the summary only. There are no successful probe reviews,
@@ -176,6 +177,9 @@ describe('postReview()', () => {
     const lastCall = octokit.pulls.createReview.mock.calls[octokit.pulls.createReview.mock.calls.length - 1][0];
     expect(lastCall.comments).toEqual([]);
     expect(lastCall.body).toContain('could not place 2 inline review comments');
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('GitHub rejected inline comment positions (422)');
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('Rebase or refresh the diff');
+    warnSpy.mockRestore();
   });
 
   it('throws for non-position API errors', async () => {
@@ -198,6 +202,7 @@ describe('postReview()', () => {
       { status: 422 },
     );
     const octokit = makeOctokit();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // First call (event=APPROVE) → 422 permission error
     // Second call (event=COMMENT downgrade) → success
@@ -224,6 +229,8 @@ describe('postReview()', () => {
     expect(secondCall.event).toBe('COMMENT');
     // Body + comments preserved
     expect(secondCall.body).toBe('Looks good.');
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('Approval permission blocked by GitHub Actions token');
+    warnSpy.mockRestore();
   });
 
   it('does NOT downgrade for unrelated 422 errors on APPROVE', async () => {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -82,9 +82,24 @@ Tool failures use MCP protocol `isError: true` with a structured JSON body:
 
 Stable error codes include `INVALID_INPUT`, `INVALID_REPO_PATH`, `REVIEW_FAILED`, `REVIEW_PR_FAILED`, `DRY_RUN_FAILED`, `CONFIG_GET_FAILED`, `CONFIG_SET_FAILED`, `EXPLAIN_SESSION_FAILED`, `LEADERBOARD_FAILED`, and `STATS_FAILED`.
 
+When reviewing the workspace where the MCP server was started, omit `repo_path`. When reviewing a target repo inside the server cwd or detected git boundary, pass the exact repository root:
+
+```json
+{
+  "diff": "diff --git a/src/app.ts b/src/app.ts\n...",
+  "repo_path": "/absolute/path/to/repository"
+}
+```
+
+If a review tool reports that no diff was provided, retry with either a unified diff string or `staged: true` after staging files:
+
+```json
+{ "staged": true }
+```
+
 ## Troubleshooting
 
 - If the server exits immediately, run `pnpm --filter @codeagora/mcp build` and confirm `packages/mcp/dist/index.js` exists.
 - If review tools return missing-provider errors, set the provider key for the configured reviewer backend.
-- If `repo_path` is rejected, pass a real directory inside the current repository boundary. Symlinks and paths outside the repo are intentionally rejected.
+- If `repo_path` is rejected, omit it for the current workspace or pass a repository root inside the server cwd/detected git boundary. Symlinks and paths outside the repository boundary are intentionally rejected.
 - If a client cannot find the command, use an absolute `node` path and an absolute `dist/index.js` path for local beta smoke.

--- a/packages/mcp/src/tests/tool-handlers.test.ts
+++ b/packages/mcp/src/tests/tool-handlers.test.ts
@@ -718,6 +718,35 @@ describe('review_quick handler', () => {
       code: 'INVALID_REPO_PATH',
     });
     expect(parsed.message).toContain('repo_path');
+    expect(parsed.details).toMatchObject({
+      next_steps: expect.arrayContaining([
+        'Omit repo_path when the MCP server already runs in the target workspace.',
+        'Pass the exact repository root directory only when it is inside the server cwd or detected git repository boundary.',
+      ]),
+    });
+    expect(runReviewCompact).not.toHaveBeenCalled();
+  });
+
+  it('returns retry guidance when diff and staged are both missing', async () => {
+    const { runReviewCompact } = await import('../helpers.js');
+    const { registerReviewQuick } = await import('../tools/review-quick.js');
+    const { server, getHandler } = createServerStub();
+    registerReviewQuick(server as never);
+
+    const result = await getHandler('review_quick')({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      status: 'error',
+      code: 'INVALID_INPUT',
+      details: {
+        next_steps: expect.arrayContaining([
+          'Pass unified diff text in the diff field.',
+          'Or set staged=true to review git staged changes.',
+        ]),
+      },
+    });
     expect(runReviewCompact).not.toHaveBeenCalled();
   });
 
@@ -759,6 +788,11 @@ describe('review_quick handler', () => {
         status: 'error',
         code: 'INVALID_REPO_PATH',
         message: 'repo_path must not be a symbolic link',
+      });
+      expect(parsed.details).toMatchObject({
+        next_steps: expect.arrayContaining([
+          'Keep repo_path inside the MCP server cwd or detected git repository root.',
+        ]),
       });
       expect(runReviewCompact).not.toHaveBeenCalled();
     } finally {

--- a/packages/mcp/src/tests/tools.test.ts
+++ b/packages/mcp/src/tests/tools.test.ts
@@ -109,6 +109,24 @@ describe('review_quick input schema', () => {
   });
 });
 
+describe('shared MCP review schema guidance', () => {
+  it('keeps repo_path optional and explains how IDE agents should use it', async () => {
+    const { reviewOptionsSchema, REPO_PATH_DESCRIPTION } = await import('@codeagora/mcp/tools/shared-schema.js');
+
+    expect(REPO_PATH_DESCRIPTION).toContain('Omit it when the MCP server already runs in the target repo');
+    expect(reviewOptionsSchema.repo_path.isOptional()).toBe(true);
+    expect(reviewOptionsSchema.repo_path.description).toContain('exact repository root');
+    expect(reviewOptionsSchema.repo_path.description).toContain('server cwd');
+  });
+
+  it('keeps output_format guidance tied to the stable agent contract', async () => {
+    const { reviewOptionsSchema } = await import('@codeagora/mcp/tools/shared-schema.js');
+
+    expect(reviewOptionsSchema.output_format.isOptional()).toBe(true);
+    expect(reviewOptionsSchema.output_format.description).toContain('codeagora.review.v1');
+  });
+});
+
 describe('review_full input schema', () => {
   const schema = z.object({ diff: z.string() });
 

--- a/packages/mcp/src/tools/config-get.ts
+++ b/packages/mcp/src/tools/config-get.ts
@@ -6,6 +6,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { errorMessage, mcpErrorResponse } from './shared-response.js';
 import { resolveRepoPathOrError } from './shared-response.js';
+import { REPO_PATH_DESCRIPTION } from './shared-schema.js';
 
 /**
  * Get a nested value from an object using dot notation.
@@ -27,10 +28,10 @@ function getNestedKey(obj: Record<string, unknown>, dotKey: string): unknown {
 export function registerConfigGet(server: McpServer): void {
   server.tool(
     'config_get',
-    'Read CodeAgora configuration. Returns full config or a specific value by dot-notation key.',
+    'Read CodeAgora configuration for an IDE/agent. Use to inspect the full active config or one dot-notation key before running review tools.',
     {
       key: z.string().optional().describe('Dot-notation key (e.g. "discussion.maxRounds"). Omit for full config.'),
-      repo_path: z.string().optional().describe('Repo root path for config lookup; must stay within the current repository boundary'),
+      repo_path: z.string().optional().describe(REPO_PATH_DESCRIPTION),
     },
     async ({ key, repo_path }) => {
       try {

--- a/packages/mcp/src/tools/config-set.ts
+++ b/packages/mcp/src/tools/config-set.ts
@@ -6,15 +6,16 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { errorMessage, mcpErrorResponse } from './shared-response.js';
 import { resolveRepoPathOrError } from './shared-response.js';
+import { REPO_PATH_DESCRIPTION } from './shared-schema.js';
 
 export function registerConfigSet(server: McpServer): void {
   server.tool(
     'config_set',
-    'Set a CodeAgora configuration value using dot-notation key. Validates against config schema.',
+    'Update a CodeAgora configuration value for the target workspace. Use only after config_get confirms the key; values are validated against the config schema.',
     {
       key: z.string().describe('Dot-notation key (e.g. "discussion.maxRounds")'),
       value: z.union([z.string(), z.number(), z.boolean()]).describe('Value to set'),
-      repo_path: z.string().optional().describe('Repo root path for config mutation; must stay within the current repository boundary'),
+      repo_path: z.string().optional().describe(REPO_PATH_DESCRIPTION),
     },
     async ({ key, value, repo_path }) => {
       try {

--- a/packages/mcp/src/tools/dry-run.ts
+++ b/packages/mcp/src/tools/dry-run.ts
@@ -10,14 +10,19 @@ import { errorMessage, mcpErrorResponse } from './shared-response.js';
 export function registerDryRun(server: McpServer): void {
   server.tool(
     'dry_run',
-    'Estimate review cost and complexity without making any LLM calls. Instant response.',
+    'Preflight a diff without making LLM calls. Use before review_quick/review_full to estimate complexity, files, line counts, security-sensitive paths, and approximate review cost.',
     {
-      diff: z.string().describe('Unified diff content'),
+      diff: z.string().describe('Unified diff content to preflight before running a review'),
     },
     async ({ diff }) => {
       try {
         if (diff.trim().length === 0) {
-          return mcpErrorResponse('INVALID_INPUT', 'diff must not be empty');
+          return mcpErrorResponse('INVALID_INPUT', 'diff must not be empty', {
+            next_steps: [
+              'Pass unified diff text in the diff field.',
+              'Use review_quick or review_full with staged=true for staged git changes.',
+            ],
+          });
         }
 
         const complexity = estimateDiffComplexity(diff);

--- a/packages/mcp/src/tools/explain.ts
+++ b/packages/mcp/src/tools/explain.ts
@@ -6,14 +6,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { explainSession } from '@codeagora/cli/commands/explain.js';
 import { errorMessage, mcpErrorResponse, resolveRepoPathOrError } from './shared-response.js';
+import { REPO_PATH_DESCRIPTION } from './shared-schema.js';
 
 export function registerExplain(server: McpServer): void {
   server.tool(
     'explain_session',
-    'Read session artifacts and produce a narrative summary of a past review. No LLM calls.',
+    'Explain a past CodeAgora review session from local artifacts. Use after review_quick/review_full or CLI runs when an IDE agent needs a narrative summary. No LLM calls.',
     {
       session: z.string().describe('Session path (e.g. 2026-03-19/001)'),
-      repo_path: z.string().optional().describe('Repo root path for session lookup; must stay within the current repository boundary'),
+      repo_path: z.string().optional().describe(REPO_PATH_DESCRIPTION),
     },
     async ({ session, repo_path }) => {
       try {

--- a/packages/mcp/src/tools/review-full.ts
+++ b/packages/mcp/src/tools/review-full.ts
@@ -12,9 +12,9 @@ import { errorMessage, mcpErrorResponse, resolveRepoPathOrError } from './shared
 export function registerReviewFull(server: McpServer): void {
   server.tool(
     'review_full',
-    'Thorough code review — multiple AI models review your diff, then debate disagreements to reach consensus (~30s). Returns verdict + issues with confidence scores + debate summary. More accurate than review_quick.',
+    'Thorough code review for final IDE/agent checks. Use when you have a unified diff or staged git changes and want the full L0→L1→L2→L3 pipeline with debate and final verdict. Returns compact JSON by default; set output_format=json for the versioned codeagora.review.v1 contract.',
     {
-      diff: z.string().optional().describe('Unified diff content (optional if staged=true)'),
+      diff: z.string().optional().describe('Unified diff content. Omit only when staged=true.'),
       ...reviewOptionsSchema,
       ...stagedSchema,
     },
@@ -27,7 +27,13 @@ export function registerReviewFull(server: McpServer): void {
 
         const diff = params.staged ? await getStagedDiff(repoPath.repoPath) : params.diff;
         if (!diff || diff.trim().length === 0) {
-          return mcpErrorResponse('INVALID_INPUT', 'Either diff or staged=true is required');
+          return mcpErrorResponse('INVALID_INPUT', 'Either diff or staged=true is required', {
+            next_steps: [
+              'Pass unified diff text in the diff field.',
+              'Or set staged=true to review git staged changes.',
+              'If staged changes are in a target repo inside the server boundary, pass repo_path as that repo root.',
+            ],
+          });
         }
 
         const options: ReviewOptions = {

--- a/packages/mcp/src/tools/review-pr.ts
+++ b/packages/mcp/src/tools/review-pr.ts
@@ -43,7 +43,7 @@ async function resolvePrUrl(prUrl?: string, prNumber?: number, repoPath?: string
 export function registerReviewPr(server: McpServer): void {
   server.tool(
     'review_pr',
-    'Review a GitHub PR — fetches the diff automatically and runs full multi-LLM review. Supports PR URL (https://github.com/owner/repo/pull/123) or just a PR number (auto-detects owner/repo from git remote). Can post results back as PR comments with --post_review.',
+    'Review a GitHub pull request by fetching its diff, then running the full multi-LLM review. Use pr_url for an explicit PR or pr_number with repo_path/current git remote for workspace-relative PRs. Can optionally post review comments when post_review=true.',
     {
       pr_url: z.string()
         .regex(
@@ -53,7 +53,7 @@ export function registerReviewPr(server: McpServer): void {
         .optional()
         .describe('GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)'),
       pr_number: z.number().int().positive().optional()
-        .describe('PR number (auto-detects owner/repo from git remote)'),
+        .describe('PR number. Requires repo_path or the server cwd to be a git repo with a GitHub origin remote.'),
       ...reviewOptionsSchema,
       ...postReviewSchema,
     },

--- a/packages/mcp/src/tools/review-quick.ts
+++ b/packages/mcp/src/tools/review-quick.ts
@@ -13,9 +13,9 @@ import { errorMessage, mcpErrorResponse, resolveRepoPathOrError } from './shared
 export function registerReviewQuick(server: McpServer): void {
   server.tool(
     'review_quick',
-    'Quick code review — 3 AI reviewers scan your diff in parallel (~10s). Returns verdict (ACCEPT/REJECT) + issues grouped as must-fix/verify/ignore with severity, confidence %, and file locations. No debate phase. Use for rapid feedback on small changes.',
+    'Quick code review for fast IDE feedback. Use when you have a unified diff or staged git changes and want a compact verdict without debate. Returns compact JSON with verdict plus must-fix/verify/ignore issues, severity, confidence, and file locations.',
     {
-      diff: z.string().optional().describe('Unified diff content (optional if staged=true)'),
+      diff: z.string().optional().describe('Unified diff content. Omit only when staged=true.'),
       ...reviewOptionsSchema,
       ...stagedSchema,
     },
@@ -28,7 +28,13 @@ export function registerReviewQuick(server: McpServer): void {
 
         const diff = params.staged ? await getStagedDiff(repoPath.repoPath) : params.diff;
         if (!diff || diff.trim().length === 0) {
-          return mcpErrorResponse('INVALID_INPUT', 'Either diff or staged=true is required');
+          return mcpErrorResponse('INVALID_INPUT', 'Either diff or staged=true is required', {
+            next_steps: [
+              'Pass unified diff text in the diff field.',
+              'Or set staged=true to review git staged changes.',
+              'If staged changes are in a target repo inside the server boundary, pass repo_path as that repo root.',
+            ],
+          });
         }
 
         const options: ReviewOptions = {

--- a/packages/mcp/src/tools/shared-response.ts
+++ b/packages/mcp/src/tools/shared-response.ts
@@ -11,6 +11,12 @@ import { redactDeep } from '@codeagora/shared/utils/redaction.js';
 
 const execFile = promisify(execFileCb);
 
+const REPO_PATH_NEXT_STEPS = [
+  'Omit repo_path when the MCP server already runs in the target workspace.',
+  'Pass the exact repository root directory only when it is inside the server cwd or detected git repository boundary.',
+  'Keep repo_path inside the MCP server cwd or detected git repository root.',
+];
+
 export interface McpStructuredError {
   status: 'error';
   code: string;
@@ -56,6 +62,14 @@ export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function repoPathErrorDetails(repoPath: string, details: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    repoPath,
+    ...details,
+    next_steps: REPO_PATH_NEXT_STEPS,
+  };
+}
+
 async function getRepoRoot(): Promise<string | undefined> {
   try {
     const { stdout } = await execFile('git', ['rev-parse', '--show-toplevel']);
@@ -86,8 +100,7 @@ export async function validateRepoPathOption(repoPath: string | undefined): Prom
     return {
       ok: false,
       error: createStructuredError('INVALID_REPO_PATH', 'repo_path is outside the allowed repository boundary', {
-        repoPath,
-        reason: validation.error,
+        ...repoPathErrorDetails(repoPath, { reason: validation.error }),
       }),
     };
   }
@@ -98,8 +111,7 @@ export async function validateRepoPathOption(repoPath: string | undefined): Prom
       return {
         ok: false,
         error: createStructuredError('INVALID_REPO_PATH', 'repo_path must not be a symbolic link', {
-          repoPath,
-          resolvedPath: validation.data,
+          ...repoPathErrorDetails(repoPath, { resolvedPath: validation.data }),
         }),
       };
     }
@@ -108,8 +120,7 @@ export async function validateRepoPathOption(repoPath: string | undefined): Prom
       return {
         ok: false,
         error: createStructuredError('INVALID_REPO_PATH', 'repo_path must reference an accessible directory', {
-          repoPath,
-          resolvedPath: validation.data,
+          ...repoPathErrorDetails(repoPath, { resolvedPath: validation.data }),
         }),
       };
     }
@@ -123,9 +134,7 @@ export async function validateRepoPathOption(repoPath: string | undefined): Prom
       return {
         ok: false,
         error: createStructuredError('INVALID_REPO_PATH', 'repo_path is outside the allowed repository boundary', {
-          repoPath,
-          resolvedPath: validation.data,
-          realPath: realRepoPath,
+          ...repoPathErrorDetails(repoPath, { resolvedPath: validation.data, realPath: realRepoPath }),
         }),
       };
     }
@@ -135,9 +144,7 @@ export async function validateRepoPathOption(repoPath: string | undefined): Prom
     return {
       ok: false,
       error: createStructuredError('INVALID_REPO_PATH', 'repo_path must reference an accessible directory', {
-        repoPath,
-        resolvedPath: validation.data,
-        reason: errorMessage(error),
+        ...repoPathErrorDetails(repoPath, { resolvedPath: validation.data, reason: errorMessage(error) }),
       }),
     };
   }

--- a/packages/mcp/src/tools/shared-schema.ts
+++ b/packages/mcp/src/tools/shared-schema.ts
@@ -5,19 +5,22 @@
 
 import { z } from 'zod';
 
+export const REPO_PATH_DESCRIPTION =
+  'Optional workspace root for this tool. Omit it when the MCP server already runs in the target repo; otherwise pass the exact repository root inside the server cwd or detected git repository boundary.';
+
 /**
  * Common optional parameters for review tools.
  * All fields mirror CLI review flags mapped to PipelineInput.
  */
 export const reviewOptionsSchema = {
-  provider: z.string().optional().describe('Override LLM provider for all reviewers'),
-  model: z.string().optional().describe('Override LLM model for all reviewers'),
+  provider: z.string().optional().describe('Override LLM provider for this review call only'),
+  model: z.string().optional().describe('Override LLM model for this review call only'),
   timeout_seconds: z.number().positive().optional().describe('Pipeline-wide timeout in seconds'),
   reviewer_timeout_seconds: z.number().positive().optional().describe('Per-reviewer timeout in seconds'),
   reviewer_count: z.number().min(1).max(10).optional().describe('Number of reviewers (1-10)'),
   reviewer_names: z.array(z.string()).optional().describe('Specific reviewer IDs to use (e.g. ["r1", "r2"])'),
   no_cache: z.boolean().optional().describe('Skip result caching, always run fresh'),
-  repo_path: z.string().optional().describe('Git repo root path for surrounding code context; explicit paths must stay within the server cwd/repository root'),
+  repo_path: z.string().optional().describe(REPO_PATH_DESCRIPTION),
   context_lines: z.number().min(0).optional().describe('Context lines around changes (default 20, 0 = disabled)'),
   output_format: z.enum(['compact', 'text', 'json', 'md', 'github', 'html', 'junit', 'sarif']).optional()
     .describe('Result format (default: compact; json returns the versioned codeagora.review.v1 agent contract)'),
@@ -27,7 +30,7 @@ export const reviewOptionsSchema = {
  * Schema for staged diff support (review_quick, review_full).
  */
 export const stagedSchema = {
-  staged: z.boolean().optional().describe('Review git staged changes instead of diff input'),
+  staged: z.boolean().optional().describe('Review git staged changes instead of passing diff. Use repo_path only for a target repository inside the server cwd or detected git repository boundary.'),
 };
 
 /**

--- a/packages/mcp/src/tools/stats.ts
+++ b/packages/mcp/src/tools/stats.ts
@@ -6,13 +6,14 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getSessionStats, formatSessionStats } from '@codeagora/core/session/queries.js';
 import { errorMessage, mcpErrorResponse, resolveRepoPathOrError } from './shared-response.js';
+import { REPO_PATH_DESCRIPTION } from './shared-schema.js';
 
 export function registerStats(server: McpServer): void {
   server.tool(
     'get_stats',
-    'Show aggregate review session statistics. No LLM calls.',
+    'Show aggregate local review session statistics for the target workspace. Use to audit recent CodeAgora activity, success rates, and historical metrics. No LLM calls.',
     {
-      repo_path: z.string().optional().describe('Repo root path for session stats; must stay within the current repository boundary'),
+      repo_path: z.string().optional().describe(REPO_PATH_DESCRIPTION),
     },
     async ({ repo_path }) => {
       try {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -44,11 +44,11 @@
   "sessions.stats": "Total: {total} | Success rate: {rate}%",
 
   "error.configNotFound": "Config file not found.",
-  "error.configHint": "Run 'agora init' to create a config file.",
-  "error.apiKeyHint": "Check 'agora providers' for required API keys.",
-  "error.doctorHint": "Run 'agora doctor' to check your setup.",
-  "error.pathHint": "Check the file path and try again.",
-  "error.syntaxHint": "Check your config file syntax.",
+  "error.configHint": "Run 'agora init' to create a config file, then run 'agora doctor'.",
+  "error.apiKeyHint": "Run 'agora providers' to see required API keys, then export the matching *_API_KEY value.",
+  "error.doctorHint": "Run 'agora doctor' to check setup and get the next command.",
+  "error.pathHint": "Check the file path and try again, or use 'git diff | agora review'.",
+  "error.syntaxHint": "Check your config file syntax, then run 'agora doctor'.",
 
   "statusbar.home": "↑↓: navigate | Enter: select | q: quit",
   "statusbar.reviewSetup": "Enter: next | Esc: back | q: home",

--- a/packages/shared/src/i18n/locales/ko.json
+++ b/packages/shared/src/i18n/locales/ko.json
@@ -44,11 +44,11 @@
   "sessions.stats": "전체: {total}개 | 성공률: {rate}%",
 
   "error.configNotFound": "설정 파일을 찾을 수 없습니다.",
-  "error.configHint": "'agora init'으로 설정 파일을 생성하세요.",
-  "error.apiKeyHint": "'agora providers'에서 필요한 API 키를 확인하세요.",
-  "error.doctorHint": "'agora doctor'로 환경을 점검하세요.",
-  "error.pathHint": "파일 경로를 확인하고 다시 시도하세요.",
-  "error.syntaxHint": "설정 파일 문법을 확인하세요.",
+  "error.configHint": "'agora init'으로 설정 파일을 만든 뒤 'agora doctor'를 실행하세요.",
+  "error.apiKeyHint": "'agora providers'로 필요한 API 키를 확인한 뒤 해당 *_API_KEY 값을 export 하세요.",
+  "error.doctorHint": "'agora doctor'로 설정을 점검하고 다음 명령을 확인하세요.",
+  "error.pathHint": "파일 경로를 확인하고 다시 시도하거나 'git diff | agora review'를 사용하세요.",
+  "error.syntaxHint": "설정 파일 문법을 확인한 뒤 'agora doctor'를 실행하세요.",
 
   "statusbar.home": "↑↓: 이동 | Enter: 선택 | q: 종료",
   "statusbar.reviewSetup": "Enter: 다음 | Esc: 뒤로 | q: 홈",

--- a/src/tests/cli-commands.test.ts
+++ b/src/tests/cli-commands.test.ts
@@ -10,8 +10,47 @@ import path from 'path';
 import { runInit, generateReviewIgnore } from '@codeagora/cli/commands/init.js';
 import { runDoctor, formatDoctorReport } from '@codeagora/cli/commands/doctor.js';
 import { listProviders, formatProviderList } from '@codeagora/cli/commands/providers.js';
+import { formatDryRunJson } from '@codeagora/cli/commands/review.js';
+import { buildDefaultConfig } from '@codeagora/core/config/loader.js';
 
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('formatDryRunJson()', () => {
+  it('preserves stable dry-run JSON without text-only readiness guidance', () => {
+    const json = formatDryRunJson({
+      readiness: {
+        classification: 'ready',
+        reasons: [],
+        nextActions: ['agora review --staged'],
+      },
+      config: {
+        reviewerCount: 1,
+        supporterCount: 0,
+        maxDiscussionRounds: 0,
+      },
+      reviewers: [],
+      estimation: {
+        estimatedL1Tokens: 0,
+        estimatedL1Cost: 'N/A',
+        estimatedL2Tokens: 0,
+        estimatedL2Cost: 'N/A',
+        estimatedL3Tokens: 0,
+        estimatedL3Cost: 'N/A',
+        totalEstimatedCost: 'N/A',
+      },
+      health: [],
+      warnings: [],
+    });
+
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('readiness');
+    expect(parsed).toHaveProperty('config');
+    expect(parsed).toHaveProperty('reviewers');
+    expect(parsed).toHaveProperty('estimation');
+    expect(parsed).toHaveProperty('health');
+    expect(parsed).toHaveProperty('warnings');
+  });
+});
 
 // ============================================================================
 // init
@@ -145,6 +184,27 @@ describe('runDoctor()', () => {
     const configCheck = result.checks.find((c) => c.name === 'Config file');
     expect(configCheck).toBeDefined();
     expect(configCheck!.status).toBe('fail');
+    expect(configCheck!.message).toContain('agora init');
+  });
+
+  it('reports invalid config with config path and remediation', async () => {
+    await fs.mkdir(path.join(tmpDir, '.ca'), { recursive: true });
+    const invalidConfig = buildDefaultConfig('groq');
+    delete (invalidConfig.moderator as { provider?: string }).provider;
+    await fs.writeFile(
+      path.join(tmpDir, '.ca', 'config.json'),
+      JSON.stringify(invalidConfig, null, 2),
+      'utf-8'
+    );
+
+    const result = await runDoctor(tmpDir);
+    const validityCheck = result.checks.find((c) => c.name === 'Config validity');
+
+    expect(validityCheck).toBeDefined();
+    expect(validityCheck!.status).toBe('fail');
+    expect(validityCheck!.message).toContain('.ca/config.json');
+    expect(validityCheck!.message).toContain('provider is required');
+    expect(validityCheck!.message).toContain('agora init --force');
   });
 
   it('reports config as pass when valid config.json exists', async () => {
@@ -204,6 +264,26 @@ describe('formatDoctorReport()', () => {
     expect(report).toContain('1 passed');
     expect(report).toContain('1 failed');
     expect(report).toContain('1 warnings');
+  });
+
+  it('groups checks and includes actionable next steps for missing setup', () => {
+    const result = {
+      checks: [
+        { name: 'Node.js version', status: 'pass' as const, message: 'Node.js v25.0.0' },
+        { name: '.ca/ directory', status: 'fail' as const, message: ".ca/ directory missing — next: run 'agora init'" },
+        { name: 'GROQ_API_KEY', status: 'warn' as const, message: "GROQ_API_KEY: missing — set with 'export GROQ_API_KEY=<your-key>' or run 'agora providers'" },
+      ],
+      summary: { pass: 1, fail: 1, warn: 1 },
+    };
+
+    const report = stripAnsi(formatDoctorReport(result));
+
+    expect(report).toContain('Blocking issues');
+    expect(report).toContain('Warnings');
+    expect(report).toContain('Ready checks');
+    expect(report).toContain('Next steps');
+    expect(report).toContain('Create project config: agora init');
+    expect(report).toContain('export GROQ_API_KEY=<your-key>');
   });
 });
 

--- a/src/tests/cli-error-handling.test.ts
+++ b/src/tests/cli-error-handling.test.ts
@@ -14,6 +14,7 @@ describe('formatError() hint matching', () => {
     const output = formatError(new Error('Config file not found at .ca/config.json'), false);
     expect(output).toContain('Hint:');
     expect(output).toContain('agora init');
+    expect(output).toContain('agora doctor');
   });
 
   it('shows config hint for config.json reference', () => {
@@ -25,6 +26,7 @@ describe('formatError() hint matching', () => {
     const output = formatError(new Error('Invalid API key provided'), false);
     expect(output).toContain('Hint:');
     expect(output).toContain('agora providers');
+    expect(output).toContain('*_API_KEY');
   });
 
   it('shows API key hint for API_KEY env var issues', () => {
@@ -58,6 +60,7 @@ describe('formatError() hint matching', () => {
     const output = formatError(new Error('Unexpected token in JSON'), false);
     expect(output).toContain('Hint:');
     expect(output).toContain('config file syntax');
+    expect(output).toContain('agora doctor');
   });
 
   it('shows syntax hint for YAML parse error', () => {

--- a/src/tests/desktop-bridge.test.ts
+++ b/src/tests/desktop-bridge.test.ts
@@ -64,7 +64,7 @@ describe('desktop bridge browser fallback contract', () => {
     const bridge = await importBridge();
 
     const sessions = await bridge.listSessions();
-    expect(sessions).toHaveLength(2);
+    expect(sessions).toHaveLength(3);
     expect(sessions[0]).toMatchObject({
       id: expect.any(String),
       status: expect.any(String),

--- a/src/tests/github-action-parse-args.test.ts
+++ b/src/tests/github-action-parse-args.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import { describe, it, expect } from 'vitest';
 import { ACTION_DEGRADED_REASONS } from '@codeagora/shared/contracts/stable.js';
 import {
+  formatActionWarning,
   determineActionPolicy,
   hasProviderCredentials,
   isForkContext,
@@ -98,6 +99,20 @@ describe('github-action parseActionInputs', () => {
   it('defaults configPath to .ca/config.json if neither CLI arg nor env present', () => {
     const result = parseActionInputs(validArgv, env({ GITHUB_TOKEN: TOKEN }));
     expect(result.configPath).toBe('.ca/config.json');
+  });
+
+  it('formats actionable action warnings with reason, context, and next step', () => {
+    const warning = formatActionWarning('missing-provider-secrets', 'Add the required provider secret(s) or switch the config to GitHub Models.', 'No provider secret was available.');
+
+    expect(warning).toContain('::warning::CodeAgora missing-provider-secrets');
+    expect(warning).toContain('Context: No provider secret was available.');
+    expect(warning).toContain('Next step: Add the required provider secret(s) or switch the config to GitHub Models.');
+  });
+
+  it('escapes workflow command control characters in action warnings', () => {
+    const warning = formatActionWarning('github-post-failed', 'Retry after fixing permissions.', 'line one\nline two with 100% value');
+
+    expect(warning).toContain('line one%0Aline two with 100%25 value');
   });
 });
 

--- a/src/tests/pipeline-dryrun.test.ts
+++ b/src/tests/pipeline-dryrun.test.ts
@@ -254,6 +254,59 @@ describe('dryRun', () => {
     expect(result.config.maxDiscussionRounds).toBe(3);
   });
 
+  it('adds readiness data for a healthy diff', async () => {
+    process.env.GROQ_API_KEY = 'test-key';
+    process.env.GOOGLE_API_KEY = 'test-key';
+    process.env.MISTRAL_API_KEY = 'test-key';
+
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
+
+    expect(result.readiness).toEqual(expect.objectContaining({
+      classification: 'ready',
+      reasons: [],
+    }));
+    expect(result.readiness?.nextActions).toEqual(expect.arrayContaining([
+      'agora doctor',
+      'agora review --staged',
+      'agora review --quick <diff.patch>',
+    ]));
+  });
+
+  it('marks empty diffs as blocked with next actions', async () => {
+    const result = await dryRun(makeConfig(), '');
+
+    expect(result.readiness?.classification).toBe('blocked');
+    expect(result.readiness?.reasons).toEqual(expect.arrayContaining(['blocked: empty diff']));
+    expect(result.readiness?.nextActions).toEqual(expect.arrayContaining([
+      'agora doctor',
+      'agora review --staged',
+    ]));
+  });
+
+  it('marks missing credentials as blocked and adds env guidance', async () => {
+    delete process.env.GROQ_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.MISTRAL_API_KEY;
+
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
+
+    expect(result.readiness?.classification).toBe('blocked');
+    expect(result.readiness?.reasons.some((reason) => reason.includes('no usable provider credentials'))).toBe(true);
+    expect(result.readiness?.nextActions.some((a) => a.includes('export') && a.includes('_API_KEY'))).toBe(true);
+  });
+
+  it('marks warnings-only runs as risky', async () => {
+    process.env.GROQ_API_KEY = 'test-key';
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.MISTRAL_API_KEY;
+
+    const result = await dryRun(makeConfig(), SAMPLE_DIFF);
+
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.readiness?.classification).toBe('risky');
+    expect(result.readiness?.reasons.some((reason) => reason.startsWith('warning:'))).toBe(true);
+  });
+
   it('declarative reviewers config: static + auto slots', async () => {
     delete process.env.GROQ_API_KEY;
 

--- a/src/tests/pipeline-dryrun.test.ts
+++ b/src/tests/pipeline-dryrun.test.ts
@@ -307,6 +307,49 @@ describe('dryRun', () => {
     expect(result.readiness?.reasons.some((reason) => reason.startsWith('warning:'))).toBe(true);
   });
 
+  it('marks unknown provider health as risky when another provider is available', async () => {
+    process.env.GROQ_API_KEY = 'test-key';
+
+    const result = await dryRun(makeConfig({
+      reviewers: [
+        {
+          id: 'r1-groq',
+          model: 'llama-3.3-70b-versatile',
+          backend: 'api',
+          provider: 'groq',
+          enabled: true,
+          timeout: 120,
+        },
+        {
+          id: 'r2-custom',
+          model: 'custom-model',
+          backend: 'api',
+          provider: 'custom-provider',
+          enabled: true,
+          timeout: 120,
+        },
+      ],
+      supporters: {
+        ...makeConfig().supporters,
+        pool: [],
+        pickCount: 1,
+      },
+      moderator: {
+        backend: 'api',
+        model: 'llama-3.3-70b-versatile',
+        provider: 'groq',
+      },
+    }), SAMPLE_DIFF);
+
+    expect(result.readiness?.classification).toBe('risky');
+    expect(result.readiness?.reasons).toEqual(expect.arrayContaining([
+      'warning: provider health unavailable for custom-provider',
+    ]));
+    expect(result.readiness?.nextActions).toEqual(expect.arrayContaining([
+      'export CUSTOM_PROVIDER_API_KEY=<your-key> for custom-provider',
+    ]));
+  });
+
   it('declarative reviewers config: static + auto slots', async () => {
     delete process.env.GROQ_API_KEY;
 

--- a/src/tests/review-output-advanced.test.ts
+++ b/src/tests/review-output-advanced.test.ts
@@ -91,6 +91,27 @@ describe('formatText() with undefined summary', () => {
   });
 });
 
+describe('formatText() footer actionability', () => {
+  it('includes session path and follow-up commands', () => {
+    const output = formatText(makeResult());
+    expect(output).toContain('.ca/sessions/2026-03-21/sess-001/');
+    expect(output).toContain('agora sessions');
+    expect(output).toContain('agora explain 2026-03-21/sess-001');
+  });
+
+  it('marks forfeited reviewers as partial output', () => {
+    const output = formatText(makeResult({ summary: { ...makeSummary(), forfeitedReviewers: 1 } }));
+    expect(output).toContain('Partial review');
+    expect(output).toContain('forfeited');
+  });
+
+  it('marks error output as degraded', () => {
+    const output = formatText(makeResult({ status: 'error', error: 'Pipeline failed' } as unknown as PipelineResult));
+    expect(output).toContain('Degraded output');
+    expect(output).toContain('.ca/sessions/2026-03-21/sess-001/');
+  });
+});
+
 // ============================================================================
 // formatHtml — escaping of special characters
 // ============================================================================


### PR DESCRIPTION
## Summary
- improve CLI init/doctor/dry-run next-step guidance and dry-run readiness classification
- clarify MCP tool schemas, repo_path retry guidance, and structured error responses
- report GitHub Action degraded states with user-facing reasons and docs
- record rc.6 setup smoke evidence and keep desktop scoped to private preview

## Validation
- pnpm vitest run packages/cli/src/tests/register-init.test.ts src/tests/cli-commands.test.ts src/tests/cli-error-handling.test.ts src/tests/review-output-advanced.test.ts src/tests/cli-output-formats.test.ts src/tests/cli-review-options.test.ts
- pnpm vitest run src/tests/pipeline-dryrun.test.ts
- pnpm vitest run packages/mcp/src/tests/tool-handlers.test.ts packages/mcp/src/tests/tools.test.ts
- pnpm --filter @codeagora/mcp build
- pnpm vitest run src/tests/github-action-parse-args.test.ts packages/github/src/tests/github-poster.test.ts packages/github/src/tests/critical-github-errors.test.ts
- pnpm typecheck
- pnpm build:action
- env npm_config_cache=/private/tmp/codeagora-npm-cache pnpm release:beta-smoke
- git diff --check

## Notes
Desktop remains private preview. The desktop gate passed through typecheck, smoke, tauri check, app e2e, macOS webdriver e2e, and evidence manifest generation, but final DMG bundling still has a packaging blocker.