### PR TITLE
[codex] Improve doctor health and env setup

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -8,8 +8,11 @@ import path from 'path';
 import { getSupportedProviders, getModel } from '@codeagora/core/l1/provider-registry.js';
 import { loadConfigFrom } from '@codeagora/core/config/loader.js';
 import { strictValidateConfig } from '@codeagora/core/config/validator.js';
+import { getCredentialsPath } from '@codeagora/core/config/credentials.js';
+import { getTopModels, loadModelsCatalog } from '@codeagora/shared/data/models-dev.js';
 import { getProviderEnvVar } from '@codeagora/shared/providers/env-vars.js';
 import { detectCliBackends, type DetectedCli } from '@codeagora/shared/utils/cli-detect.js';
+import { redactSecrets } from '@codeagora/shared/utils/redaction.js';
 import { statusColor, dim } from '../utils/colors.js';
 import { generateText } from 'ai';
 import type { Config, AgentConfig } from '@codeagora/core/types/config.js';
@@ -22,6 +25,7 @@ export interface DoctorCheck {
   name: string;
   status: 'pass' | 'fail' | 'warn';
   message: string;
+  details?: Record<string, unknown>;
 }
 
 export interface DoctorResult {
@@ -34,6 +38,9 @@ export interface DoctorResult {
 export interface LiveCheckResult {
   provider: string;
   model: string;
+  configuredModel?: string;
+  envVar: string;
+  agents: string[];
   status: 'ok' | 'error' | 'timeout';
   latencyMs?: number;
   error?: string;
@@ -83,6 +90,17 @@ interface ProviderKeyStatus {
 interface RuntimeRequirements {
   apiProviders: Set<string>;
   cliBackends: Set<string>;
+  autoReviewers: string[];
+  agentRefs: RuntimeAgentRef[];
+}
+
+interface RuntimeAgentRef {
+  id: string;
+  role: string;
+  backend: string;
+  model: string;
+  provider?: string;
+  envVar?: string;
 }
 
 function getProviderKeyStatuses(): ProviderKeyStatus[] {
@@ -116,8 +134,20 @@ function formatEnvVars(envVars: string[]): string {
 function addRuntimeRequirement(
   requirements: RuntimeRequirements,
   agent: { backend: string; provider?: string; enabled?: boolean },
+  role: string,
+  id: string,
+  model?: string,
 ): void {
   if (agent.enabled === false) return;
+  const envVar = agent.provider ? getProviderEnvVar(agent.provider) : undefined;
+  requirements.agentRefs.push({
+    id,
+    role,
+    backend: agent.backend,
+    model: model ?? 'auto',
+    ...(agent.provider ? { provider: agent.provider } : {}),
+    ...(envVar ? { envVar } : {}),
+  });
   if (agent.backend === 'api') {
     if (agent.provider) requirements.apiProviders.add(agent.provider);
     return;
@@ -129,29 +159,116 @@ function collectRuntimeRequirements(config: Config): RuntimeRequirements {
   const requirements: RuntimeRequirements = {
     apiProviders: new Set<string>(),
     cliBackends: new Set<string>(),
+    autoReviewers: [],
+    agentRefs: [],
   };
 
   if (Array.isArray(config.reviewers)) {
     for (const reviewer of config.reviewers) {
-      if (!('backend' in reviewer)) continue;
-      addRuntimeRequirement(requirements, reviewer);
+      if (!('backend' in reviewer)) {
+        if (reviewer.enabled !== false) requirements.autoReviewers.push(reviewer.id);
+        continue;
+      }
+      addRuntimeRequirement(requirements, reviewer, 'reviewer', reviewer.id, reviewer.model);
     }
   } else {
+    for (let i = 0; i < config.reviewers.count; i += 1) {
+      requirements.autoReviewers.push(`auto-${i + 1}`);
+    }
     for (const reviewer of config.reviewers.static ?? []) {
-      addRuntimeRequirement(requirements, reviewer);
+      addRuntimeRequirement(requirements, reviewer, 'reviewer', reviewer.id, reviewer.model);
     }
   }
 
   for (const supporter of config.supporters.pool) {
-    addRuntimeRequirement(requirements, supporter);
+    addRuntimeRequirement(requirements, supporter, 'supporter', supporter.id, supporter.model);
   }
-  addRuntimeRequirement(requirements, config.supporters.devilsAdvocate);
-  addRuntimeRequirement(requirements, config.moderator);
+  addRuntimeRequirement(
+    requirements,
+    config.supporters.devilsAdvocate,
+    'devilsAdvocate',
+    config.supporters.devilsAdvocate.id,
+    config.supporters.devilsAdvocate.model,
+  );
+  addRuntimeRequirement(requirements, config.moderator, 'moderator', 'moderator', config.moderator.model);
   if (config.head) {
-    addRuntimeRequirement(requirements, config.head);
+    addRuntimeRequirement(requirements, config.head, 'head', 'head', config.head.model);
   }
 
   return requirements;
+}
+
+function checkConfigRuntimeMap(config: Config): DoctorCheck {
+  const requirements = collectRuntimeRequirements(config);
+  const apiProviders = [...requirements.apiProviders];
+  const cliBackends = [...requirements.cliBackends];
+  const parts = [
+    `API: ${apiProviders.length > 0 ? formatProviderNames(apiProviders) : 'none'}`,
+    `CLI: ${cliBackends.length > 0 ? formatProviderNames(cliBackends) : 'none'}`,
+  ];
+  if (requirements.autoReviewers.length > 0) {
+    parts.push(`auto reviewers: ${requirements.autoReviewers.length}`);
+  }
+  return {
+    name: 'Config runtime map',
+    status: 'pass',
+    message: parts.join('; '),
+    details: {
+      agents: requirements.agentRefs,
+      autoReviewers: requirements.autoReviewers,
+    },
+  };
+}
+
+function looksLikeApiKey(value: string): boolean {
+  if (value.length < 10) return false;
+  if (/\s/.test(value)) return false;
+  return true;
+}
+
+function checkConfiguredApiKeyFormats(config: Config): DoctorCheck | null {
+  const requirements = collectRuntimeRequirements(config);
+  const envVars = [...new Set([...requirements.apiProviders].map((provider) => getProviderEnvVar(provider)))];
+  const unusual = envVars.filter((envVar) => process.env[envVar] && !looksLikeApiKey(process.env[envVar] ?? ''));
+  if (envVars.length === 0 || unusual.length === 0) return null;
+
+  return {
+    name: 'Configured API key formats',
+    status: 'warn',
+    message: `Configured API keys look unusual: ${formatEnvVars(unusual)}`,
+    details: { unusualEnvVars: unusual },
+  };
+}
+
+async function checkCredentialStore(hasApiKey: boolean): Promise<DoctorCheck> {
+  const credentialsPath = getCredentialsPath();
+  try {
+    const stat = await fs.stat(credentialsPath);
+    const mode = stat.mode & 0o777;
+    if (process.platform !== 'win32' && mode !== 0o600) {
+      return {
+        name: 'Credential store',
+        status: 'warn',
+        message: `Credential file permissions are 0o${mode.toString(8)}; expected 0o600`,
+        details: { path: credentialsPath, mode: `0o${mode.toString(8)}`, expectedMode: '0o600' },
+      };
+    }
+    return {
+      name: 'Credential store',
+      status: 'pass',
+      message: `Credential file present (${credentialsPath})`,
+      details: { path: credentialsPath, mode: process.platform === 'win32' ? 'n/a' : `0o${mode.toString(8)}` },
+    };
+  } catch {
+    return {
+      name: 'Credential store',
+      status: hasApiKey ? 'pass' : 'warn',
+      message: hasApiKey
+        ? 'Credential file not found; using API keys from environment'
+        : 'Credential file not found; run first-run setup or export an API key',
+      details: { path: credentialsPath, exists: false },
+    };
+  }
 }
 
 function checkConfiguredApiCredentials(config: Config): DoctorCheck | null {
@@ -168,6 +285,13 @@ function checkConfiguredApiCredentials(config: Config): DoctorCheck | null {
       name: 'Configured API credentials',
       status: 'pass',
       message: `Config API credentials ready: ${formatEnvVars(envVars)}`,
+      details: {
+        providers: [...requirements.apiProviders].map((provider) => ({
+          provider,
+          envVar: getProviderEnvVar(provider),
+          set: true,
+        })),
+      },
     };
   }
 
@@ -180,6 +304,7 @@ function checkConfiguredApiCredentials(config: Config): DoctorCheck | null {
     name: 'Configured API credentials',
     status: 'fail',
     message: `Missing API keys required by config: ${details}`,
+    details: { missing },
   };
 }
 
@@ -198,6 +323,9 @@ function checkConfiguredCliBackends(config: Config, cliBackends: DetectedCli[] |
       name: 'Configured CLI backends',
       status: 'pass',
       message: `Config CLI backends ready: ${formatProviderNames([...requirements.cliBackends])}`,
+      details: {
+        backends: [...requirements.cliBackends].map((backend) => detectedByBackend.get(backend)).filter(Boolean),
+      },
     };
   }
 
@@ -205,6 +333,7 @@ function checkConfiguredCliBackends(config: Config, cliBackends: DetectedCli[] |
     name: 'Configured CLI backends',
     status: 'fail',
     message: `Missing CLI backends required by config: ${missing.sort((a, b) => a.localeCompare(b)).join(', ')}`,
+    details: { missing },
   };
 }
 
@@ -217,6 +346,12 @@ function checkAvailableApiKeys(statuses: ProviderKeyStatus[], hasAvailableCli: b
       name: 'Available API keys',
       status: 'pass',
       message: `API keys found for ${formatProviderNames(providerNames)} (${formatEnvVars(envVars)})`,
+      details: {
+        keys: configured.map((status) => ({
+          envVar: status.envVar,
+          providers: status.providers,
+        })),
+      },
     };
   }
 
@@ -225,6 +360,7 @@ function checkAvailableApiKeys(statuses: ProviderKeyStatus[], hasAvailableCli: b
     name: 'Available API keys',
     status: hasAvailableCli ? 'pass' : 'warn',
     message: hasAvailableCli ? `${message}. CLI backends can still run reviews.` : message,
+    details: { expectedEnvVars: statuses.map((status) => status.envVar) },
   };
 }
 
@@ -237,6 +373,7 @@ function checkAvailableCliBackends(cliBackends: DetectedCli[] | undefined, hasAp
       name: 'Available CLI backends',
       status: 'pass',
       message: `CLI backends found: ${labels.join(', ')}`,
+      details: { backends: available },
     };
   }
 
@@ -247,6 +384,7 @@ function checkAvailableCliBackends(cliBackends: DetectedCli[] | undefined, hasAp
     name: 'Available CLI backends',
     status: hasApiKey ? 'pass' : 'warn',
     message: hasApiKey ? `No CLI backends found. API providers can still run reviews.` : `No CLI backends found. Install/auth one of: ${expected}`,
+    details: { checked: detected },
   };
 }
 
@@ -264,6 +402,14 @@ function checkReviewBackend(hasApiKey: boolean, hasAvailableCli: boolean): Docto
     name: 'Review backend',
     status: 'fail',
     message: 'No review backend ready. Set an API key or install/auth a supported CLI backend.',
+  };
+}
+
+function summarizeChecks(checks: DoctorCheck[]): DoctorResult['summary'] {
+  return {
+    pass: checks.filter((c) => c.status === 'pass').length,
+    fail: checks.filter((c) => c.status === 'fail').length,
+    warn: checks.filter((c) => c.status === 'warn').length,
   };
 }
 
