### PR TITLE
feat: add fast OpenRouter flash preset

### DIFF
--- a/docs/for-users/DEMO_RUNBOOK.md
+++ b/docs/for-users/DEMO_RUNBOOK.md
@@ -16,9 +16,13 @@ Pick one based on the room and how much time you want to spend on token cost.
 
 | Preset | Suggested models | When to use |
 |---|---|---|
-| Premium | `openai/gpt-5.3-codex`, `anthropic/claude-sonnet-4.6`, `deepseek/deepseek-v4-flash`, `qwen/qwen3.7-max`, `x-ai/grok-4.3` | Live demo where quality matters more than cost |
+| Fast | `google/gemini-2.5-flash`, `deepseek/deepseek-v4-flash`, `z-ai/glm-4.7-flash`, `qwen/qwen3-coder-flash` | Short live demo, preflight, or repeated iteration |
 | Balanced | `openai/gpt-5.3-codex`, `anthropic/claude-sonnet-4.5`, `qwen/qwen3-coder-flash`, `qwen/qwen3-next-80b-a3b-instruct`, `x-ai/grok-4.3` | Demo with better latency and lower spend |
+| Premium | `openai/gpt-5.3-codex`, `anthropic/claude-sonnet-4.6`, `deepseek/deepseek-v4-flash`, `qwen/qwen3.7-max`, `x-ai/grok-4.3` | Live demo where quality matters more than cost |
+| Deep | `openai/gpt-5.3-codex`, `anthropic/claude-sonnet-4.6`, `deepseek/deepseek-v4-flash`, `z-ai/glm-5.1`, `minimax/minimax-m3`, `x-ai/grok-4.3`, `qwen/qwen3.7-max` | Best when you want the strongest debate and don't care about spend |
 | Efficient | `qwen/qwen3-coder-flash`, `qwen/qwen3-next-80b-a3b-instruct`, `x-ai/grok-4.3` | Internal walkthrough or repeated practice runs |
+
+CLI init aliases are intentionally short: `fast` uses the quick OpenRouter flash lineup, `balanced`/`standard` use the starter lineup, and `premium`/`deep` use the thorough preset.
 
 ### Demo config
 
@@ -143,6 +147,8 @@ What to point out:
 - `--dry-run` shows readiness before you spend provider calls.
 - `--json-stream` proves the pipeline is incremental and machine-readable.
 - `agora explain` replays a previous session without re-running the review.
+- For a live demo, start with `agora doctor --live`, then run `agora review --staged --json-stream` so the room can watch progress events arrive in real time.
+- If you want to replay the result, copy the session ID from the review output and run `agora explain <session>`.
 
 ## MCP demo
 
@@ -172,6 +178,10 @@ Demo calls:
 ```
 
 ```json
