### PR TITLE
feat: harden review prompts for guardrail regressions

### DIFF
--- a/packages/core/src/l1/reviewer.ts
+++ b/packages/core/src/l1/reviewer.ts
@@ -521,6 +521,7 @@ Before writing issues, systematically check:
    - Check for property access before a null/undefined guard.
    - Check slice/page limits for \`limit + 1\` or inclusive/exclusive boundary mistakes.
    - Check functions whose comments/contracts imply "returns updated value/record/copy" but mutate their input object.
+6. **Guardrails and thresholds**: Did the change weaken a readiness gate, raise an acceptance threshold, or make a blocked state easier to pass?
 
 ## Your Task
 For each **real, actionable issue** in the **newly added or modified code**, write an evidence document:
@@ -791,6 +792,7 @@ Before flagging, systematically check:
 2. **Error paths**: Are failures caught, logged, propagated correctly?
 3. **Logic correctness**: Off-by-one? Null deref? Race condition? Unhandled edge case?
    - Especially: property access before null checks, \`limit + 1\` slice bounds, and input mutation hidden behind a "returns updated value/record" contract.
+4. **Guardrails and thresholds**: Did a readiness gate, config check, or policy threshold get weaker or easier to pass?
 
 ## Severity (pick one per finding)
 

--- a/packages/core/src/pipeline/pre-analysis.ts
+++ b/packages/core/src/pipeline/pre-analysis.ts
@@ -212,6 +212,7 @@ export function buildEnrichedSection(ctx: EnrichedDiffContext): string {
 const AUTH_RE = /\b(auth|login|logout|session|token|jwt|oauth|permission|role|rbac|acl|tenant|admin)\b/i;
 const SECURITY_RE = /\b(security|sanitize|validation|sql|query|secret|credential|password|crypto|encrypt|decrypt|csrf|xss|ssrf|exec|command|shell|upload|webhook|http|api|network|file system)\b/i;
 const DATA_RE = /\b(data|db|database|migration|schema|transaction|payment|billing|invoice|order|balance|ledger|persist|storage|rollback|idempot|consisten|write|delete|upsert|cache|queue)\b/i;
+const GUARDRAIL_RE = /\b(readiness|threshold|guard|gate|policy|contract|invariant|monotonic|limit|boundary)\b/i;
 
 function clipSignal(text: string, maxLength: number = 96): string {
   const normalized = text.replace(/\s+/g, ' ').trim();
@@ -249,6 +250,13 @@ function buildRiskFocusBuckets(ctx: EnrichedDiffContext): RiskFocusBucket[] {
     if (AUTH_RE.test(filePath)) addRiskSignal(auth, fileSignal, 2);
     if (SECURITY_RE.test(filePath)) addRiskSignal(security, fileSignal, 2);
     if (DATA_RE.test(filePath)) addRiskSignal(dataIntegrity, fileSignal, 2);
+    if (GUARDRAIL_RE.test(filePath)) {
+      addRiskSignal(
+        dataIntegrity,
+        `semantic guardrail file \`${filePath}\` — re-check thresholds, gates, and default behavior`,
+        classification === 'config' ? 3 : 2,
+      );
+    }
   }
 
   for (const diag of ctx.tscDiagnostics.slice(0, 10)) {
@@ -257,6 +265,9 @@ function buildRiskFocusBuckets(ctx: EnrichedDiffContext): RiskFocusBucket[] {
     if (AUTH_RE.test(diagText)) addRiskSignal(auth, signal, 1);
     if (SECURITY_RE.test(diagText)) addRiskSignal(security, signal, 1);
     if (DATA_RE.test(diagText)) addRiskSignal(dataIntegrity, signal, 1);
+    if (GUARDRAIL_RE.test(diagText)) {
+      addRiskSignal(dataIntegrity, signal, 1);
+    }
   }
 
   for (const [, entry] of ctx.impactAnalysis.entries()) {
@@ -281,6 +292,9 @@ function buildRiskFocusBuckets(ctx: EnrichedDiffContext): RiskFocusBucket[] {
     if (AUTH_RE.test(source.text)) addRiskSignal(auth, signal, 2);
     if (SECURITY_RE.test(source.text)) addRiskSignal(security, signal, 2);
     if (DATA_RE.test(source.text)) addRiskSignal(dataIntegrity, signal, 2);
+    if (GUARDRAIL_RE.test(source.text)) {
+      addRiskSignal(dataIntegrity, signal, 2);
+    }
   }
 
   return [auth, security, dataIntegrity]

--- a/packages/core/src/tests/l1-reviewer-messages.test.ts
+++ b/packages/core/src/tests/l1-reviewer-messages.test.ts
@@ -27,6 +27,7 @@ describe('buildReviewerMessages', () => {
     expect(system).toContain('Analysis Checklist');
     expect(system).toContain('Severity Guide');
     expect(system).toContain('HARSHLY_CRITICAL');
+    expect(system).toContain('Guardrails and thresholds');
   });
 
   it('system does NOT contain diff content', () => {
@@ -254,6 +255,7 @@ Do one short second pass on the flagged buckets before finalizing findings.
       expect(system).toContain('CRITICAL');
       expect(system).toContain('WARNING');
       expect(system).toMatch(/untrusted/i);
+      expect(system).toContain('Guardrails and thresholds');
     });
 
     it('drops verbose sections: extensive analysis checklist, long examples', () => {

--- a/packages/core/src/tests/pre-analysis.test.ts
+++ b/packages/core/src/tests/pre-analysis.test.ts
@@ -371,6 +371,24 @@ describe('buildEnrichedSection', () => {
     expect(result).toContain('Verify backward compat');
   });
 
+  it('should flag semantic guardrail files in the risk-focus pass', () => {
+    const ctx: EnrichedDiffContext = {
+      fileClassifications: new Map<string, FileClassification>([
+        ['packages/desktop/src/readiness.ts', 'logic'],
+      ]),
+      tscDiagnostics: [],
+      impactAnalysis: new Map(),
+      externalRules: [],
+      pathRuleNotes: [],
+    };
+
+    const result = buildEnrichedSection(ctx);
+
+    expect(result).toContain('Risk-Focus Pass');
+    expect(result).toContain('DATA_INTEGRITY');
+    expect(result).toContain('semantic guardrail file `packages/desktop/src/readiness.ts`');
+  });
+
   it('should combine all sections', () => {
     const ctx: EnrichedDiffContext = {
       fileClassifications: new Map<string, FileClassification>([


### PR DESCRIPTION
## Summary
- Tighten pre-analysis risk focus for readiness/threshold guardrail changes.
- Add explicit reviewer checklist guidance for guardrail and threshold regressions.

## Verification
- pnpm exec vitest run packages/core/src/tests/pre-analysis.test.ts packages/core/src/tests/l1-reviewer-messages.test.ts
- pnpm typecheck

## Goal
- Improve CodeAgora review recall on regressions that weaken readiness gates or acceptance thresholds.