### PR TITLE
[codex] degrade provider runtime action failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,11 @@ name: CodeAgora Review
 #   (examples: missing credentials, untrusted context, diff too large, posting failures, stale PR head). Runtime
 #   logs and the job summary include the matching reason plus next-step guidance. Loading the
 #   repository config uses a default path; failures to load the config are surfaced via degraded
-#   outputs but do not change input precedence (CLI > env > default). When review posting is
-#   disabled, the run still executes but is marked degraded. Untrusted fork PRs are
-#   always skipped before provider-backed reviewers are invoked.
+#   outputs but do not change input precedence (CLI > env > default). Provider runtime failures
+#   after startup, such as quota, auth, rate-limit, billing, or provider availability failures,
+#   are also marked degraded instead of being reported as code-review rejects. When review posting
+#   is disabled, the run still executes but is marked degraded. Untrusted fork PRs are always
+#   skipped before provider-backed reviewers are invoked.
 # - `reporter-mode` selects exactly one GitHub verdict reporter: `check-run` or `commit-status`.
 # - GitHub write operations are suppressed after any degraded/untrusted decision. This includes
 #   review comments, verdict reporters, reviewer/label mutations, Code Scanning upload, and the
@@ -60,7 +62,8 @@ inputs:
 outputs:
   verdict:
     description: >
-      Final verdict — ACCEPT, REJECT, NEEDS_HUMAN, or SKIPPED.
+      Final verdict — ACCEPT, REJECT, NEEDS_HUMAN, DEGRADED, or SKIPPED.
+      DEGRADED is returned if provider/runtime infrastructure prevents a review result.
       SKIPPED is returned if the skip label is present or the run cannot start because
       required credentials are missing.
     value: ${{ steps.review.outputs.verdict }}
@@ -80,8 +83,8 @@ outputs:
   degraded:
     description: >
       Whether the action ran in degraded or skipped mode (true if SKIPPED or degraded).
-      Disabled posting, missing credentials, diff limits, stale heads, config failures, and
-      posting failures set this to true.
+      Disabled posting, missing credentials, diff limits, provider runtime failures, stale heads,
+      config failures, and posting failures set this to true.
     value: ${{ steps.review.outputs.degraded }}
 
   degraded-reason:
@@ -89,7 +92,7 @@ outputs:
       Stable reason code for degraded or skipped mode.
       Values include missing-github-token, untrusted-github-context, missing-provider-secrets,
       untrusted-fork-pr, fork-missing-provider-secrets, posting-disabled, diff-too-large,
-      config-load-failed, stale-head-sha, github-post-failed, and sarif-write-failed.
+      config-load-failed, provider-runtime-failed, stale-head-sha, github-post-failed, and sarif-write-failed.
       Always set if degraded is true.
     value: ${{ steps.review.outputs.degraded-reason }}
 

--- a/packages/github/src/action-policy.ts
+++ b/packages/github/src/action-policy.ts
@@ -450,6 +450,15 @@ export function getActionGuidance(reason: ActionDegradedReason): ActionGuidance 
           'Fix the config file and rerun the workflow after the file is readable and valid.',
         ],
       };