@@ -355,24 +501,74 @@ export async function runDoctor(baseDir: string): Promise<DoctorResult> {
   const hasAvailableCli = Boolean(cliBackends?.some((cli) => cli.available));
 
   if (loadedConfig) {
+    checks.push(checkConfigRuntimeMap(loadedConfig));
+
     const configuredApiCheck = checkConfiguredApiCredentials(loadedConfig);
     if (configuredApiCheck) checks.push(configuredApiCheck);
+
+    const apiKeyFormatCheck = checkConfiguredApiKeyFormats(loadedConfig);
+    if (apiKeyFormatCheck) checks.push(apiKeyFormatCheck);
 
     const configuredCliCheck = checkConfiguredCliBackends(loadedConfig, cliBackends);
     if (configuredCliCheck) checks.push(configuredCliCheck);
   }
 
+  checks.push(await checkCredentialStore(hasApiKey));
   checks.push(checkAvailableApiKeys(providerKeyStatuses, hasAvailableCli));
   checks.push(checkAvailableCliBackends(cliBackends, hasApiKey));
   checks.push(checkReviewBackend(hasApiKey, hasAvailableCli));
 
-  const summary = {
-    pass: checks.filter((c) => c.status === 'pass').length,
-    fail: checks.filter((c) => c.status === 'fail').length,
-    warn: checks.filter((c) => c.status === 'warn').length,
-  };
+  return { checks, summary: summarizeChecks(checks), cliBackends };
+}
 
-  return { checks, summary, cliBackends };
+function summarizeLiveHealth(liveChecks: LiveCheckResult[]): DoctorCheck {
+  if (liveChecks.length === 0) {
+    return {
+      name: 'Live API health',
+      status: 'pass',
+      message: 'No enabled API agents to ping; live API check skipped',
+    };
+  }
+
+  const ok = liveChecks.filter((check) => check.status === 'ok').length;
+  const failed = liveChecks.length - ok;
+  if (failed === 0) {
+    return {
+      name: 'Live API health',
+      status: 'pass',
+      message: `Live API check passed for ${ok}/${liveChecks.length} provider/model pairs`,
+    };
+  }
+
+  const failedLabels = liveChecks
+    .filter((check) => check.status !== 'ok')
+    .map((check) => `${check.provider}/${check.model}`)
+    .join(', ');
+  return {
+    name: 'Live API health',
+    status: 'fail',
+    message: `Live API check failed for ${failed}/${liveChecks.length}: ${failedLabels}`,
+  };
+}
+
+export async function runDoctorWithLive(baseDir: string): Promise<DoctorResult> {
+  const result = await runDoctor(baseDir);
+
+  try {
+    const config = await loadConfigFrom(baseDir);
+    result.liveChecks = await runLiveHealthCheck(config);
+    result.checks.push(summarizeLiveHealth(result.liveChecks));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result.checks.push({
+      name: 'Live API health',
+      status: 'fail',
+      message: `Live check setup failed: ${redactSecrets(msg)}`,
+    });
+  }
+
+  result.summary = summarizeChecks(result.checks);
+  return result;
 }
 
 // getProviderEnvVar is re-exported for backward compatibility