+{ "name": "review_pr", "arguments": { "pr_number": 123, "post_review": true } }
+```
+
+```json
 { "name": "config_get", "arguments": { "key": "discussion.maxRounds" } }
 ```
 
@@ -183,6 +193,7 @@ What to point out:
 
 - `dry_run` is the preflight gate.
 - `review_full` returns the same stable machine contract as the CLI.
+- `review_pr` is the easiest way to show the bot posting inline comments on a real pull request. Replace `123` with the current demo PR number.
 - `config_get` and `get_leaderboard` show that MCP is not a shell wrapper.
 
 ## Desktop app demo

--- a/docs/for-users/EXTENSIONS.md
+++ b/docs/for-users/EXTENSIONS.md
@@ -32,3 +32,16 @@ Exposes the full CodeAgora pipeline as an MCP server compatible with Claude Code
 Provider keys are only needed for live review tools. `dry_run`, `tools/list`, and config reads should start without API keys.
 
 `review_quick` runs L1 only for fast feedback. `review_full` runs the complete L1 > L2 > L3 pipeline. `review_pr` reviews a GitHub PR by URL or number. `repo_path` is accepted by review tools plus `explain_session`, `get_stats`, `config_get`, and `config_set`; it lets the MCP server operate inside a specific checked-out repository while still rejecting paths outside the current repository boundary. Failures return MCP `isError: true` with JSON `{ "status": "error", "code": string, "message": string, "details"?: object, "guidance"?: string[] }`.
+
+### Suggested natural-language mapping
+
+Use this in the client prompt or command router when you want one phrase to map to one MCP tool:
+
+| Phrase | MCP tool | Use when |
+|---|---|---|
+| `fast`, `quick`, `skim`, `fast-ass` | `review_quick` | You want the fastest useful read on staged changes or a pasted diff. |
+| `full`, `standard`, `proper`, `deep` | `review_full` | You want the full debate and final verdict. |
+| `pr`, `comment it`, `review this PR` | `review_pr` | You want inline GitHub comments on a real pull request. |
+| `preflight`, `dry-run`, `check readiness` | `dry_run` | You want to see blockers and cost before spending provider calls. |
+
+For a local assistant prompt, keep the mapping simple: `fast` → `review_quick`, `full` → `review_full`, `pr` → `review_pr`, and `preflight` → `dry_run`.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -91,6 +91,7 @@ export interface DynamicPreset {
   labelKo: string;
   providers: string[];
   models: Record<string, string>;
+  reviewerModels?: string[];
   reviewerCount: number;
   discussion: boolean;
   backend: 'api' | 'cli';
@@ -98,8 +99,11 @@ export interface DynamicPreset {
 
 const PRESET_ALIASES: Record<string, string> = {
   budget: 'quick',
+  fast: 'quick',
   balanced: 'free',
+  standard: 'free',
   premium: 'thorough',
+  deep: 'thorough',
 };
 
 export const PRESET_ALIAS_ENTRIES = Object.entries(PRESET_ALIASES).map(
@@ -371,6 +375,18 @@ const PROVIDER_DEFAULT_MODELS: Record<string, string> = {
   groq: 'llama-3.3-70b-versatile',
 };
 
+const OPENROUTER_FAST_REVIEWERS = [
+  'google/gemini-2.5-flash',
+  'deepseek/deepseek-v4-flash',
+  'z-ai/glm-4.7-flash',
+  'qwen/qwen3-coder-flash',
+];
+
+const OPENROUTER_STARTER_REVIEWERS = [
+  'qwen/qwen3-coder-flash',
+  'qwen/qwen3-next-80b-a3b-instruct',
+];
+
 // ============================================================================
 // Static fallback presets (used when catalog/detection unavailable)
 // ============================================================================
@@ -381,8 +397,9 @@ const FALLBACK_PRESETS: DynamicPreset[] = [
     label: 'Quick review (OpenRouter)',
     labelKo: '\uBE60\uB978 \uB9AC\uBDF0 (OpenRouter)',
     providers: ['openrouter'],
-    models: { openrouter: 'xiaomi/mimo-v2.5' },
-    reviewerCount: 1,
+    models: { openrouter: OPENROUTER_FAST_REVIEWERS[0]! },
+    reviewerModels: OPENROUTER_FAST_REVIEWERS,
+    reviewerCount: OPENROUTER_FAST_REVIEWERS.length,
     discussion: false,
     backend: 'api',
   },
@@ -449,16 +466,18 @@ export function generatePresets(
     return PROVIDER_DEFAULT_MODELS[provider] ?? 'xiaomi/mimo-v2.5';
   }
 
-  // 1. "Quick review" — single fastest provider, 1 reviewer, no discussion
+  // 1. "Quick review" — fastest available provider, no discussion
   if (detected.length > 0) {
     const fastest = detected[0]!;
+    const openrouterFast = fastest === 'openrouter';
     presets.push({
       id: 'quick',
       label: `Quick review (${fastest})`,
       labelKo: `\uBE60\uB978 \uB9AC\uBDF0 (${fastest})`,
       providers: [fastest],
-      models: { [fastest]: bestModel(fastest) },
-      reviewerCount: 1,
+      models: { [fastest]: openrouterFast ? OPENROUTER_FAST_REVIEWERS[0]! : bestModel(fastest) },
+      reviewerModels: openrouterFast ? OPENROUTER_FAST_REVIEWERS : undefined,
+      reviewerCount: openrouterFast ? OPENROUTER_FAST_REVIEWERS.length : 1,
       discussion: false,
       backend: 'api',
     });
@@ -478,6 +497,18 @@ export function generatePresets(
       providers: freeDetected,
       models: freeModels,
       reviewerCount: Math.min(freeDetected.length * 2, 5),
+      discussion: false,
+      backend: 'api',
+    });
+  } else if (detected.includes('openrouter')) {
+    presets.push({
+      id: 'free',
+      label: 'Starter review (OpenRouter)',
+      labelKo: '\uC2A4\uD0C0\uD130 \uB9AC\uBDF0 (OpenRouter)',
+      providers: ['openrouter'],
+      models: { openrouter: OPENROUTER_STARTER_REVIEWERS[0]! },
+      reviewerModels: OPENROUTER_STARTER_REVIEWERS,
+      reviewerCount: OPENROUTER_STARTER_REVIEWERS.length,
       discussion: false,
       backend: 'api',
     });
@@ -714,11 +745,17 @@ export async function buildPresetConfig(preset: string): Promise<GeneratedConfig
     );
   }
 
-  const selections: ProviderModelSelection[] = selected.providers.map((provider) => ({
-    provider,
-    model: selected.models[provider] ?? PROVIDER_DEFAULT_MODELS[provider] ?? 'xiaomi/mimo-v2.5',
-    backend: selected.backend,
-  }));
+  const selections: ProviderModelSelection[] = selected.reviewerModels?.length
+    ? selected.reviewerModels.map((model) => ({
+      provider: selected.providers[0]!,
+      model,
+      backend: selected.backend,
+    }))
+    : selected.providers.map((provider) => ({
+      provider,
+      model: selected.models[provider] ?? PROVIDER_DEFAULT_MODELS[provider] ?? 'xiaomi/mimo-v2.5',
+      backend: selected.backend,
+    }));
 
   if (selections.length === 0) {
     throw new Error(`Preset "${preset}" has no providers.`);

--- a/packages/cli/src/tests/cli-init-advanced.test.ts
+++ b/packages/cli/src/tests/cli-init-advanced.test.ts
@@ -241,6 +241,17 @@ describe('buildMultiProviderConfig()', () => {
 // ============================================================================
 
 describe('generatePresets()', () => {
+  const openrouterFastModels = [
+    'google/gemini-2.5-flash',
+    'deepseek/deepseek-v4-flash',
+    'z-ai/glm-4.7-flash',
+    'qwen/qwen3-coder-flash',
+  ];
+  const openrouterStarterModels = [
+    'qwen/qwen3-coder-flash',
+    'qwen/qwen3-next-80b-a3b-instruct',
+  ];
+
   it('returns fallback presets when no providers or CLI detected', () => {
     const env = makeEnv([{ name: 'groq', available: false }]);
     const presets = generatePresets(env, null);
@@ -248,6 +259,9 @@ describe('generatePresets()', () => {
     expect(presets.length).toBeGreaterThan(0);
     const ids = presets.map((p) => p.id);
     expect(ids).toContain('quick');
+    const quick = presets.find((p) => p.id === 'quick');
+    expect(quick!.reviewerCount).toBe(4);
+    expect(quick!.reviewerModels).toEqual(openrouterFastModels);
   });
 
   it('generates a "quick" preset from the first detected provider', () => {
@@ -332,6 +346,26 @@ describe('generatePresets()', () => {
     expect(quick!.models['groq']).toBe('llama-3.3-70b-versatile');
   });
 
+  it('uses the flash lineup for OpenRouter quick preset', () => {
+    const env = makeEnv([{ name: 'openrouter', available: true }]);
+    const presets = generatePresets(env, null);
+    const quick = presets.find((p) => p.id === 'quick');
+    expect(quick).toBeDefined();
+    expect(quick!.providers).toEqual(['openrouter']);
+    expect(quick!.reviewerCount).toBe(4);
+    expect(quick!.reviewerModels).toEqual(openrouterFastModels);
+  });
+
+  it('generates OpenRouter starter preset for balanced aliases', () => {
+    const env = makeEnv([{ name: 'openrouter', available: true }]);
+    const presets = generatePresets(env, null);
+    const starter = presets.find((p) => p.id === 'free');
+    expect(starter).toBeDefined();
+    expect(starter!.providers).toEqual(['openrouter']);
+    expect(starter!.reviewerCount).toBe(2);
+    expect(starter!.reviewerModels).toEqual(openrouterStarterModels);
+  });
+
   it('includes label with provider name for quick preset', () => {
     const env = makeEnv([{ name: 'anthropic', available: true }]);
     const presets = generatePresets(env, null);
@@ -355,6 +389,9 @@ describe('resolvePresetAlias()', () => {
 
   it('trims and normalizes case', () => {
     expect(resolvePresetAlias('  BuDGeT  ')).toBe('quick');
+    expect(resolvePresetAlias('fast')).toBe('quick');
+    expect(resolvePresetAlias('standard')).toBe('free');
+    expect(resolvePresetAlias('deep')).toBe('thorough');
     expect(resolvePresetAlias('  QUICK  ')).toBe('quick');
   });
 

--- a/packages/core/src/config/presets.ts
+++ b/packages/core/src/config/presets.ts
@@ -30,12 +30,19 @@ export interface PresetConfig {
   discussion: boolean;
 }
 
+const OPENROUTER_FAST_REVIEWERS = [
+  'google/gemini-2.5-flash',
+  'deepseek/deepseek-v4-flash',
+  'z-ai/glm-4.7-flash',
+  'qwen/qwen3-coder-flash',
+];
+
 const OPENROUTER_QUALITY_REVIEWERS = [
   'xiaomi/mimo-v2.5',
   'qwen/qwen3-coder-30b-a3b-instruct',
   'tencent/hy3-preview',
-  'deepseek/deepseek-v4-flash',
   'meta-llama/llama-4-scout',
+  'deepseek/deepseek-v4-flash',
 ];
 
 const OPENROUTER_QUALITY_SUPPORTERS = [
@@ -52,12 +59,12 @@ export const STATIC_PRESETS: PresetConfig[] = [
     id: 'quick',
     name: 'Quick Setup',
     nameKo: '빠른 설정',
-    description: '3 reviewers, no discussion — fast and cheap',
-    descriptionKo: '리뷰어 3개, 토론 없음 — 빠르고 저렴',
-    reviewerCount: 3,
+    description: '4 flash reviewers, no discussion — fast and cheap',
+    descriptionKo: 'Flash 리뷰어 4개, 토론 없음 — 빠르고 저렴',
+    reviewerCount: 4,
     providers: ['openrouter'],
-    models: { openrouter: OPENROUTER_QUALITY_REVIEWERS[0]! },
-    reviewerModels: OPENROUTER_QUALITY_REVIEWERS.slice(0, 3),
+    models: { openrouter: OPENROUTER_FAST_REVIEWERS[0]! },
+    reviewerModels: OPENROUTER_FAST_REVIEWERS,
     supporterModels: OPENROUTER_QUALITY_SUPPORTERS.slice(0, 1),
     devilsAdvocateModel: OPENROUTER_QUALITY_DA,
     moderatorModel: OPENROUTER_QUALITY_MODERATOR,

--- a/packages/core/src/tests/presets.test.ts
+++ b/packages/core/src/tests/presets.test.ts
@@ -48,9 +48,9 @@ describe('STATIC_PRESETS', () => {
     expect(ids).toContain('minimal');
   });
 
-  it('quick preset has 3 reviewers and no discussion', () => {
+  it('quick preset has 4 reviewers and no discussion', () => {
     const quick = STATIC_PRESETS.find((p) => p.id === 'quick')!;
-    expect(quick.reviewerCount).toBe(3);
+    expect(quick.reviewerCount).toBe(4);
     expect(quick.discussion).toBe(false);
   });
 
@@ -134,9 +134,9 @@ describe('buildPresetConfig() — required fields', () => {
 describe('buildPresetConfig() — quick preset', () => {
   const quickPreset = STATIC_PRESETS.find((p) => p.id === 'quick')!;
 
-  it('creates 3 reviewers', () => {
+  it('creates 4 reviewers', () => {
     const config = buildPresetConfig({ preset: quickPreset });
-    expect(config.reviewers).toHaveLength(3);
+    expect(config.reviewers).toHaveLength(4);
   });
 
   it('all reviewers use openrouter provider', () => {
@@ -176,6 +176,16 @@ describe('buildPresetConfig() — quick preset', () => {
     const config = buildPresetConfig({ preset: quickPreset });
     const ids = reviewers(config).map((r) => r.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('uses the flash lineup for reviewers', () => {
+    const config = buildPresetConfig({ preset: quickPreset });
+    expect(reviewers(config).map((r) => r.model)).toEqual([
+      'google/gemini-2.5-flash',
+      'deepseek/deepseek-v4-flash',
+      'z-ai/glm-4.7-flash',
+      'qwen/qwen3-coder-flash',
+    ]);
   });
 });
 

--- a/src/tests/init-multiselect.test.ts
+++ b/src/tests/init-multiselect.test.ts
@@ -131,6 +131,17 @@ function makeCli(available: string[]): DetectedCli[] {
 // ============================================================================
 
 describe('generatePresets()', () => {
+  const openrouterFastModels = [
+    'google/gemini-2.5-flash',
+    'deepseek/deepseek-v4-flash',
+    'z-ai/glm-4.7-flash',
+    'qwen/qwen3-coder-flash',
+  ];
+  const openrouterStarterModels = [
+    'qwen/qwen3-coder-flash',
+    'qwen/qwen3-next-80b-a3b-instruct',
+  ];
+
   it('returns fallback presets when no providers or CLIs detected', () => {
     const presets = generatePresets(makeEmptyEnv(), null);
     expect(presets).toHaveLength(3);
@@ -141,6 +152,8 @@ describe('generatePresets()', () => {
     for (const p of presets) {
       expect(p.providers).toContain('openrouter');
     }
+    expect(presets[0]!.reviewerCount).toBe(4);
+    expect(presets[0]!.reviewerModels).toEqual(openrouterFastModels);
   });
 
   it('returns fallback presets when no providers detected and no CLI available', () => {
@@ -156,6 +169,24 @@ describe('generatePresets()', () => {
     expect(quick!.providers).toEqual(['openai']);
     expect(quick!.reviewerCount).toBe(1);
     expect(quick!.discussion).toBe(false);
+  });
+
+  it('generates OpenRouter quick preset with the flash lineup', () => {
+    const presets = generatePresets(makeEnv(['openrouter']), null);
+    const quick = presets.find((p) => p.id === 'quick');
+    expect(quick).toBeDefined();
+    expect(quick!.providers).toEqual(['openrouter']);
+    expect(quick!.reviewerCount).toBe(4);
+    expect(quick!.reviewerModels).toEqual(openrouterFastModels);
+  });
+
+  it('generates OpenRouter starter preset for balanced aliases', () => {
+    const presets = generatePresets(makeEnv(['openrouter']), null);
+    const starter = presets.find((p) => p.id === 'free');
+    expect(starter).toBeDefined();
+    expect(starter!.providers).toEqual(['openrouter']);
+    expect(starter!.reviewerCount).toBe(2);
+    expect(starter!.reviewerModels).toEqual(openrouterStarterModels);
   });
 
   it('does not generate free preset when groq is detected', () => {


### PR DESCRIPTION
## Summary
- add a Fast/OpenRouter flash reviewer lineup for quick presets
- make CLI preset aliases generate real configs for fast/balanced/standard flows
- document MCP natural-language routing and demo preset usage

## Verification
- OPENROUTER_API_KEY=dummy pnpm exec tsx -e "import { buildPresetConfig } from './packages/cli/src/commands/init.ts'; void Promise.all(['fast', 'balanced', 'standard', 'premium', 'deep'].map(async (name) => { const config = await buildPresetConfig(name); return [name, config.reviewers.map((r) => r.model)]; })).then((rows) => console.log(JSON.stringify(Object.fromEntries(rows), null, 2)));"
- pnpm exec vitest run packages/cli/src/tests/cli-init-advanced.test.ts src/tests/init-multiselect.test.ts packages/core/src/tests/presets.test.ts
- pnpm --filter @codeagora/cli typecheck && pnpm --filter @codeagora/core typecheck
- git diff --check