### PR TITLE
[codex] stabilize live evidence recovery paths

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -31,6 +31,7 @@ export interface DoctorCheck {
 export interface DoctorResult {
   checks: DoctorCheck[];
   summary: { pass: number; fail: number; warn: number };
+  nextSteps?: string[];
   liveChecks?: LiveCheckResult[];
   cliBackends?: DetectedCli[];
 }
@@ -413,6 +414,54 @@ function summarizeChecks(checks: DoctorCheck[]): DoctorResult['summary'] {
   };
 }
 
+export function buildDoctorNextSteps(result: Pick<DoctorResult, 'checks' | 'liveChecks'>): string[] {
+  const blocking = result.checks.filter((check) => check.status === 'fail');
+  const warnings = result.checks.filter((check) => check.status === 'warn');
+  const nextSteps: string[] = [];
+  const hasConfigFailure = blocking.some((check) => check.name === 'Config file' || check.name === 'Config validity');
+  const hasWorkspaceFailure = blocking.some((check) => check.name === '.ca/ directory');
+  const hasConfiguredApiFailure = blocking.some((check) => check.name === 'Configured API credentials');
+  const hasConfiguredCliFailure = blocking.some((check) => check.name === 'Configured CLI backends');
+  const hasReviewBackendFailure = blocking.some((check) => check.name === 'Review backend');
+  const hasLiveHealthFailure = blocking.some((check) => check.name === 'Live API health');
+  const hasApiWarnings = warnings.some((check) => check.name === 'Available API keys');
+  const hasCliWarnings = warnings.some((check) => check.name === 'Available CLI backends');
+
+  if (hasWorkspaceFailure) {
+    nextSteps.push('Run `agora init` in the workspace to create the missing project files.');
+  }
+  if (hasConfigFailure && !hasWorkspaceFailure) {
+    nextSteps.push('Fix the config errors, then rerun `agora doctor`.');
+  }
+  if (hasConfiguredApiFailure) {
+    nextSteps.push('Run `agora env set <provider> <api-key>` for the missing provider, then rerun `agora doctor --live`.');
+  }
+  if (hasConfiguredCliFailure) {
+    nextSteps.push('Install or authenticate the CLI backends named in `.ca/config`, then rerun `agora doctor`.');
+  }
+  if (hasReviewBackendFailure) {
+    nextSteps.push('Run `agora env set openrouter <api-key>` or install/auth one supported CLI backend, then rerun `agora doctor`.');
+  }
+  if (hasLiveHealthFailure && !hasConfiguredApiFailure) {
+    const failedProviders = Array.from(
+      new Set((result.liveChecks ?? []).filter((check) => check.status !== 'ok').map((check) => check.provider)),
+    );
+    const providerHint = failedProviders.length === 1 ? failedProviders[0] : '<provider>';
+    nextSteps.push(`The key is present, but the provider rejected the live check. Replace it with \`agora env set ${providerHint} <new-api-key>\`, then rerun \`agora doctor --live\`. Credential store: ${getCredentialsPath()}`);
+  } else if (hasApiWarnings) {
+    nextSteps.push('Run `agora env set openrouter <api-key>` if you want API-backed reviews, then rerun `agora doctor --live`.');
+  } else if (hasCliWarnings) {
+    nextSteps.push('Install/auth a CLI backend if you want CLI-backed reviews, then rerun `agora doctor`.');
+  }
+  if (blocking.length === 0 && warnings.length === 0) {
+    nextSteps.push('Run `agora review --dry-run` or `agora review --staged` next.');
+  } else if (blocking.length === 0) {
+    nextSteps.push('Rerun `agora review --dry-run` after the warnings above are resolved.');
+  }
+
+  return nextSteps;
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -518,7 +567,9 @@ export async function runDoctor(baseDir: string): Promise<DoctorResult> {
   checks.push(checkAvailableCliBackends(cliBackends, hasApiKey));
   checks.push(checkReviewBackend(hasApiKey, hasAvailableCli));
 
-  return { checks, summary: summarizeChecks(checks), cliBackends };
+  const result: DoctorResult = { checks, summary: summarizeChecks(checks), cliBackends };
+  result.nextSteps = buildDoctorNextSteps(result);
+  return result;
 }
 
 function summarizeLiveHealth(liveChecks: LiveCheckResult[]): DoctorCheck {
@@ -568,6 +619,7 @@ export async function runDoctorWithLive(baseDir: string): Promise<DoctorResult> 
   }
 
   result.summary = summarizeChecks(result.checks);
+  result.nextSteps = buildDoctorNextSteps(result);
   return result;
 }
 