+    case 'provider-runtime-failed':
+      return {
+        why: 'The review pipeline started, but provider-backed reviewers could not produce a usable result because credentials, quota, rate limits, network connectivity, or provider availability failed.',
+        nextSteps: [
+          'Run `agora doctor --live` with the same provider credentials to confirm whether the key is valid and within quota.',
+          'Rotate or top up the provider key when the provider reports quota, weekly limit, billing, or authentication failures.',
+          'Rerun the workflow after provider health is restored; this state does not mean CodeAgora found code defects.',
+        ],
+      };
     case 'stale-head-sha':
       return {
         why: 'The PR head changed before CodeAgora could post the review, so the result was skipped.',

--- a/packages/github/src/action.ts
+++ b/packages/github/src/action.ts
@@ -38,6 +38,13 @@ import type { EvidenceDocument } from '@codeagora/core/types/core.js';
 
 const DEFAULT_SARIF_OUTPUT_PATH = '/tmp/codeagora-results.sarif';
 
+function isProviderRuntimePipelineFailure(message: string | undefined): boolean {
+  const text = message ?? '';
+  return /provider\/API failures/i.test(text) ||
+    (/all reviewers failed/i.test(text) && /(auth|api key|credential|quota|rate.?limit|limit exceeded|billing|provider|network|timeout|circuit open)/i.test(text)) ||
+    /(auth error|api key|credential|quota|rate.?limit|limit exceeded|weekly limit|billing|provider unavailable|network connectivity|circuit breaker)/i.test(text);
+}
+
 async function writeSarifOutput(
   evidenceDocs: EvidenceDocument[],
   sessionId: string,
@@ -233,6 +240,20 @@ async function main(): Promise<void> {
   console.log('::endgroup::');
 
   if (result.status === 'error') {
+    if (isProviderRuntimePipelineFailure(result.error)) {
+      const detail = result.error ?? 'Provider-backed reviewers failed before CodeAgora could produce a verdict.';
+      logActionDiagnostic('Provider runtime degraded', 'provider-runtime-failed', detail);
+      markActionDegraded('provider-runtime-failed');
+      writeActionSummary('degraded', 'provider-runtime-failed', detail);
+      writeDocumentedActionOutputs({
+        verdict: 'DEGRADED',
+        reviewUrl: '',
+        sessionId: result.sessionId === 'unknown' ? undefined : result.sessionId,
+      });
+      console.log('Verdict: DEGRADED');
+      return;
+    }
+
     console.error(`::error::Pipeline failed: ${result.error}`);
     process.exit(2);
   }

--- a/packages/github/src/tests/action-runtime.test.ts
+++ b/packages/github/src/tests/action-runtime.test.ts
@@ -504,6 +504,89 @@ describe('GitHub Action runtime', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  it('marks provider runtime failures degraded instead of failing the Action job', async () => {
+    const { mkdtemp, readFile, rm, writeFile } = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'codeagora-action-runtime-'));
+    const outputFile = path.join(tempDir, 'output.txt');
+    const summaryFile = path.join(tempDir, 'summary.md');
+    const diffFile = path.join(tempDir, 'diff.patch');
+    const eventFile = path.join(tempDir, 'event.json');
+
+    process.env.GITHUB_OUTPUT = outputFile;
+    process.env.GITHUB_STEP_SUMMARY = summaryFile;
+    process.env.GITHUB_TOKEN = 'ghp_test';
+    process.env.OPENROUTER_API_KEY = 'provider-secret';
+    process.env.GITHUB_EVENT_NAME = 'pull_request';
+    process.env.GITHUB_EVENT_PATH = eventFile;
+    await writeFile(eventFile, JSON.stringify({ pull_request: { head: { sha: eventHeadSha } } }));
+
+    vi.mocked(mocks.parseActionInputs).mockReturnValue({
+      repo: 'owner/repo',
+      sha: inputSha,
+      pr: 42,
+      diff: diffFile,
+      token: 'ghp_test',
+      configPath: '.ca/config.json',
+      baseSha: 'base123',
+      maxDiffLines: 0,
+      failOnReject: true,
+      postResults: true,
+      reporterMode: 'check-run',
+      baseRepo: 'owner/repo',
+      headRepo: 'owner/repo',
+      checkRunName: 'CodeAgora Review',
+    } as never);
+
+    vi.mocked(mocks.determineActionPolicy).mockReturnValue({
+      degraded: false,
+      shouldRunReview: true,
+      shouldPostResults: true,
+      verdictOverride: undefined,
+    } as never);
+
+    vi.mocked(mocks.validateActionDiffPath).mockResolvedValue(diffFile);
+    vi.mocked(mocks.loadConfigFile).mockResolvedValue({ github: {} } as never);
+    vi.mocked(mocks.runPipeline).mockResolvedValue({
+      status: 'error',
+      sessionId: '001',
+      date: '2026-06-13',
+      error: [
+        'All reviewers failed (forfeited or errored) due to provider/API failures.',
+        '- r-gpt5 (openrouter/openai/gpt-5.3-codex): auth: Auth error (permanent): Key limit exceeded (weekly limit).',
+        'Recovery hint: check provider API keys, quota/rate limits, network connectivity, and circuit breaker status with `agora doctor --live`.',
+      ].join('\n'),
+    } as never);
+
+    await import('../action.js');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mocks.mapToGitHubReview).not.toHaveBeenCalled();
+    expect(mocks.postReview).not.toHaveBeenCalled();
+    expect(mocks.setCommitStatus).not.toHaveBeenCalled();
+    expect(mocks.fetchPrMetadata).not.toHaveBeenCalled();
+    expect(mocks.createAppOctokit).not.toHaveBeenCalled();
+    expect(mocks.handleNeedsHuman).not.toHaveBeenCalled();
+    expect(mocks.validateActionOutputPath).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+
+    const output = await readFile(outputFile, 'utf-8');
+    expect(output).toContain(`head-sha=${eventHeadSha}`);
+    expect(output).toContain('base-sha=base123');
+    expect(output).toContain('degraded=true');
+    expect(output).toContain('degraded-reason=provider-runtime-failed');
+    expect(output).toContain('verdict=DEGRADED');
+    expect(output).toContain('review-url=');
+    expect(output).toContain('session-id=001');
+
+    const summary = await readFile(summaryFile, 'utf-8');
+    expect(summary).toContain('CodeAgora review degraded');
+    expect(summary).toContain('Reason: `provider-runtime-failed`');
+    expect(summary).toContain('Key limit exceeded');
+    expect(summary).toContain('agora doctor --live');
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
   it('blocks privileged GitHub comments, reporters, and mutations when the write context is not trusted', async () => {
     const { mkdtemp, readFile, rm, writeFile } = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'codeagora-action-runtime-'));

--- a/packages/shared/src/contracts/stable.ts
+++ b/packages/shared/src/contracts/stable.ts
@@ -59,6 +59,7 @@ export const ACTION_DEGRADED_REASONS = [
   'posting-disabled',
   'diff-too-large',
   'config-load-failed',
+  'provider-runtime-failed',
   'stale-head-sha',
   'github-post-failed',
   'sarif-write-failed',

--- a/src/tests/github-action-parse-args.test.ts
+++ b/src/tests/github-action-parse-args.test.ts
@@ -454,6 +454,7 @@ describe('github-action production policy', () => {
       'posting-disabled',
       'diff-too-large',
       'config-load-failed',
+      'provider-runtime-failed',
       'stale-head-sha',
       'github-post-failed',
       'sarif-write-failed',
@@ -518,6 +519,14 @@ describe('github-action production policy', () => {
     expect(staleHead.nextSteps).toEqual(expect.arrayContaining([
       expect.stringContaining('Rerun the workflow'),
       expect.stringContaining('branch head'),
+    ]));
+
+    const providerRuntime = getActionGuidance('provider-runtime-failed');
+    expect(providerRuntime.why).toContain('provider-backed reviewers');
+    expect(providerRuntime.nextSteps).toEqual(expect.arrayContaining([
+      expect.stringContaining('agora doctor --live'),
+      expect.stringContaining('quota'),
+      expect.stringContaining('does not mean CodeAgora found code defects'),
     ]));
   });
 });


### PR DESCRIPTION
## Summary
- Treat provider-backed runtime failures in the GitHub Action as `DEGRADED` instead of failing the workflow job.
- Add the stable `provider-runtime-failed` degraded reason with user-facing recovery guidance.
- Regenerate `dist/action.js` and update Action output docs/tests for the new degraded path.

## Root cause
When every reviewer failed because the provider rejected requests, for example quota or weekly key limits, the orchestrator returned an error. The Action treated that as a hard workflow failure, which made provider infrastructure look like a CodeAgora review rejection.

## Validation
- `pnpm build:action`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm vitest run packages/github/src/tests/action-runtime.test.ts src/tests/github-action-parse-args.test.ts packages/github/src/tests/action-reporting.test.ts src/tests/github-actions-runtime.test.ts src/tests/stable-scope-audit.test.ts src/tests/product-surface-reset.test.ts`
- `pnpm test -- --no-file-parallelism`
- `git diff --check`
