### PR TITLE
test: readiness regression after guardrail hardening

### DIFF
--- a/packages/desktop/src/readiness.ts
+++ b/packages/desktop/src/readiness.ts
@@ -37,7 +37,7 @@ export function evaluateConfigPolicy(raw: string): ConfigPolicyReadiness {
     const activeReviewers = activeReviewerCount(parsed.reviewers);
     return {
       activeReviewers,
-      complete: (activeReviewers ?? 0) > 0,
+      complete: (activeReviewers ?? 0) > 1,
       validJson: true,
     };
   } catch {


### PR DESCRIPTION
## Summary
- Reintroduce the readiness threshold regression to verify the hardening changes improve review recall.

## Notes
- Throwaway PR for validation only.