@@ -823,47 +875,7 @@ export function formatDoctorReport(result: DoctorResult): string {
     lines.push(formatLiveCheckReport(result.liveChecks));
   }
 
-  const nextSteps: string[] = [];
-  const hasConfigFailure = blocking.some((check) => check.name === 'Config file' || check.name === 'Config validity');
-  const hasWorkspaceFailure = blocking.some((check) => check.name === '.ca/ directory');
-  const hasConfiguredApiFailure = blocking.some((check) => check.name === 'Configured API credentials');
-  const hasConfiguredCliFailure = blocking.some((check) => check.name === 'Configured CLI backends');
-  const hasReviewBackendFailure = blocking.some((check) => check.name === 'Review backend');
-  const hasLiveHealthFailure = blocking.some((check) => check.name === 'Live API health');
-  const hasApiWarnings = warnings.some((check) => check.name === 'Available API keys');
-  const hasCliWarnings = warnings.some((check) => check.name === 'Available CLI backends');
-
-  if (hasWorkspaceFailure) {
-    nextSteps.push('Run `agora init` in the workspace to create the missing project files.');
-  }
-  if (hasConfigFailure && !hasWorkspaceFailure) {
-    nextSteps.push('Fix the config errors, then rerun `agora doctor`.');
-  }
-  if (hasConfiguredApiFailure) {
-    nextSteps.push('Run `agora env set <provider> <api-key>` for the missing provider, then rerun `agora doctor --live`.');
-  }
-  if (hasConfiguredCliFailure) {
-    nextSteps.push('Install or authenticate the CLI backends named in `.ca/config`, then rerun `agora doctor`.');
-  }
-  if (hasReviewBackendFailure) {
-    nextSteps.push('Run `agora env set openrouter <api-key>` or install/auth one supported CLI backend, then rerun `agora doctor`.');
-  }
-  if (hasLiveHealthFailure && !hasConfiguredApiFailure) {
-    const failedProviders = Array.from(
-      new Set((result.liveChecks ?? []).filter((check) => check.status !== 'ok').map((check) => check.provider)),
-    );
-    const providerHint = failedProviders.length === 1 ? failedProviders[0] : '<provider>';
-    nextSteps.push(`The key is present, but the provider rejected the live check. Replace it with \`agora env set ${providerHint} <new-api-key>\`, then rerun \`agora doctor --live\`. Credential store: ${getCredentialsPath()}`);
-  } else if (hasApiWarnings) {
-    nextSteps.push('Run `agora env set openrouter <api-key>` if you want API-backed reviews, then rerun `agora doctor --live`.');
-  } else if (hasCliWarnings) {
-    nextSteps.push('Install/auth a CLI backend if you want CLI-backed reviews, then rerun `agora doctor`.');
-  }
-  if (blocking.length === 0 && warnings.length === 0) {
-    nextSteps.push('Run `agora review --dry-run` or `agora review --staged` next.');
-  } else if (blocking.length === 0) {
-    nextSteps.push('Rerun `agora review --dry-run` after the warnings above are resolved.');
-  }
+  const nextSteps = result.nextSteps ?? buildDoctorNextSteps(result);
 
   if (nextSteps.length > 0) {
     lines.push('Next steps');

--- a/packages/cli/src/tests/agent-contract.test.ts
+++ b/packages/cli/src/tests/agent-contract.test.ts
@@ -209,6 +209,11 @@ describe('CLI exit code classification', () => {
     expect(classifyCliErrorExitCode(new Error('Groq rate limit exceeded'))).toBe(3);
     expect(classifyCliErrorExitCode(new Error('Reviewer timed out'))).toBe(3);
     expect(classifyCliErrorExitCode(new Error('Pipeline failed after retries'))).toBe(3);
+    expect(classifyCliErrorExitCode(new Error([
+      'All reviewers failed (forfeited or errored) due to provider/API failures.',
+      '- r1 (openrouter/xiaomi/mimo-v2.5): auth: Auth error (permanent): Missing Authentication header',
+      'Recovery hint: check provider API keys, quota/rate limits, network connectivity, and circuit breaker status with `agora doctor --live`.',
+    ].join('\n')))).toBe(3);
   });
 
   it('redacts secrets from formatted error messages and verbose stacks', () => {

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -54,6 +54,15 @@ export function formatError(error: Error, verbose: boolean): string {
 export function classifyCliErrorExitCode(error: Error): CliExitCode {
   const msg = error.message.toLowerCase();
   if (
+    msg.includes('provider/api failures') ||
+    msg.includes('all reviewers failed') ||
+    msg.includes('forfeited or errored') ||
+    msg.includes('reviewer timed out') ||
+    msg.includes('pipeline timed out')
+  ) {
+    return 3;
+  }
+  if (
     msg.includes('config') ||
     msg.includes('invalid output format') ||
     msg.includes('requires --pr') ||

--- a/src/tests/cli-doctor-live.test.ts
+++ b/src/tests/cli-doctor-live.test.ts
@@ -526,6 +526,10 @@ describe('runDoctorWithLive()', () => {
     expect(result.summary.fail).toBeGreaterThan(0);
     expect(result.liveChecks?.[0].error).toContain('[REDACTED]');
     expect(result.liveChecks?.[0].error).not.toContain('sk-1234567890secret');
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps?.[0]).toContain('agora env set groq <new-api-key>');
+    expect(result.nextSteps?.[0]).toContain('agora doctor --live');
+    expect(result.nextSteps?.[0]).toContain('Credential store:');
     expect(report).toContain('The key is present, but the provider rejected the live check');
     expect(report).toContain('agora env set groq <new-api-key>');
   });


### PR DESCRIPTION
## Summary
- Add structured `nextSteps` to `doctor --json` so automation can recover from live provider failures without scraping text output.
- Keep provider/API all-reviewer failures classified as runtime failures even when recovery hints mention API keys.
- Preserve the existing text doctor output by sharing the same next-step helper.

## Live evidence sweep
- `agora doctor --live --json` currently reaches OpenRouter but fails with `User not found.` for the saved `OPENROUTER_API_KEY`.
- Stable success-path CLI live smoke remains blocked until the provider key is replaced.
- Generated passing local live/error evidence for:
  - `pnpm smoke:cli-invalid-config -- --output .sisyphus/evidence/cli-live-invalid-config-smoke.json`
  - `pnpm smoke:cli-missing-provider-key -- --output .sisyphus/evidence/cli-live-missing-provider-key-smoke.json`
  - `pnpm smoke:cli-provider-failure -- --output .sisyphus/evidence/cli-live-provider-failure-smoke.json`
- `pnpm evidence:manifest -- --require=stable` still reports the expected missing stable artifacts: success-path CLI live smokes, timeout runtime smoke, and desktop macOS signing evidence.

## Validation
- `pnpm vitest run src/tests/cli-doctor-live.test.ts src/tests/cli-commands.test.ts src/tests/cli-env.test.ts`
- `pnpm vitest run packages/cli/src/tests/agent-contract.test.ts src/tests/cli-clean-diff-smoke.test.ts src/tests/cli-doctor-live.test.ts`
- `pnpm typecheck`
- `pnpm --filter @codeagora/cli build`
- `pnpm lint`
- `pnpm test -- --no-file-parallelism`
- `git diff --check`
