### PR TITLE
test: invert critical issue verdict guard

### DIFF
--- a/packages/core/src/l3/verdict.ts
+++ b/packages/core/src/l3/verdict.ts
@@ -303,7 +303,7 @@ export function applyHeadVerdictSafety(
   const criticalIssues = allCritical.filter(
     (d) => d.avgConfidence == null || d.avgConfidence > CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD
   );
-  if (criticalIssues.length > 0) {
+  if (criticalIssues.length === 0) {
     if (verdict.decision === 'REJECT') return verdict;
     return {
       decision: 'REJECT',


### PR DESCRIPTION
## Summary
- Intentionally invert the critical issue guard in the head verdict path.

## Notes
- Throwaway PR for showing CodeAgora review comments after prompt hardening.