@@ -384,69 +580,110 @@ export { getProviderEnvVar } from '@codeagora/shared/providers/env-vars.js';
 
 const LIVE_CHECK_TIMEOUT_MS = 10_000;
 
+const HEALTH_CHECK_DEFAULT_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  openai: 'gpt-4o-mini',
+  openrouter: 'anthropic/claude-sonnet-4.6',
+  'opencode-go': 'deepseek-v4-flash',
+  'opencode-zen': 'gpt-5.4-mini',
+  groq: 'llama-3.3-70b-versatile',
+};
+
+interface LiveAgentPair {
+  provider: string;
+  model: string;
+  configuredModel?: string;
+  envVar: string;
+  agents: string[];
+}
+
+function resolveHealthCheckModel(provider: string, model: string, fallbackModels: Map<string, string>): { model: string; configuredModel?: string } {
+  if (model !== 'auto') return { model };
+  const resolved = fallbackModels.get(provider);
+  if (resolved) {
+    return { model: resolved, configuredModel: model };
+  }
+  return { model, configuredModel: model };
+}
+
+function pickFallbackHealthCheckModel(provider: string, catalog: Awaited<ReturnType<typeof loadModelsCatalog>>): string | undefined {
+  const configuredDefault = HEALTH_CHECK_DEFAULT_MODELS[provider];
+  if (configuredDefault) return configuredDefault;
+
+  const ranked = getTopModels(catalog, provider, 20);
+  const paid = ranked.find((model) => ((model.cost?.input ?? 0) + (model.cost?.output ?? 0)) > 0);
+  return paid?.id ?? ranked[0]?.id;
+}
+
 /**
  * Collect unique provider+model pairs from all enabled agents in config.
  */
-function collectAgentPairs(config: Config): Array<{ provider: string; model: string }> {
-  const seen = new Set<string>();
-  const pairs: Array<{ provider: string; model: string }> = [];
+function collectAgentPairs(config: Config, fallbackModels: Map<string, string>): LiveAgentPair[] {
+  const pairsByKey = new Map<string, LiveAgentPair>();
 
-  function addAgent(agent: AgentConfig): void {
+  function addPair(provider: string, configuredModel: string, agentLabel: string): void {
+    const resolved = resolveHealthCheckModel(provider, configuredModel, fallbackModels);
+    const key = `${provider}/${resolved.model}`;
+    const existing = pairsByKey.get(key);
+    if (existing) {
+      existing.agents.push(agentLabel);
+      return;
+    }
+    pairsByKey.set(key, {
+      provider,
+      model: resolved.model,
+      ...(resolved.configuredModel ? { configuredModel: resolved.configuredModel } : {}),
+      envVar: getProviderEnvVar(provider),
+      agents: [agentLabel],
+    });
+  }
+
+  function addAgent(agent: AgentConfig, role: string): void {
     if (!agent.enabled) return;
     if (agent.backend !== 'api') return;
     if (!agent.provider) return;
-    const key = `${agent.provider}/${agent.model}`;
-    if (seen.has(key)) return;
-    seen.add(key);
-    pairs.push({ provider: agent.provider, model: agent.model });
+    addPair(agent.provider, agent.model, `${role}:${agent.id}`);
   }
 
   // reviewers
   if (Array.isArray(config.reviewers)) {
     for (const r of config.reviewers) {
       if ('auto' in r && r.auto) continue;
-      addAgent(r as AgentConfig);
+      addAgent(r as AgentConfig, 'reviewer');
     }
   } else if ('static' in config.reviewers && config.reviewers.static) {
     for (const r of config.reviewers.static) {
-      addAgent(r);
+      addAgent(r, 'reviewer');
     }
   }
 
   // supporters pool
   for (const s of config.supporters.pool) {
-    addAgent(s);
+    addAgent(s, 'supporter');
   }
-  addAgent(config.supporters.devilsAdvocate);
+  addAgent(config.supporters.devilsAdvocate, 'devilsAdvocate');
 
   // moderator
   if (config.moderator.backend === 'api' && config.moderator.provider) {
-    const key = `${config.moderator.provider}/${config.moderator.model}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      pairs.push({ provider: config.moderator.provider, model: config.moderator.model });
-    }
+    addPair(config.moderator.provider, config.moderator.model, 'moderator');
   }
 
   if (config.head?.enabled !== false && config.head?.backend === 'api' && config.head.provider) {
-    const key = `${config.head.provider}/${config.head.model}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      pairs.push({ provider: config.head.provider, model: config.head.model });
-    }
+    addPair(config.head.provider, config.head.model, 'head');
   }
 
-  return pairs;
+  return [...pairsByKey.values()];
 }
 
-async function pingModel(provider: string, model: string): Promise<LiveCheckResult> {
+async function pingModel(pair: LiveAgentPair): Promise<LiveCheckResult> {
+  const { provider, model, configuredModel, envVar, agents } = pair;
   const start = performance.now();
   try {
     const languageModel = getModel(provider, model);
     const abortSignal = AbortSignal.timeout(LIVE_CHECK_TIMEOUT_MS);
     await generateText({ model: languageModel, prompt: 'Say OK', abortSignal });
     const latencyMs = Math.round(performance.now() - start);
-    return { provider, model, status: 'ok', latencyMs };
+    return { provider, model, ...(configuredModel ? { configuredModel } : {}), envVar, agents, status: 'ok', latencyMs };
   } catch (err) {
     const latencyMs = Math.round(performance.now() - start);
     const msg = err instanceof Error ? err.message : String(err);
@@ -456,20 +693,38 @@ async function pingModel(provider: string, model: string): Promise<LiveCheckResu
       msg.toLowerCase().includes('timeout') ||
       latencyMs >= LIVE_CHECK_TIMEOUT_MS - 100
     ) {
-      return { provider, model, status: 'timeout', latencyMs, error: `timeout (${LIVE_CHECK_TIMEOUT_MS / 1000}s)` };
+      return { provider, model, ...(configuredModel ? { configuredModel } : {}), envVar, agents, status: 'timeout', latencyMs, error: `timeout (${LIVE_CHECK_TIMEOUT_MS / 1000}s)` };
     }
-    return { provider, model, status: 'error', latencyMs, error: msg };
+    return { provider, model, ...(configuredModel ? { configuredModel } : {}), envVar, agents, status: 'error', latencyMs, error: redactSecrets(msg) };
   }
 }
 
 export async function runLiveHealthCheck(config: Config): Promise<LiveCheckResult[]> {
-  const pairs = collectAgentPairs(config);
+  const fallbackModels = new Map<string, string>();
+  const providers = collectRuntimeRequirements(config).apiProviders;
+  for (const provider of providers) {
+    const configuredDefault = HEALTH_CHECK_DEFAULT_MODELS[provider];
+    if (configuredDefault) fallbackModels.set(provider, configuredDefault);
+  }
+
+  try {
+    const catalog = await loadModelsCatalog();
+    for (const provider of providers) {
+      if (fallbackModels.has(provider)) continue;
+      const model = pickFallbackHealthCheckModel(provider, catalog);
+      if (model) fallbackModels.set(provider, model);
+    }
+  } catch {
+    // Catalog lookup is a best-effort improvement for model:auto health checks.
+  }
+
+  const pairs = collectAgentPairs(config, fallbackModels);
   if (pairs.length === 0) {
     return [];
   }
 
   const settled = await Promise.allSettled(
-    pairs.map(({ provider, model }) => pingModel(provider, model))
+    pairs.map((pair) => pingModel(pair))
   );
 
   return settled.map((result, i) => {
@@ -478,8 +733,11 @@ export async function runLiveHealthCheck(config: Config): Promise<LiveCheckResul
     return {
       provider: pairs[i].provider,
       model: pairs[i].model,
+      ...(pairs[i].configuredModel ? { configuredModel: pairs[i].configuredModel } : {}),
+      envVar: pairs[i].envVar,
+      agents: pairs[i].agents,
       status: 'error' as const,
-      error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      error: redactSecrets(result.reason instanceof Error ? result.reason.message : String(result.reason)),
     };
   });
 }
@@ -490,15 +748,18 @@ export function formatLiveCheckReport(liveChecks: LiveCheckResult[]): string {
   lines.push('\u2500'.repeat(14));
 
   for (const check of liveChecks) {
+    const configured = check.configuredModel ? dim(`configured=${check.configuredModel}`) : '';
     const label = `${check.provider}/${check.model}`;
+    const agents = check.agents.length > 0 ? dim(`used by ${check.agents.join(', ')}`) : '';
+    const envVar = dim(check.envVar);
     if (check.status === 'ok') {
       const latency = check.latencyMs !== undefined ? dim(`${check.latencyMs}ms`) : '';
-      lines.push(`${statusColor.pass('✓')} ${label}  ${latency}`);
+      lines.push(`${statusColor.pass('✓')} ${label}  ${latency}  ${envVar}  ${configured}  ${agents}`);
     } else if (check.status === 'timeout') {
-      lines.push(`${statusColor.fail('✗')} ${label}  ${statusColor.fail('timeout (10s)')}`);
+      lines.push(`${statusColor.fail('✗')} ${label}  ${statusColor.fail('timeout (10s)')}  ${envVar}  ${configured}  ${agents}`);
     } else {
       const errMsg = check.error ? statusColor.fail(check.error) : statusColor.fail('error');
-      lines.push(`${statusColor.fail('✗')} ${label}  ${errMsg}`);
+      lines.push(`${statusColor.fail('✗')} ${label}  ${errMsg}  ${envVar}  ${configured}  ${agents}`);
     }
   }
 
@@ -524,11 +785,30 @@ export function formatDoctorReport(result: DoctorResult): string {
   );
   lines.push('');
 
+  const renderDetails = (check: DoctorCheck): void => {
+    if (!check.details) return;
+    if (check.name === 'Config runtime map' && Array.isArray(check.details.agents)) {
+      const agents = check.details.agents as RuntimeAgentRef[];
+      for (const agent of agents.slice(0, 10)) {
+        const provider = agent.provider ? ` provider=${agent.provider}` : '';
+        const envVar = agent.envVar ? ` env=${agent.envVar}` : '';
+        lines.push(`      ${agent.role}:${agent.id} backend=${agent.backend}${provider} model=${agent.model}${envVar}`);
+      }
+      if (agents.length > 10) {
+        lines.push(`      ... and ${agents.length - 10} more configured agents`);
+      }
+    }
+    if (check.name === 'Credential store' && typeof check.details.path === 'string') {
+      lines.push(`      path: ${check.details.path}`);
+    }
+  };
+
   const renderSection = (title: string, checks: DoctorCheck[], iconFn: (text: string) => string): void => {
     if (checks.length === 0) return;
     lines.push(`${title} (${checks.length})`);
     for (const check of checks) {
       lines.push(`  ${iconFn(check.message)}${check.name ? ` — ${dim(check.name)}` : ''}`);
+      renderDetails(check);
     }
     lines.push('');
   };
@@ -549,6 +829,7 @@ export function formatDoctorReport(result: DoctorResult): string {
   const hasConfiguredApiFailure = blocking.some((check) => check.name === 'Configured API credentials');
   const hasConfiguredCliFailure = blocking.some((check) => check.name === 'Configured CLI backends');
   const hasReviewBackendFailure = blocking.some((check) => check.name === 'Review backend');
+  const hasLiveHealthFailure = blocking.some((check) => check.name === 'Live API health');
   const hasApiWarnings = warnings.some((check) => check.name === 'Available API keys');
   const hasCliWarnings = warnings.some((check) => check.name === 'Available CLI backends');
 
@@ -559,15 +840,18 @@ export function formatDoctorReport(result: DoctorResult): string {
     nextSteps.push('Fix the config errors, then rerun `agora doctor`.');
   }
   if (hasConfiguredApiFailure) {
-    nextSteps.push('Set the API keys required by `.ca/config`, then rerun `agora doctor --live`.');
+    nextSteps.push('Run `agora env set <provider> <api-key>` for the missing provider, then rerun `agora doctor --live`.');
   }
   if (hasConfiguredCliFailure) {
     nextSteps.push('Install or authenticate the CLI backends named in `.ca/config`, then rerun `agora doctor`.');
   }
   if (hasReviewBackendFailure) {
-    nextSteps.push('Set one API key or install/auth one supported CLI backend, then rerun `agora doctor`.');
+    nextSteps.push('Run `agora env set openrouter <api-key>` or install/auth one supported CLI backend, then rerun `agora doctor`.');
+  }
+  if (hasLiveHealthFailure && !hasConfiguredApiFailure) {
+    nextSteps.push('Fix the live provider errors above, then rerun `agora doctor --live`.');
   } else if (hasApiWarnings) {
-    nextSteps.push('Set an API key if you want API-backed reviews, then rerun `agora doctor --live`.');
+    nextSteps.push('Run `agora env set openrouter <api-key>` if you want API-backed reviews, then rerun `agora doctor --live`.');
   } else if (hasCliWarnings) {
     nextSteps.push('Install/auth a CLI backend if you want CLI-backed reviews, then rerun `agora doctor`.');
   }

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -1,0 +1,85 @@
+/**
+ * Environment credential commands.
+ */
+
+import { getCredentialsPath, saveCredential } from '@codeagora/core/config/credentials.js';
+import { PROVIDER_ENV_VARS } from '@codeagora/shared/providers/env-vars.js';
+import { dim, statusColor } from '../utils/colors.js';
+import { parseCredentialInput } from '../utils/inline-setup.js';
+
+export interface EnvCredentialStatus {
+  provider: string;
+  envVar: string;
+  isSet: boolean;
+}
+
+export interface EnvSetResult {
+  provider: string;
+  envVar: string;
+  credentialsPath: string;
+}
+
+function looksLikeEnvVar(input: string): boolean {
+  return /^[A-Z][A-Z0-9_]*_API_KEY$/.test(input.trim());
+}
+
+export function listEnvironmentCredentials(): EnvCredentialStatus[] {
+  return Object.entries(PROVIDER_ENV_VARS)
+    .map(([provider, envVar]) => ({
+      provider,
+      envVar,
+      isSet: Boolean(process.env[envVar]),
+    }))
+    .sort((a, b) => a.provider.localeCompare(b.provider));
+}
+
+export async function setEnvironmentCredential(target: string, value: string): Promise<EnvSetResult> {
+  const trimmedTarget = target.trim();
+  const trimmedValue = value.trim();
+  if (!trimmedTarget) {
+    throw new Error('Provider or ENV_VAR is required. Example: agora env set openrouter sk-or-...');
+  }
+  if (!trimmedValue) {
+    throw new Error('API key is required. Example: agora env set openrouter sk-or-...');
+  }
+
+  const input = looksLikeEnvVar(trimmedTarget) && !trimmedValue.includes('=')
+    ? `${trimmedTarget}=${trimmedValue}`
+    : trimmedValue;
+  const credential = parseCredentialInput(input, trimmedTarget);
+
+  await saveCredential(credential.envVar, credential.key);
+  process.env[credential.envVar] = credential.key;
+
+  return {
+    provider: credential.provider,
+    envVar: credential.envVar,
+    credentialsPath: getCredentialsPath(),
+  };
+}
+
+export function formatEnvironmentCredentials(statuses: EnvCredentialStatus[]): string {
+  const lines: string[] = [];
+  lines.push('CodeAgora env');
+  lines.push('=============');
+  lines.push('');
+  lines.push(`${'Provider'.padEnd(14)} ${'ENV'.padEnd(22)} Status`);
+  lines.push(`${'─'.repeat(14)} ${'─'.repeat(22)} ${'─'.repeat(10)}`);
+  for (const status of statuses) {
+    const marker = status.isSet ? statusColor.pass('✓ set') : statusColor.fail('✗ missing');
+    lines.push(`${status.provider.padEnd(14)} ${status.envVar.padEnd(22)} ${marker}`);
+  }
+  lines.push('');
+  lines.push(`Credential store: ${dim(getCredentialsPath())}`);
+  lines.push('Set a key: agora env set openrouter <api-key>');
+  lines.push('Then run: agora doctor --live');
+  return lines.join('\n');
+}
+
+export function formatEnvSetResult(result: EnvSetResult): string {
+  return [
+    `${statusColor.pass('✓')} Saved ${result.envVar} for ${result.provider}`,
+    `Credential store: ${dim(result.credentialsPath)}`,
+    'Next: agora doctor --live',
+  ].join('\n');
+}

--- a/packages/cli/src/commands/help-text.ts
+++ b/packages/cli/src/commands/help-text.ts
@@ -45,6 +45,14 @@ Examples:
   ${displayName} doctor --live                     Test actual API connections
 `);
         break;
+      case 'env':
+        cmd.addHelpText('after', `
+Examples:
+  ${displayName} env                               Show API key readiness
+  ${displayName} env set openrouter <api-key>      Save an OpenRouter key
+  printf '%s' "$OPENROUTER_API_KEY" | ${displayName} env set openrouter --stdin
+`);
+        break;
       case 'sessions':
         cmd.addHelpText('after', `
 Examples:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ import { registerResearchCommand } from './commands/research.js';
 import { addHelpExamples } from './commands/help-text.js';
 
 // Command logic imports (for simple inline wiring)
-import { runDoctor, formatDoctorReport, runLiveHealthCheck } from './commands/doctor.js';
+import { runDoctor, runDoctorWithLive, formatDoctorReport } from './commands/doctor.js';
 import { listProviders, formatProviderList } from './commands/providers.js';
 import { getModelLeaderboard, formatLeaderboard } from './commands/models.js';
 import { explainSession } from './commands/explain.js';
@@ -41,6 +41,7 @@ import { getCostSummary } from './commands/costs.js';
 import { getStatus } from './commands/status.js';
 import { setConfigValue, editConfig } from './commands/config-set.js';
 import { testProviders, formatProviderTestResults } from './commands/providers-test.js';
+import { formatEnvironmentCredentials, formatEnvSetResult, listEnvironmentCredentials, setEnvironmentCredential } from './commands/env.js';
 
 // Load API keys from ~/.config/codeagora/credentials
 await loadCredentials();
@@ -161,15 +162,9 @@ program.command('doctor').description('Check environment and configuration')
   .option('--json', 'output JSON', false)
   .action(async (options: { live: boolean; json: boolean }) => {
     try {
-      const result = await runDoctor(process.cwd());
-      if (options.live) {
-        try {
-          const config = await loadConfig();
-          result.liveChecks = await runLiveHealthCheck(config);
-        } catch (liveErr) {
-          console.error('Live check failed:', liveErr instanceof Error ? liveErr.message : liveErr);
-        }
-      }
+      const result = options.live
+        ? await runDoctorWithLive(process.cwd())
+        : await runDoctor(process.cwd());
       if (options.json) {
         console.log(JSON.stringify(result));
       } else {
@@ -189,6 +184,27 @@ program.command('providers').description('List supported providers and API key s
   try { cliBackends = await detectCliBackends(); } catch { /* optional */ }
   console.log(formatProviderList(listProviders(catalog), cliBackends));
 });
+
+const envCommand = program.command('env').description('Manage CodeAgora API keys');
+envCommand.action(() => {
+  console.log(formatEnvironmentCredentials(listEnvironmentCredentials()));
+});
+envCommand
+  .command('set <provider-or-env> [api-key]')
+  .description('Save an API key to the CodeAgora credential store')
+  .option('--stdin', 'read API key from stdin', false)
+  .action(async (target: string, apiKey: string | undefined, options: { stdin: boolean }) => {
+    try {
+      const value = options.stdin ? await readStdinText() : apiKey;
+      if (!value) {
+        throw new Error('API key is required. Example: agora env set openrouter sk-or-...');
+      }
+      console.log(formatEnvSetResult(await setEnvironmentCredential(target, value)));
+    } catch (error) {
+      console.error('Error:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
 
 program.command('models').description('Show model performance leaderboard').action(async () => {
   try {
@@ -341,6 +357,7 @@ program.action(() => {
   console.log(`    ${b}agora review --quick${r}    ${d}Fast review (L1 only)${r}`);
   console.log(`    ${b}agora review --verbose${r}  ${d}Show full issue details${r}`);
   console.log(`    ${b}agora providers${r}         ${d}Show available providers${r}`);
+  console.log(`    ${b}agora env${r}               ${d}Manage API keys${r}`);
   console.log(`    ${b}agora doctor${r}            ${d}Check setup health${r}`);
   console.log(`    ${b}agora language${r}          ${d}Switch language (en/ko)${r}\n`);
   console.log(`  ${y}Free tier:${r} ${d}Groq can run low-cost/free API-backed reviews${r}`);

--- a/src/tests/cli-commands.test.ts
+++ b/src/tests/cli-commands.test.ts
@@ -374,7 +374,7 @@ describe('formatDoctorReport()', () => {
     };
 
     const report = stripAnsi(formatDoctorReport(result));
-    expect(report).toContain('Set an API key if you want API-backed reviews');
+    expect(report).toContain('agora env set openrouter <api-key>');
     expect(report).toContain('agora doctor --live');
   });
 });

--- a/src/tests/cli-doctor-live.test.ts
+++ b/src/tests/cli-doctor-live.test.ts
@@ -3,8 +3,11 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { runLiveHealthCheck, formatLiveCheckReport } from '@codeagora/cli/commands/doctor.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'os';
+import fs from 'fs/promises';
+import path from 'path';
+import { runLiveHealthCheck, runDoctorWithLive, formatLiveCheckReport, formatDoctorReport, type LiveCheckResult } from '@codeagora/cli/commands/doctor.js';
 import type { Config } from '@codeagora/core/types/config.js';
 
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
@@ -12,8 +15,24 @@ const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 // Mock provider registry
 vi.mock('../../packages/core/src/l1/provider-registry.js', () => ({
   getModel: vi.fn(),
-  getSupportedProviders: vi.fn(() => []),
+  getSupportedProviders: vi.fn(() => ['groq', 'openrouter']),
   clearProviderCache: vi.fn(),
+}));
+
+vi.mock('@codeagora/shared/utils/cli-detect.js', () => ({
+  detectCliBackends: vi.fn(() => Promise.resolve([
+    { backend: 'claude', bin: 'claude', available: false },
+    { backend: 'codex', bin: 'codex', available: false },
+  ])),
+}));
+
+vi.mock('@codeagora/shared/data/models-dev.js', () => ({
+  loadModelsCatalog: vi.fn(() => Promise.resolve({})),
+  getTopModels: vi.fn((_catalog, provider: string) => {
+    if (provider === 'groq') return [{ id: 'llama-3.3-70b-versatile' }];
+    if (provider === 'openrouter') return [{ id: 'z-ai/glm-4.5-air:free' }, { id: 'anthropic/claude-sonnet-4.6' }];
+    return [];
+  }),
 }));
 
 // Mock ai SDK
@@ -22,10 +41,33 @@ vi.mock('ai', () => ({
 }));
 
 import { getModel } from '@codeagora/core/l1/provider-registry.js';
+import { loadModelsCatalog } from '@codeagora/shared/data/models-dev.js';
 import { generateText } from 'ai';
 
 const mockGetModel = vi.mocked(getModel);
+const mockLoadModelsCatalog = vi.mocked(loadModelsCatalog);
 const mockGenerateText = vi.mocked(generateText);
+
+function liveCheck(overrides: Partial<LiveCheckResult> = {}): LiveCheckResult {
+  return { ...baseLiveCheck(), ...overrides };
+}
+
+function baseLiveCheck(): LiveCheckResult {
+  return {
+    provider: 'groq',
+    model: 'llama-3.3-70b-versatile',
+    envVar: 'GROQ_API_KEY',
+    agents: ['reviewer:r1'],
+    status: 'ok' as const,
+    latencyMs: 245,
+  };
+}
+
+async function writeConfig(baseDir: string, config: Config): Promise<void> {
+  const caDir = path.join(baseDir, '.ca');
+  await fs.mkdir(caDir, { recursive: true });
+  await fs.writeFile(path.join(caDir, 'config.json'), JSON.stringify(config, null, 2));
+}
 
 // ============================================================================
 // Minimal valid config fixture
@@ -98,6 +140,7 @@ describe('runLiveHealthCheck()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetModel.mockReturnValue({ modelId: 'test-model' } as any);
+    mockLoadModelsCatalog.mockResolvedValue({} as any);
   });
 
   it('returns ok status with latencyMs on successful ping', async () => {
@@ -122,6 +165,8 @@ describe('runLiveHealthCheck()', () => {
     expect(results).toHaveLength(1);
     expect(results[0].provider).toBe('groq');
     expect(results[0].model).toBe('llama-3.3-70b-versatile');
+    expect(results[0].envVar).toBe('GROQ_API_KEY');
+    expect(results[0].agents).toEqual(['reviewer:r1']);
     expect(results[0].status).toBe('ok');
     expect(typeof results[0].latencyMs).toBe('number');
   });
@@ -196,6 +241,7 @@ describe('runLiveHealthCheck()', () => {
     const results = await runLiveHealthCheck(config);
     // Should only ping once for groq/llama-3.3-70b-versatile
     expect(results).toHaveLength(1);
+    expect(results[0].agents).toEqual(['reviewer:r1', 'reviewer:r2']);
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
   });
 
@@ -207,7 +253,7 @@ describe('runLiveHealthCheck()', () => {
         { id: 'r1', model: 'llama-3.3-70b-versatile', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
       ],
       supporters: {
-        pool: [],
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
         pickCount: 1,
         pickStrategy: 'random',
         devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
@@ -232,7 +278,7 @@ describe('runLiveHealthCheck()', () => {
         { id: 'r1', model: 'llama-3.3-70b-versatile', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
       ],
       supporters: {
-        pool: [],
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
         pickCount: 1,
         pickStrategy: 'random',
         devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
@@ -255,7 +301,7 @@ describe('runLiveHealthCheck()', () => {
         { id: 'r1', model: 'llama-3.3-70b-versatile', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
       ],
       supporters: {
-        pool: [],
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
         pickCount: 1,
         pickStrategy: 'random',
         devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
@@ -278,7 +324,7 @@ describe('runLiveHealthCheck()', () => {
         { id: 'r1', model: 'claude-3', backend: 'claude', provider: undefined, timeout: 120, enabled: true },
       ],
       supporters: {
-        pool: [],
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
         pickCount: 1,
         pickStrategy: 'random',
         devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
@@ -307,11 +353,84 @@ describe('runLiveHealthCheck()', () => {
     expect(results.every((r) => r.status === 'ok')).toBe(true);
   });
 
+  it('resolves model:auto to a provider health-check model and records the configured model', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'OK' } as any);
+
+    const config = makeConfig({
+      reviewers: [
+        { id: 'r1', model: 'auto', backend: 'api', provider: 'groq', timeout: 120, enabled: true },
+      ],
+      supporters: {
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
+        pickCount: 1,
+        pickStrategy: 'random',
+        devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
+        personaPool: ['critic'],
+        personaAssignment: 'random',
+      },
+      moderator: { backend: 'opencode', model: 'claude-3', provider: 'anthropic' },
+    });
+
+    const results = await runLiveHealthCheck(config);
+    expect(results).toHaveLength(1);
+    expect(results[0].configuredModel).toBe('auto');
+    expect(results[0].model).toBe('llama-3.3-70b-versatile');
+  });
+
+  it('uses curated smoke defaults for OpenRouter auto instead of the cheapest catalog entry', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'OK' } as any);
+
+    const config = makeConfig({
+      reviewers: [
+        { id: 'r1', model: 'auto', backend: 'api', provider: 'openrouter', timeout: 120, enabled: true },
+      ],
+      supporters: {
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
+        pickCount: 1,
+        pickStrategy: 'random',
+        devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
+        personaPool: ['critic'],
+        personaAssignment: 'random',
+      },
+      moderator: { backend: 'opencode', model: 'claude-3', provider: 'anthropic' },
+    });
+
+    const results = await runLiveHealthCheck(config);
+    expect(results).toHaveLength(1);
+    expect(results[0].configuredModel).toBe('auto');
+    expect(results[0].model).toBe('anthropic/claude-sonnet-4.6');
+  });
+
+  it('keeps static smoke defaults when the model catalog cannot load', async () => {
+    mockLoadModelsCatalog.mockRejectedValueOnce(new Error('catalog unavailable'));
+    mockGenerateText.mockResolvedValue({ text: 'OK' } as any);
+
+    const config = makeConfig({
+      reviewers: [
+        { id: 'r1', model: 'auto', backend: 'api', provider: 'openrouter', timeout: 120, enabled: true },
+      ],
+      supporters: {
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
+        pickCount: 1,
+        pickStrategy: 'random',
+        devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
+        personaPool: ['critic'],
+        personaAssignment: 'random',
+      },
+      moderator: { backend: 'opencode', model: 'claude-3', provider: 'anthropic' },
+    });
+
+    const results = await runLiveHealthCheck(config);
+    expect(results).toHaveLength(1);
+    expect(results[0].configuredModel).toBe('auto');
+    expect(results[0].model).toBe('anthropic/claude-sonnet-4.6');
+  });
+
   it('returns empty array when no enabled api-backend agents exist', async () => {
     const config = makeConfig({
       reviewers: [],
       supporters: {
-        pool: [],
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
         pickCount: 1,
         pickStrategy: 'random',
         devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
@@ -326,6 +445,91 @@ describe('runLiveHealthCheck()', () => {
   });
 });
 
+describe('runDoctorWithLive()', () => {
+  let tmpDir: string;
+  let savedGroq: string | undefined;
+  let savedOpenRouter: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codeagora-doctor-live-'));
+    savedGroq = process.env['GROQ_API_KEY'];
+    savedOpenRouter = process.env['OPENROUTER_API_KEY'];
+    process.env['GROQ_API_KEY'] = 'gsk_test_key_for_live_doctor';
+    delete process.env['OPENROUTER_API_KEY'];
+    vi.clearAllMocks();
+    mockGetModel.mockReturnValue({ modelId: 'test-model' } as any);
+  });
+
+  afterEach(async () => {
+    if (savedGroq === undefined) {
+      delete process.env['GROQ_API_KEY'];
+    } else {
+      process.env['GROQ_API_KEY'] = savedGroq;
+    }
+    if (savedOpenRouter === undefined) {
+      delete process.env['OPENROUTER_API_KEY'];
+    } else {
+      process.env['OPENROUTER_API_KEY'] = savedOpenRouter;
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('adds live API health to doctor summary when live checks pass', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'OK' } as any);
+    await writeConfig(tmpDir, makeConfig({
+      reviewers: [
+        { id: 'r1', model: 'llama-3.3-70b-versatile', backend: 'api', provider: 'groq', timeout: 120, enabled: true },
+      ],
+      supporters: {
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
+        pickCount: 1,
+        pickStrategy: 'random',
+        devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
+        personaPool: ['critic'],
+        personaAssignment: 'random',
+      },
+      moderator: { backend: 'api', model: 'llama-3.3-70b-versatile', provider: 'groq' },
+    }));
+
+    const result = await runDoctorWithLive(tmpDir);
+    const liveHealth = result.checks.find((check) => check.name === 'Live API health');
+
+    expect(liveHealth?.status).toBe('pass');
+    expect(result.liveChecks).toHaveLength(1);
+    expect(result.liveChecks?.[0].agents).toContain('reviewer:r1');
+    expect(result.liveChecks?.[0].agents).toContain('moderator');
+    expect(result.summary.fail).toBe(0);
+  });
+
+  it('turns live API errors into blocking doctor checks with redacted messages', async () => {
+    mockGenerateText.mockRejectedValue(new Error('authentication failed for sk-1234567890secret'));
+    await writeConfig(tmpDir, makeConfig({
+      reviewers: [
+        { id: 'r1', model: 'llama-3.3-70b-versatile', backend: 'api', provider: 'groq', timeout: 120, enabled: true },
+      ],
+      supporters: {
+        pool: [{ id: 's1', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false }],
+        pickCount: 1,
+        pickStrategy: 'random',
+        devilsAdvocate: { id: 'da', model: 'x', backend: 'api', provider: 'groq', timeout: 120, enabled: false },
+        personaPool: ['critic'],
+        personaAssignment: 'random',
+      },
+      moderator: { backend: 'api', model: 'llama-3.3-70b-versatile', provider: 'groq' },
+    }));
+
+    const result = await runDoctorWithLive(tmpDir);
+    const liveHealth = result.checks.find((check) => check.name === 'Live API health');
+    const report = stripAnsi(formatDoctorReport(result));
+
+    expect(liveHealth?.status).toBe('fail');
+    expect(result.summary.fail).toBeGreaterThan(0);
+    expect(result.liveChecks?.[0].error).toContain('[REDACTED]');
+    expect(result.liveChecks?.[0].error).not.toContain('sk-1234567890secret');
+    expect(report).toContain('Fix the live provider errors above');
+  });
+});
+
 // ============================================================================
 // formatLiveCheckReport
 // ============================================================================
@@ -333,8 +537,14 @@ describe('runLiveHealthCheck()', () => {
 describe('formatLiveCheckReport()', () => {
   it('contains provider names in output', () => {
     const checks = [
-      { provider: 'groq', model: 'llama-3.3-70b-versatile', status: 'ok' as const, latencyMs: 245 },
-      { provider: 'openrouter', model: 'anthropic/claude-sonnet-4.6', status: 'ok' as const, latencyMs: 380 },
+      liveCheck(),
+      liveCheck({
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4.6',
+        envVar: 'OPENROUTER_API_KEY',
+        agents: ['head'],
+        latencyMs: 380,
+      }),
     ];
     const output = formatLiveCheckReport(checks);
     expect(output).toContain('groq/llama-3.3-70b-versatile');
@@ -343,15 +553,37 @@ describe('formatLiveCheckReport()', () => {
 
   it('contains latency for ok checks', () => {
     const checks = [
-      { provider: 'groq', model: 'llama-3.3-70b-versatile', status: 'ok' as const, latencyMs: 245 },
+      liveCheck({ latencyMs: 245 }),
     ];
     const output = formatLiveCheckReport(checks);
     expect(output).toContain('245ms');
   });
 
+  it('contains env var and configured agent labels', () => {
+    const output = stripAnsi(formatLiveCheckReport([
+      liveCheck({ envVar: 'GROQ_API_KEY', agents: ['reviewer:r1', 'moderator'] }),
+    ]));
+    expect(output).toContain('GROQ_API_KEY');
+    expect(output).toContain('used by reviewer:r1, moderator');
+  });
+
+  it('shows configured auto model when a health-check model was substituted', () => {
+    const output = stripAnsi(formatLiveCheckReport([
+      liveCheck({ configuredModel: 'auto', model: 'llama-3.3-70b-versatile' }),
+    ]));
+    expect(output).toContain('configured=auto');
+  });
+
   it('shows timeout for timeout status', () => {
     const checks = [
-      { provider: 'mistral', model: 'mistral-large', status: 'timeout' as const, latencyMs: 10000, error: 'timeout (10s)' },
+      liveCheck({
+        provider: 'mistral',
+        model: 'mistral-large',
+        envVar: 'MISTRAL_API_KEY',
+        status: 'timeout',
+        latencyMs: 10000,
+        error: 'timeout (10s)',
+      }),
     ];
     const output = formatLiveCheckReport(checks);
     expect(output).toContain('timeout');
@@ -360,7 +592,7 @@ describe('formatLiveCheckReport()', () => {
 
   it('shows error message for error status', () => {
     const checks = [
-      { provider: 'groq', model: 'bad-model', status: 'error' as const, error: 'model not found' },
+      liveCheck({ model: 'bad-model', status: 'error', error: 'model not found' }),
     ];
     const output = formatLiveCheckReport(checks);
     expect(output).toContain('model not found');
@@ -368,8 +600,15 @@ describe('formatLiveCheckReport()', () => {
 
   it('includes summary line with passed/failed counts', () => {
     const checks = [
-      { provider: 'groq', model: 'llama', status: 'ok' as const, latencyMs: 100 },
-      { provider: 'mistral', model: 'large', status: 'timeout' as const, error: 'timeout (10s)' },
+      liveCheck({ model: 'llama', latencyMs: 100 }),
+      liveCheck({
+        provider: 'mistral',
+        model: 'large',
+        envVar: 'MISTRAL_API_KEY',
+        agents: ['head'],
+        status: 'timeout',
+        error: 'timeout (10s)',
+      }),
     ];
     const output = stripAnsi(formatLiveCheckReport(checks));
     expect(output).toContain('1 passed');
@@ -378,8 +617,8 @@ describe('formatLiveCheckReport()', () => {
 
   it('shows ✓ for ok and ✗ for failed', () => {
     const checks = [
-      { provider: 'groq', model: 'llama', status: 'ok' as const, latencyMs: 100 },
-      { provider: 'bad', model: 'model', status: 'error' as const, error: 'fail' },
+      liveCheck({ model: 'llama', latencyMs: 100 }),
+      liveCheck({ provider: 'bad', model: 'model', envVar: 'BAD_API_KEY', status: 'error', error: 'fail' }),
     ];
     const output = formatLiveCheckReport(checks);
     expect(output).toContain('✓');

--- a/src/tests/cli-env.test.ts
+++ b/src/tests/cli-env.test.ts
@@ -1,0 +1,116 @@
+/**
+ * CLI env command tests.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  saveCredential: vi.fn(),
+}));
+
+vi.mock('@codeagora/core/config/credentials.js', () => ({
+  getCredentialsPath: vi.fn(() => '/tmp/codeagora-test-credentials'),
+  saveCredential: mocks.saveCredential,
+}));
+
+import {
+  formatEnvironmentCredentials,
+  formatEnvSetResult,
+  listEnvironmentCredentials,
+  setEnvironmentCredential,
+} from '@codeagora/cli/commands/env.js';
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('env command helpers', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envVars = [
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY',
+    'OPENROUTER_API_KEY',
+    'OPENCODE_API_KEY',
+    'GROQ_API_KEY',
+  ];
+
+  beforeEach(() => {
+    mocks.saveCredential.mockReset();
+    for (const envVar of envVars) {
+      savedEnv[envVar] = process.env[envVar];
+      delete process.env[envVar];
+    }
+  });
+
+  afterEach(() => {
+    for (const envVar of envVars) {
+      if (savedEnv[envVar] === undefined) {
+        delete process.env[envVar];
+      } else {
+        process.env[envVar] = savedEnv[envVar];
+      }
+    }
+  });
+
+  it('lists supported provider env vars', () => {
+    process.env['OPENROUTER_API_KEY'] = 'sk-or-test';
+
+    const statuses = listEnvironmentCredentials();
+    expect(statuses.map((status) => status.provider).sort()).toEqual([
+      'anthropic',
+      'groq',
+      'openai',
+      'opencode-go',
+      'opencode-zen',
+      'openrouter',
+    ]);
+    expect(statuses.find((status) => status.provider === 'openrouter')?.isSet).toBe(true);
+  });
+
+  it('saves a raw key for a provider target', async () => {
+    const result = await setEnvironmentCredential('openrouter', 'sk-or-test');
+
+    expect(mocks.saveCredential).toHaveBeenCalledWith('OPENROUTER_API_KEY', 'sk-or-test');
+    expect(process.env['OPENROUTER_API_KEY']).toBe('sk-or-test');
+    expect(result).toEqual({
+      provider: 'openrouter',
+      envVar: 'OPENROUTER_API_KEY',
+      credentialsPath: '/tmp/codeagora-test-credentials',
+    });
+  });
+
+  it('saves a raw key for an ENV_VAR target', async () => {
+    const result = await setEnvironmentCredential('GROQ_API_KEY', 'gsk_test');
+
+    expect(mocks.saveCredential).toHaveBeenCalledWith('GROQ_API_KEY', 'gsk_test');
+    expect(process.env['GROQ_API_KEY']).toBe('gsk_test');
+    expect(result.provider).toBe('groq');
+  });
+
+  it('accepts pasted ENV_VAR=value assignments', async () => {
+    const result = await setEnvironmentCredential('groq', 'OPENROUTER_API_KEY=sk-or-test');
+
+    expect(mocks.saveCredential).toHaveBeenCalledWith('OPENROUTER_API_KEY', 'sk-or-test');
+    expect(result.provider).toBe('openrouter');
+  });
+
+  it('rejects empty keys before writing', async () => {
+    await expect(setEnvironmentCredential('openrouter', '   ')).rejects.toThrow('API key is required');
+    expect(mocks.saveCredential).not.toHaveBeenCalled();
+  });
+
+  it('formats list output with the setup command', () => {
+    const output = stripAnsi(formatEnvironmentCredentials(listEnvironmentCredentials()));
+    expect(output).toContain('CodeAgora env');
+    expect(output).toContain('agora env set openrouter <api-key>');
+    expect(output).toContain('agora doctor --live');
+  });
+
+  it('formats set output without printing the secret', () => {
+    const output = stripAnsi(formatEnvSetResult({
+      provider: 'openrouter',
+      envVar: 'OPENROUTER_API_KEY',
+      credentialsPath: '/tmp/codeagora-test-credentials',
+    }));
+    expect(output).toContain('Saved OPENROUTER_API_KEY for openrouter');
+    expect(output).not.toContain('sk-or-test');
+  });
+});


### PR DESCRIPTION
## What changed
- Expanded `agora doctor` diagnostics with config runtime mapping, credential-store checks, configured provider/CLI details, and live health failure propagation.
- Added `agora env` and `agora env set <provider-or-env> [api-key]` so users can save API keys directly into the CodeAgora credential store.
- Made `doctor --live` resolve `model: auto` to stable smoke models for health checks instead of accidentally selecting slow/free catalog entries.
- Updated CLI help and doctor next-step guidance to point users at `agora env set ...`.

## Why
First-run and health-check UX should be actionable for non-developers: if an API key is missing, the CLI now gives a direct command to fix it, then verifies the setup with a live provider ping.

## Validation
- `pnpm vitest run src/tests/cli-env.test.ts src/tests/cli-commands.test.ts src/tests/cli-doctor-live.test.ts src/tests/cli-help-parity.test.ts`
- `pnpm typecheck`
- `pnpm --silent dev doctor --live`
- `pnpm --silent dev env`
- `pnpm --silent dev review --dry-run /tmp/codeagora-smoke.diff`
- `pnpm test`
- `pnpm build`
- `pnpm build:action`
- `git diff --check`
