### PR TITLE
Stabilize CLI backends and OpenRouter action preset

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # .github
 
@@ -12,7 +12,7 @@ GitHub Actions workflows, issue templates, and PR configuration. Automates CI/CD
 |------|---------|
 | `workflows/ci.yml` | Lint, typecheck, and test on push/PR to main (Node 20, 22) |
 | `workflows/release.yml` | Build and publish npm packages on version tag (v*) |
-| `workflows/review.yml` | Run CodeAgora review on PRs; post findings as comments (skippable via `review:skip` label) |
+| `workflows/review.yml` | Run CodeAgora review on PRs; requires `OPENROUTER_API_KEY`, skips forks and `review:skip` PRs, posts findings through the local composite Action |
 | `workflows/pr-size.yml` | Auto-label PRs by diff size (XS, S, M, L, XL) |
 | `workflows/build-action.yml` | Rebuild `dist/action.js` bundle on push to main (auto-commits via `[skip ci]`) |
 | `workflows/provider-health.yml` | Scheduled provider health checks across registered API providers |
@@ -31,6 +31,10 @@ GitHub Actions workflows, issue templates, and PR configuration. Automates CI/CD
 - **Node version matrix**: CI tests against Node 20 and 22; update `matrix.node-version` if adding new versions
 - **pnpm version**: Currently pinned to `version: 10` in workflow steps; update when upgrading
 - **Review workflow**: Checks for `review:skip` label to skip CodeAgora review; respects PR size threshold
+- **OpenRouter secret handling**: Pass `OPENROUTER_API_KEY` only through `env: OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}`. Do not write provider keys into generated `.ca/config.json`, logs, docs examples, or committed files.
+- **Fork PR boundary**: Untrusted fork PRs must skip before provider-backed reviewers run. Do not weaken this to "try without secrets".
+- **Action-source verification**: Changes to `action.yml`, `.github/workflows/review.yml`, `.github/workflows/build-action.yml`, or bundled Action runtime inputs/outputs require `pnpm build:action` plus focused Action tests.
+- **Evidence boundary**: CI and degraded-path tests prove deterministic policy behavior. Live Action posting evidence requires a real `pull_request` workflow run and matching evidence artifacts.
 - **Release triggers**: Triggered only on tags matching `v*` pattern (e.g., `v1.2.3`)
 - **Issue templates**: Update YAML frontmatter in `.md` files for form fields and defaults
 - **Permissions**: Review workflow has read/write perms for PRs and status checks; release has write for contents

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -50,24 +50,25 @@ jobs:
             "mode": "pragmatic",
             "language": "ko",
             "reviewers": [
-              { "id": "r-gpt5", "model": "openai/gpt-5.3-codex", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:logic" },
-              { "id": "r-sonnet", "model": "anthropic/claude-sonnet-4.6", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:security" },
-              { "id": "r-deepseek", "model": "deepseek/deepseek-v4-flash", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:api-contract" }
+              { "id": "r-qwen235", "model": "qwen/qwen3-235b-a22b-2507", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:logic" },
+              { "id": "r-deepseek", "model": "deepseek/deepseek-v4-flash", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:api-contract" },
+              { "id": "r-qwen9", "model": "qwen/qwen3.5-9b", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:general" },
+              { "id": "r-glm-flash", "model": "z-ai/glm-4.7-flash", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:security" },
+              { "id": "r-gpt-oss", "model": "openai/gpt-oss-120b", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180, "persona": "builtin:logic" }
             ],
             "supporters": {
               "pool": [
-                { "id": "s-glm", "model": "z-ai/glm-5.1", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180 },
-                { "id": "s-minimax", "model": "minimax/minimax-m3", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180 }
+                { "id": "s-glm", "model": "z-ai/glm-5.1", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180 }
               ],
-              "pickCount": 2,
+              "pickCount": 1,
               "pickStrategy": "random",
-              "devilsAdvocate": { "id": "da-grok", "model": "x-ai/grok-4.3", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180 },
+              "devilsAdvocate": { "id": "da-kimi", "model": "moonshotai/kimi-k2.5", "backend": "api", "provider": "openrouter", "enabled": true, "timeout": 180 },
               "personaPool": ["builtin:security", "builtin:logic", "builtin:api-contract", "builtin:general"],
               "personaAssignment": "random"
             },
-            "moderator": { "model": "openai/gpt-5.3-codex", "backend": "api", "provider": "openrouter", "timeout": 180 },
-            "discussion": { "maxRounds": 2, "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null }, "codeSnippetRange": 10 },
-            "head": { "backend": "api", "model": "qwen/qwen3.7-max", "provider": "openrouter", "enabled": true, "timeout": 180 },
+            "moderator": { "model": "z-ai/glm-5.1", "backend": "api", "provider": "openrouter", "enabled": false, "timeout": 180 },
+            "discussion": { "maxRounds": 1, "registrationThreshold": { "HARSHLY_CRITICAL": 1, "CRITICAL": 1, "WARNING": 2, "SUGGESTION": null }, "codeSnippetRange": 10 },
+            "head": { "backend": "api", "model": "z-ai/glm-5.1", "provider": "openrouter", "enabled": true, "timeout": 180 },
             "errorHandling": { "maxRetries": 1, "forfeitThreshold": 0.7 }
           }
           CONF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
-<!-- Generated: 2026-03-20 | Updated: 2026-06-05 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # CodeAgora
 
 ## Purpose
-Multi-LLM code review pipeline where multiple AI reviewers independently analyze code, debate conflicting opinions, and a head agent renders a final verdict. Supported release surfaces are the CLI, GitHub Action, MCP server, and Tauri desktop app.
+Multi-LLM code review pipeline where API and local CLI reviewers independently analyze code, debate conflicting opinions, and a head agent renders a final verdict. Supported release surfaces are the CLI, GitHub Action, MCP server, and Tauri desktop app; all four must route through shared core behavior rather than defining separate review semantics.
 
 ## Key Files
 
@@ -45,6 +45,22 @@ Multi-LLM code review pipeline where multiple AI reviewers independently analyze
 - Run CLI in dev: `pnpm dev <command>`
 - Regenerate the bundled GitHub Action after action-source changes: `pnpm build:action`
 - Package/evidence smoke: `pnpm release:beta-smoke`, `pnpm evidence:manifest -- --require=rc`
+- For `agora init --preset ...`, the source of truth is `packages/cli/src/commands/init.ts` (`generatePresets`, `buildPresetConfig`, and `PRESET_ALIASES`).
+- Validate local CLI backend readiness with `agora doctor` / `agora doctor --live`; CLI-backed configs may run without provider API keys only when required local tools are installed and authenticated.
+- For GitHub Action setup, prefer `agora init --preset action` / `--preset github-action`; this is the cheap OpenRouter Actions preset.
+
+### Runtime Scope And Presets
+- Supported release surfaces are exactly CLI, GitHub Action, MCP, and Desktop unless roadmap and release evidence are updated first.
+- The GitHub Action preset is OpenRouter-only, cheap by default, uses five low-cost reviewers, one discussion round, and direct head escalation via `z-ai/glm-5.1`.
+- `fast` and `budget` alias to `quick`; `balanced` and `standard` alias to `free`; `local` and `local-cli` alias to `cli`; `gha` and `github-action` alias to `action`.
+- Local CLI presets are for installed/authenticated local tools such as Codex, Claude, OpenCode, Cursor, and Antigravity. Do not add Copilot to the default CLI preset without an explicit decision.
+
+### Credentials And Key Handling
+- Prefer `agora env set <provider>` for local provider keys; saved credentials live in `~/.config/codeagora/credentials` with `0o600` permissions.
+- Environment variables remain supported, especially `OPENROUTER_API_KEY` for GitHub Actions and smoke tests.
+- Never store provider keys in `.ca/config.*`, committed docs, fixtures, session artifacts, or evidence logs.
+- Error output, JSON/NDJSON contracts, MCP responses, Desktop exports, and evidence artifacts must redact secrets.
+- GitHub token handling is separate from provider credentials; fork PRs and missing secrets must degrade safely before provider-backed work.
 
 ### Architecture Overview
 ```
@@ -64,6 +80,9 @@ CLI Layer → L0 (Model Intelligence) → Pre-Analysis → L1 (Parallel Reviewer
 - Run: `pnpm test` (root Vitest config includes root and package-local tests)
 - E2E tests use `forks` pool; unit tests use default pool
 - Coverage targets the active workspace packages under `packages/*`
+- Local CLI backend changes need smoke coverage for CLI-backed readiness paths as well as API-key-backed paths; dry-run plumbing is not live provider evidence.
+- GitHub Action preset or runtime changes need focused Action tests and `pnpm build:action` when the bundled runtime can change.
+- MCP behavior changes should verify tool listing/calls through the MCP SDK path, not hand-rolled JSON-RPC framing.
 
 ### Common Patterns
 - TypeScript strict mode everywhere
@@ -76,7 +95,9 @@ CLI Layer → L0 (Model Intelligence) → Pre-Analysis → L1 (Parallel Reviewer
 - Do not reintroduce retired web dashboard, terminal TUI, or notification package surfaces.
 - Keep desktop claims backed by package, launch, WebDriver, visual QA, export, signing/notarization/updater, and release-evidence gates.
 - Do not widen the stable release contract beyond CLI, GitHub Action, MCP, and Desktop without explicit roadmap/evidence updates.
-- Do not treat deterministic tests as live provider or live GitHub evidence; release claims need the artifacts named in `docs/archived/RELEASE_EVIDENCE.md`.
+- Keep Desktop as an official supported local UI surface, but do not let Desktop introduce config formats, verdict semantics, or release promises that diverge from CLI, GitHub Action, or MCP.
+- Do not treat deterministic tests, dry-runs, or provider-free smoke as live provider, live CLI quality, or live GitHub evidence; release claims need the artifacts and tiers named in `docs/archived/RELEASE_EVIDENCE.md`.
+- Stable GitHub Action claims require real pull-request workflow evidence, including degraded paths for forks, missing provider secrets, stale heads, oversized diffs, provider failures, and posting failures.
 
 ## Repository Map
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,10 +1,10 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-06-05 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # packages
 
 ## Purpose
-Monorepo workspace containing scoped packages (`@codeagora/*`) that implement the multi-LLM code review pipeline. Each package has a focused responsibility: shared utilities and types, core review logic (L0-L3), CLI entrypoint, GitHub integration, MCP server support, and the official desktop UI.
+Monorepo workspace containing scoped packages (`@codeagora/*`) that implement the multi-LLM code review pipeline. Each package has a focused responsibility: shared utilities and types, core review logic (L0-L3), CLI entrypoint, GitHub integration, MCP-compatible agent/IDE support, and the official desktop UI.
 
 ## Subdirectories
 
@@ -14,7 +14,7 @@ Monorepo workspace containing scoped packages (`@codeagora/*`) that implement th
 | `core/` | Review pipeline implementation (L0 model intelligence, L1 parallel reviewers, L2 debate, L3 head verdict), config management, session handling, plugin system |
 | `cli/` | CLI entrypoint (`codeagora` / `agora` commands), command definitions, formatters, user prompts — orchestrates core pipeline |
 | `github/` | GitHub PR integration: diff parsing, SARIF generation, comment posting, deduplication, Actions support |
-| `mcp/` | MCP (Model Context Protocol) server with 9 tools exposing review pipeline to Claude and other MCP clients |
+| `mcp/` | MCP (Model Context Protocol) server with 9 tools exposing the review pipeline to MCP-compatible clients, IDEs, and agents |
 | `desktop/` | Official Tauri app over existing CLI/core/session/config contracts |
 
 ## For AI Agents
@@ -37,12 +37,18 @@ Monorepo workspace containing scoped packages (`@codeagora/*`) that implement th
 - `pnpm dev <command>` — run the CLI package directly
 - Each package has its own `package.json` with `main`, `types`, and `bin` (if applicable)
 
+**Current Stabilization Focus:**
+- Stable package work targets CLI, GitHub Action, MCP, and Desktop only.
+- Action-source changes require `pnpm build:action` and an intentional `dist/action.js` diff review.
+- Desktop bridge, Rust, package, or release-evidence changes require the relevant desktop gate, normally `pnpm rc:desktop-gate`.
+- Release/evidence changes require `pnpm evidence:manifest -- --require=rc` when making RC/stable claims.
+
 **Dependencies Flow:**
 - `shared` — no internal deps, foundation layer
 - `core` — depends on `shared`
 - `cli`, `github`, `mcp`, `desktop` — depend on `core`/`shared` contracts, directly or through CLI/session artifacts
 - `cli` also depends on `github` (orchestration)
-- `mcp` also depends on `cli` (tools expose CLI functions)
+- `mcp` imports selected CLI modules for command/review behavior; keep package startup, `tools/list`, and packed-runtime smoke green when changing this boundary.
 
 ### Common Patterns
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # CLI Package (@codeagora/cli)
 
@@ -22,6 +22,7 @@ Core command modules:
 - `init.ts` — Project initialization wizard; creates `.ca/config.json` or `.ca/config.yaml`
 - `review.ts` (in index.ts) — Main review pipeline orchestrator; handles stdin, --pr, --staged
 - `doctor.ts` — Environment and configuration health checks
+- `env.ts` — Local provider key storage and status helpers
 - `providers.ts` — List supported providers and API key status
 - `sessions.ts` — Past review session management (list, show, diff, prune, stats)
 - `models.ts` — Model performance leaderboard
@@ -31,8 +32,12 @@ Core command modules:
 - `costs.ts` — Cost analytics and summaries
 - `status.ts` — CodeAgora status overview
 - `config-set.ts` — Config value mutations (dot notation)
+- `config-get.ts` — Config value reads
 - `providers-test.ts` — API key status verification
 - `learn.ts` — Pattern learning and management
+- `review.ts` — Review entry behavior for stdin, file path, `--staged`, PR, dry-run, and output modes
+- `trace.ts` — Trace/session inspection helpers
+- `register-init.ts`, `register-sessions.ts` — Commander registration for init/session commands
 
 ### formatters/
 Output formatters:
@@ -54,6 +59,8 @@ Output formatters:
 3. Diff input can come from: file path, stdin, --pr (GitHub), or --staged (git)
 4. Output formatting is centralized in `formatters/`
 5. Error handling uses `formatError()` and `classifyError()` for consistent UX
+6. CLI is the executable contract used by GitHub Action, MCP, and Desktop; avoid behavior that only works through one adapter.
+7. Preserve JSON/NDJSON stdout purity. Human progress, warnings, and diagnostics must not corrupt machine-readable output streams.
 
 ### Common Patterns
 - **Diff acquisition**: Handle file path, stdin, --pr URL parsing, --staged git diff
@@ -62,6 +69,9 @@ Output formatters:
 - **Session management**: Store in `.ca/sessions/{YYYY-MM-DD}/{NNN}/`
 - **Config validation**: Load and validate via `@codeagora/core/config/loader`
 - **Credential loading**: Call `loadCredentials()` at startup to populate environment
+- **Key UX**: Local provider keys should be managed through `agora env set <provider>` and redacted in every status/error path.
+- **Preset source of truth**: `src/commands/init.ts` owns `quick`, `free`, `thorough`, `cli`, and `action` presets plus aliases. Keep CLI help, tests, and generated config behavior aligned.
+- **Runtime failures**: Provider/setup/runtime failures should be structured and actionable, with dry-run or doctor next-step guidance where possible.
 
 ### Adding a New Command
 1. Create a new file in `src/commands/`

--- a/packages/cli/src/AGENTS.md
+++ b/packages/cli/src/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # CLI Source Directory
 
@@ -10,7 +10,7 @@ Core CLI source code: entrypoint, commands, formatters, options parsing, and uti
 | File | Description |
 |------|-------------|
 | `index.ts` | CLI entrypoint and main command router |
-| `commands/` | 14 command modules |
+| `commands/` | Flat command modules; verify current inventory before editing |
 | `formatters/` | Output formatting logic |
 | `options/` | CLI option parsing |
 | `utils/` | Helper functions |
@@ -28,6 +28,9 @@ Core CLI source code: entrypoint, commands, formatters, options parsing, and uti
 - Check `formatters/` to see output formatting patterns
 - Use `utils/colors.ts` and `utils/errors.ts` for consistent styling and error handling
 - Commands integrate with the core pipeline via `runPipeline()` from `@codeagora/core`
+- `commands/review.ts` owns stdin/path/`--staged`/PR/dry-run review entry behavior.
+- Formatters own machine-readable output stability; do not add progress or warnings to JSON/NDJSON stdout.
+- Stable CLI options need help text, CLI reference/docs parity, and focused tests when added or changed.
 
 ### Common Patterns
 - Commands use async/await and commander hooks
@@ -35,6 +38,7 @@ Core CLI source code: entrypoint, commands, formatters, options parsing, and uti
 - All commands export a primary function that is called by the command handler
 - Error handling uses `classifyError()` to determine exit codes
 - i18n support via `t()` from `@codeagora/shared/i18n`
+- `commands/init.ts` is the source of truth for generated presets, including local CLI and OpenRouter Action presets.
 
 ## Dependencies
 - Core: `@codeagora/core`, `@codeagora/shared`

--- a/packages/cli/src/commands/AGENTS.md
+++ b/packages/cli/src/commands/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # CLI Commands Directory
 
@@ -9,8 +9,9 @@ Command implementations for CodeAgora CLI. Each file exports a public function t
 ## Key Files
 | File | Description |
 |------|-------------|
-| `init.ts` | Initialize CodeAgora in a project (wizard + default setup) |
+| `init.ts` | Initialize CodeAgora in a project; owns presets, aliases, generated configs, and local/Action setup UX |
 | `doctor.ts` | Environment and config health checks |
+| `env.ts` | Local provider key storage/status commands |
 | `providers.ts` | List supported providers and API key status |
 | `providers-test.ts` | Verify API keys work (live tests) |
 | `sessions.ts` | Past review session management |
@@ -21,6 +22,7 @@ Command implementations for CodeAgora CLI. Each file exports a public function t
 | `costs.ts` | Cost analytics |
 | `status.ts` | CodeAgora status overview |
 | `config-set.ts` | Mutate config values |
+| `config-get.ts` | Read config values |
 | `learn.ts` | Pattern learning |
 
 ## Subdirectories
@@ -34,6 +36,9 @@ None — all commands are flat in this directory.
 - Session commands read from `.ca/sessions/{YYYY-MM-DD}/{NNN}/`
 - Config commands read from `.ca/config.json` or `.ca/config.yaml`
 - All external input is validated before use
+- Keep `init.ts` preset output aligned with tests in `src/tests/init-multiselect.test.ts` and `packages/cli/src/tests/cli-init-advanced.test.ts`.
+- `agora env set <provider>` is the preferred local key UX. Do not print saved key values; status output should show presence only.
+- Action setup should prefer `--preset action` / `--preset github-action` and `OPENROUTER_API_KEY`.
 
 ### Common Patterns
 - **Session format**: `YYYY-MM-DD/NNN` (date/ID)
@@ -41,6 +46,8 @@ None — all commands are flat in this directory.
 - **File operations**: All async via `fs/promises`
 - **Output**: Return formatted strings or structured data for `formatters/` to render
 - **Error handling**: Throw descriptive errors; CLI layer catches and formats
+- **Machine output**: JSON/NDJSON command output must remain parseable and free of human diagnostics on stdout.
+- **Backend setup**: Distinguish API providers that need environment/credential keys from CLI backends that need installed/authenticated local tools.
 
 ### Adding a New Command
 1. Create `command-name.ts` in this directory

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -438,20 +438,8 @@ export function buildDoctorNextSteps(result: Pick<DoctorResult, 'checks' | 'live
     nextSteps.push('Run `gh secret set OPENROUTER_API_KEY` to add the repository secret used by GitHub Actions.');
   }
 
-  if (hasWorkspaceFailure && !needsOpenRouterActionSetup) {
-    nextSteps.push('Run `agora init` in the workspace to create the missing project files.');
-  }
-  if (hasConfigFailure && !hasWorkspaceFailure && !needsOpenRouterActionSetup) {
-    nextSteps.push('Fix the config errors, then rerun `agora doctor`.');
-  }
-  if (hasConfiguredApiFailure && !needsOpenRouterActionSetup) {
-    nextSteps.push('Run `agora env set <provider> <api-key>` for the missing provider, then rerun `agora doctor --live`.');
-  }
   if (hasConfiguredCliFailure) {
     nextSteps.push('Install or authenticate the CLI backends named in `.ca/config`, then rerun `agora doctor`.');
-  }
-  if (hasReviewBackendFailure && !needsOpenRouterActionSetup) {
-    nextSteps.push('Run `agora env set openrouter <api-key>` or install/auth one supported CLI backend, then rerun `agora doctor`.');
   }
   if (hasLiveHealthFailure && !hasConfiguredApiFailure) {
     const failedProviders = Array.from(
@@ -459,8 +447,6 @@ export function buildDoctorNextSteps(result: Pick<DoctorResult, 'checks' | 'live
     );
     const providerHint = failedProviders.length === 1 ? failedProviders[0] : '<provider>';
     nextSteps.push(`The key is present, but the provider rejected the live check. Replace it with \`agora env set ${providerHint} <new-api-key>\`, then rerun \`agora doctor --live\`. Credential store: ${getCredentialsPath()}`);
-  } else if (hasApiWarnings && !needsOpenRouterActionSetup) {
-    nextSteps.push('Run `agora env set openrouter <api-key>` if you want API-backed reviews, then rerun `agora doctor --live`.');
   } else if (hasCliWarnings) {
     nextSteps.push('Install/auth a CLI backend if you want CLI-backed reviews, then rerun `agora doctor`.');
   }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -426,20 +426,31 @@ export function buildDoctorNextSteps(result: Pick<DoctorResult, 'checks' | 'live
   const hasLiveHealthFailure = blocking.some((check) => check.name === 'Live API health');
   const hasApiWarnings = warnings.some((check) => check.name === 'Available API keys');
   const hasCliWarnings = warnings.some((check) => check.name === 'Available CLI backends');
+  const needsOpenRouterActionSetup = hasWorkspaceFailure ||
+    hasConfigFailure ||
+    hasConfiguredApiFailure ||
+    hasReviewBackendFailure ||
+    hasApiWarnings;
 
-  if (hasWorkspaceFailure) {
+  if (needsOpenRouterActionSetup) {
+    nextSteps.push('Run `agora env set openrouter` to save your OpenRouter key locally.');
+    nextSteps.push('Run `agora init --preset action --ci` to create CodeAgora config and the GitHub Actions workflow.');
+    nextSteps.push('Run `gh secret set OPENROUTER_API_KEY` to add the repository secret used by GitHub Actions.');
+  }
+
+  if (hasWorkspaceFailure && !needsOpenRouterActionSetup) {
     nextSteps.push('Run `agora init` in the workspace to create the missing project files.');
   }
-  if (hasConfigFailure && !hasWorkspaceFailure) {
+  if (hasConfigFailure && !hasWorkspaceFailure && !needsOpenRouterActionSetup) {
     nextSteps.push('Fix the config errors, then rerun `agora doctor`.');
   }
-  if (hasConfiguredApiFailure) {
+  if (hasConfiguredApiFailure && !needsOpenRouterActionSetup) {
     nextSteps.push('Run `agora env set <provider> <api-key>` for the missing provider, then rerun `agora doctor --live`.');
   }
   if (hasConfiguredCliFailure) {
     nextSteps.push('Install or authenticate the CLI backends named in `.ca/config`, then rerun `agora doctor`.');
   }
-  if (hasReviewBackendFailure) {
+  if (hasReviewBackendFailure && !needsOpenRouterActionSetup) {
     nextSteps.push('Run `agora env set openrouter <api-key>` or install/auth one supported CLI backend, then rerun `agora doctor`.');
   }
   if (hasLiveHealthFailure && !hasConfiguredApiFailure) {
@@ -448,7 +459,7 @@ export function buildDoctorNextSteps(result: Pick<DoctorResult, 'checks' | 'live
     );
     const providerHint = failedProviders.length === 1 ? failedProviders[0] : '<provider>';
     nextSteps.push(`The key is present, but the provider rejected the live check. Replace it with \`agora env set ${providerHint} <new-api-key>\`, then rerun \`agora doctor --live\`. Credential store: ${getCredentialsPath()}`);
-  } else if (hasApiWarnings) {
+  } else if (hasApiWarnings && !needsOpenRouterActionSetup) {
     nextSteps.push('Run `agora env set openrouter <api-key>` if you want API-backed reviews, then rerun `agora doctor --live`.');
   } else if (hasCliWarnings) {
     nextSteps.push('Install/auth a CLI backend if you want CLI-backed reviews, then rerun `agora doctor`.');

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -55,7 +55,7 @@ interface AgentEntry { id: string; label?: string; model: string; backend: strin
 export interface GeneratedConfig {
   reviewers: AgentEntry[];
   supporters: { pool: AgentEntry[]; pickCount: number; pickStrategy: string; devilsAdvocate: AgentEntry; personaPool: string[]; personaAssignment: string };
-  moderator: { model: string; backend: string; provider: string };
+  moderator: { model: string; backend: string; provider?: string; enabled?: boolean };
   discussion: { enabled: boolean; maxRounds: number; registrationThreshold: Record<string, number | null>; codeSnippetRange: number };
   errorHandling: { maxRetries: number; forfeitThreshold: number };
   [key: string]: unknown;
@@ -73,6 +73,7 @@ export interface ProviderModelSelection {
   provider: string;
   model: string;
   backend: 'api' | 'cli';
+  runtimeProvider?: string;
   contextWindow?: number;
   isFree?: boolean;
 }
@@ -83,6 +84,12 @@ export interface MultiProviderConfigParams {
   discussion: boolean;
   mode?: ReviewMode;
   language?: Language;
+  maxRounds?: number;
+  supporterSelection?: ProviderModelSelection;
+  devilsAdvocateSelection?: ProviderModelSelection;
+  moderatorSelection?: ProviderModelSelection;
+  moderatorEnabled?: boolean;
+  headSelection?: ProviderModelSelection;
 }
 
 export interface DynamicPreset {
@@ -91,10 +98,19 @@ export interface DynamicPreset {
   labelKo: string;
   providers: string[];
   models: Record<string, string>;
+  runtimeProviders?: Record<string, string>;
   reviewerModels?: string[];
   reviewerCount: number;
   discussion: boolean;
+  maxRounds?: number;
   backend: 'api' | 'cli';
+  roleSelections?: {
+    supporter?: ProviderModelSelection;
+    devilsAdvocate?: ProviderModelSelection;
+    moderator?: ProviderModelSelection;
+    moderatorEnabled?: boolean;
+    head?: ProviderModelSelection;
+  };
 }
 
 const PRESET_ALIASES: Record<string, string> = {
@@ -104,6 +120,11 @@ const PRESET_ALIASES: Record<string, string> = {
   standard: 'free',
   premium: 'thorough',
   deep: 'thorough',
+  local: 'cli',
+  'local-cli': 'cli',
+  action: 'action',
+  gha: 'action',
+  'github-action': 'action',
 };
 
 export const PRESET_ALIAS_ENTRIES = Object.entries(PRESET_ALIASES).map(
@@ -286,7 +307,19 @@ export function buildCustomConfig(params: CustomConfigParams): GeneratedConfig {
  * - Moderator/Head: strongest model (highest context window from selections)
  */
 export function buildMultiProviderConfig(params: MultiProviderConfigParams): GeneratedConfig {
-  const { selections, reviewerCount, discussion, mode = 'pragmatic', language = 'en' } = params;
+  const {
+    selections,
+    reviewerCount,
+    discussion,
+    mode = 'pragmatic',
+    language = 'en',
+    maxRounds,
+    supporterSelection,
+    devilsAdvocateSelection,
+    moderatorSelection,
+    moderatorEnabled,
+    headSelection,
+  } = params;
 
   if (reviewerCount < 1 || reviewerCount > 10) {
     throw new Error(`reviewerCount must be between 1 and 10, got ${reviewerCount}`);
@@ -296,62 +329,67 @@ export function buildMultiProviderConfig(params: MultiProviderConfigParams): Gen
   }
 
   const preset = getModePreset(mode);
+  const selectionBackend = (sel: ProviderModelSelection): Backend => (
+    sel.backend === 'cli' ? sel.provider as Backend : 'api'
+  );
+  const selectionProvider = (sel: ProviderModelSelection): string | undefined => (
+    sel.backend === 'cli'
+      ? sel.runtimeProvider
+      : sel.provider
+  );
+  const agentFromSelection = (id: string, sel: ProviderModelSelection, label?: string): AgentEntry => ({
+    id,
+    ...(label ? { label } : {}),
+    model: sel.model,
+    backend: selectionBackend(sel),
+    provider: selectionProvider(sel),
+    enabled: true,
+    timeout: 120,
+  } as AgentEntry);
 
   // Distribute reviewers across providers evenly
   const reviewers: AgentEntry[] = [];
   for (let i = 0; i < reviewerCount; i++) {
     const sel = selections[i % selections.length]!;
-    const isCli = sel.backend === 'cli';
-    reviewers.push({
-      id: `r${i + 1}`,
-      label: `${sel.provider} ${sel.model} Reviewer ${i + 1}`,
-      model: sel.model,
-      backend: (isCli ? sel.provider : 'api') as Backend,
-      provider: isCli ? undefined : sel.provider,
-      enabled: true,
-      timeout: 120,
-    } as AgentEntry);
+    reviewers.push(agentFromSelection(`r${i + 1}`, sel, `${sel.provider} ${sel.model} Reviewer ${i + 1}`));
   }
 
   // Supporters: prefer a different provider than the first reviewer for diversity
-  const supporterSel = selections.length > 1 ? selections[1]! : selections[0]!;
-  const supporterBase = {
-    model: supporterSel.model,
-    backend: supporterSel.backend,
-    provider: supporterSel.provider,
-    enabled: true,
-    timeout: 120,
-  };
+  const supporterSel = supporterSelection ?? (selections.length > 1 ? selections[1]! : selections[0]!);
+  const devilsSel = devilsAdvocateSelection ?? supporterSel;
 
   // Moderator/Head: strongest model (highest context window, then first in list)
   const strongest = [...selections].sort((a, b) => (b.contextWindow ?? 0) - (a.contextWindow ?? 0))[0]!;
+  const moderatorSel = moderatorSelection ?? strongest;
+  const headSel = headSelection ?? moderatorSel;
 
   return {
     mode,
     language,
     reviewers,
     supporters: {
-      pool: [{ id: 's1', ...supporterBase }],
+      pool: [agentFromSelection('s1', supporterSel)],
       pickCount: 1,
       pickStrategy: 'random',
-      devilsAdvocate: { id: 'da', ...supporterBase },
+      devilsAdvocate: agentFromSelection('da', devilsSel),
       personaPool: preset.personaPool,
       personaAssignment: 'random',
     },
     moderator: {
-      model: strongest.model,
-      backend: strongest.backend,
-      provider: strongest.provider,
+      model: moderatorSel.model,
+      backend: selectionBackend(moderatorSel),
+      provider: selectionProvider(moderatorSel),
+      enabled: moderatorEnabled ?? true,
     },
     head: {
-      backend: strongest.backend,
-      model: strongest.model,
-      provider: strongest.provider,
+      backend: selectionBackend(headSel),
+      model: headSel.model,
+      provider: selectionProvider(headSel),
       enabled: true,
     },
     discussion: {
       enabled: discussion !== false,
-      maxRounds: preset.maxRounds,
+      maxRounds: maxRounds ?? preset.maxRounds,
       registrationThreshold: preset.registrationThreshold,
       codeSnippetRange: 10,
     },
@@ -382,16 +420,77 @@ const OPENROUTER_FAST_REVIEWERS = [
   'qwen/qwen3-coder-flash',
 ];
 
+const OPENROUTER_ACTION_CHEAP_REVIEWERS = [
+  'qwen/qwen3-235b-a22b-2507',
+  'deepseek/deepseek-v4-flash',
+  'qwen/qwen3.5-9b',
+  'z-ai/glm-4.7-flash',
+  'openai/gpt-oss-120b',
+];
+
+const OPENROUTER_ACTION_SUPPORTER = 'z-ai/glm-5.1';
+const OPENROUTER_ACTION_DEVILS_ADVOCATE = 'moonshotai/kimi-k2.5';
+const OPENROUTER_ACTION_HEAD = 'z-ai/glm-5.1';
+
 const OPENROUTER_STARTER_REVIEWERS = [
   'qwen/qwen3-coder-flash',
   'qwen/qwen3-next-80b-a3b-instruct',
 ];
+
+const CLI_BACKEND_DEFAULT_MODELS: Record<string, string> = {
+  antigravity: 'default',
+  claude: 'haiku',
+  codex: 'gpt-5.4-mini',
+  cursor: 'default',
+  gemini: 'gemini-2.5-pro',
+  opencode: 'deepseek-v4-flash',
+  pi: 'default',
+};
+
+const LOCAL_CLI_SUPPORTER_MODEL = 'gpt-5.3-codex-spark';
+const LOCAL_CLI_HEAD_MODEL = 'gpt-5.5';
+const LOCAL_CLI_DEVILS_ADVOCATE_MODEL = 'kimi-k2.7-code';
+
+const CLI_BACKEND_RUNTIME_PROVIDERS: Record<string, string> = {
+  opencode: 'opencode-go',
+};
+
+const CLI_PRESET_ORDER = [
+  'codex',
+  'claude',
+  'opencode',
+  'cursor',
+  'antigravity',
+  'gemini',
+  'pi',
+];
+
+const CLI_PRESET_EXCLUDED_BACKENDS = new Set(['copilot']);
 
 // ============================================================================
 // Static fallback presets (used when catalog/detection unavailable)
 // ============================================================================
 
 const FALLBACK_PRESETS: DynamicPreset[] = [
+  {
+    id: 'action',
+    label: 'GitHub Action review (OpenRouter cheap)',
+    labelKo: 'GitHub Action \uB9AC\uBDF0 (OpenRouter \uC800\uBE44\uC6A9)',
+    providers: ['openrouter'],
+    models: { openrouter: OPENROUTER_ACTION_CHEAP_REVIEWERS[0]! },
+    reviewerModels: OPENROUTER_ACTION_CHEAP_REVIEWERS,
+    reviewerCount: OPENROUTER_ACTION_CHEAP_REVIEWERS.length,
+    discussion: true,
+    maxRounds: 1,
+    backend: 'api',
+    roleSelections: {
+      supporter: { provider: 'openrouter', model: OPENROUTER_ACTION_SUPPORTER, backend: 'api' },
+      devilsAdvocate: { provider: 'openrouter', model: OPENROUTER_ACTION_DEVILS_ADVOCATE, backend: 'api' },
+      moderator: { provider: 'openrouter', model: OPENROUTER_ACTION_HEAD, backend: 'api' },
+      moderatorEnabled: false,
+      head: { provider: 'openrouter', model: OPENROUTER_ACTION_HEAD, backend: 'api' },
+    },
+  },
   {
     id: 'quick',
     label: 'Quick review (OpenRouter)',
@@ -465,6 +564,8 @@ export function generatePresets(
     }
     return PROVIDER_DEFAULT_MODELS[provider] ?? 'xiaomi/mimo-v2.5';
   }
+
+  presets.push(FALLBACK_PRESETS.find((preset) => preset.id === 'action')!);
 
   // 1. "Quick review" — fastest available provider, no discussion
   if (detected.length > 0) {
@@ -546,22 +647,62 @@ export function generatePresets(
   }
 
   // 4. "CLI review" — if CLI backends detected
-  const availableCli = cliBackends?.filter((c) => c.available) ?? [];
+  const availableCli = [...(cliBackends?.filter((c) => c.available && !CLI_PRESET_EXCLUDED_BACKENDS.has(c.backend)) ?? [])].sort((a, b) => {
+    const aIndex = CLI_PRESET_ORDER.indexOf(a.backend);
+    const bIndex = CLI_PRESET_ORDER.indexOf(b.backend);
+    const aRank = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;
+    const bRank = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex;
+    return aRank - bRank || a.backend.localeCompare(b.backend);
+  });
   if (availableCli.length > 0) {
-    const cliProvider = availableCli[0]!;
-    const cliModel = cliProvider.backend === 'claude' ? 'opus'
-      : cliProvider.backend === 'codex' ? 'codex'
-      : cliProvider.backend === 'gemini' ? 'gemini'
-      : cliProvider.backend;
+    const selectedCli = availableCli.slice(0, 6);
+    const hasCliBackend = (backend: string) => selectedCli.some((cli) => cli.backend === backend);
+    const roleSelections: DynamicPreset['roleSelections'] = {};
+    if (hasCliBackend('codex')) {
+      roleSelections.supporter = {
+        provider: 'codex',
+        model: LOCAL_CLI_SUPPORTER_MODEL,
+        backend: 'cli',
+      };
+      roleSelections.moderator = {
+        provider: 'codex',
+        model: LOCAL_CLI_HEAD_MODEL,
+        backend: 'cli',
+      };
+      roleSelections.head = {
+        provider: 'codex',
+        model: LOCAL_CLI_HEAD_MODEL,
+        backend: 'cli',
+      };
+    }
+    if (hasCliBackend('opencode')) {
+      roleSelections.devilsAdvocate = {
+        provider: 'opencode',
+        model: LOCAL_CLI_DEVILS_ADVOCATE_MODEL,
+        backend: 'cli',
+        runtimeProvider: CLI_BACKEND_RUNTIME_PROVIDERS.opencode,
+      };
+    }
+    const models: Record<string, string> = {};
+    const runtimeProviders: Record<string, string> = {};
+    for (const cli of selectedCli) {
+      models[cli.backend] = CLI_BACKEND_DEFAULT_MODELS[cli.backend] ?? 'auto';
+      const runtimeProvider = CLI_BACKEND_RUNTIME_PROVIDERS[cli.backend];
+      if (runtimeProvider) {
+        runtimeProviders[cli.backend] = runtimeProvider;
+      }
+    }
     presets.push({
       id: 'cli',
-      label: `CLI review (${availableCli.map((c) => c.backend).join(', ')})`,
-      labelKo: `CLI \uB9AC\uBDF0 (${availableCli.map((c) => c.backend).join(', ')})`,
-      providers: availableCli.map((c) => c.backend),
-      models: { [cliProvider.backend]: cliModel },
-      reviewerCount: Math.min(availableCli.length, 3),
-      discussion: false,
+      label: `Local CLI ensemble (${selectedCli.map((c) => c.backend).join(', ')})`,
+      labelKo: `\uB85C\uCEEC CLI \uC559\uC0C1\uBE14 (${selectedCli.map((c) => c.backend).join(', ')})`,
+      providers: selectedCli.map((c) => c.backend),
+      models,
+      runtimeProviders,
+      reviewerCount: selectedCli.length,
+      discussion: true,
       backend: 'cli',
+      ...(Object.keys(roleSelections).length > 0 ? { roleSelections } : {}),
     });
   }
 
@@ -724,6 +865,24 @@ export async function writeGitHubWorkflow(
   return true;
 }
 
+function selectionsFromPreset(selected: DynamicPreset): ProviderModelSelection[] {
+  if (selected.reviewerModels?.length) {
+    return selected.reviewerModels.map((model) => ({
+      provider: selected.providers[0]!,
+      model,
+      backend: selected.backend,
+      runtimeProvider: selected.runtimeProviders?.[selected.providers[0]!],
+    }));
+  }
+
+  return selected.providers.map((provider) => ({
+    provider,
+    model: selected.models[provider] ?? PROVIDER_DEFAULT_MODELS[provider] ?? 'xiaomi/mimo-v2.5',
+    backend: selected.backend,
+    runtimeProvider: selected.runtimeProviders?.[provider],
+  }));
+}
+
 export async function buildPresetConfig(preset: string): Promise<GeneratedConfig> {
   const canonicalPreset = resolvePresetAlias(preset);
   if (!canonicalPreset) {
@@ -745,17 +904,7 @@ export async function buildPresetConfig(preset: string): Promise<GeneratedConfig
     );
   }
 
-  const selections: ProviderModelSelection[] = selected.reviewerModels?.length
-    ? selected.reviewerModels.map((model) => ({
-      provider: selected.providers[0]!,
-      model,
-      backend: selected.backend,
-    }))
-    : selected.providers.map((provider) => ({
-      provider,
-      model: selected.models[provider] ?? PROVIDER_DEFAULT_MODELS[provider] ?? 'xiaomi/mimo-v2.5',
-      backend: selected.backend,
-    }));
+  const selections = selectionsFromPreset(selected);
 
   if (selections.length === 0) {
     throw new Error(`Preset "${preset}" has no providers.`);
@@ -764,7 +913,7 @@ export async function buildPresetConfig(preset: string): Promise<GeneratedConfig
   const primaryProvider = selections[0]!.provider;
   const primaryModel = selections[0]!.model;
 
-  if (selections.length === 1) {
+  if (selections.length === 1 && selected.backend === 'api') {
     return buildCustomConfig({
       provider: primaryProvider,
       model: primaryModel,
@@ -781,6 +930,12 @@ export async function buildPresetConfig(preset: string): Promise<GeneratedConfig
     discussion: selected.discussion,
     language: 'en',
     mode: 'pragmatic',
+    maxRounds: selected.maxRounds,
+    supporterSelection: selected.roleSelections?.supporter,
+    devilsAdvocateSelection: selected.roleSelections?.devilsAdvocate,
+    moderatorSelection: selected.roleSelections?.moderator,
+    moderatorEnabled: selected.roleSelections?.moderatorEnabled,
+    headSelection: selected.roleSelections?.head,
   });
 }
 
@@ -899,11 +1054,7 @@ export async function runInitInteractive(options: InitOptions): Promise<InitResu
   const selectedPreset = dynamicPresets.find((pr) => pr.id === setupMode);
   if (selectedPreset) {
     // Use preset defaults — build selections from preset
-    const selections: ProviderModelSelection[] = selectedPreset.providers.map((prov) => ({
-      provider: prov,
-      model: selectedPreset.models[prov] ?? PROVIDER_DEFAULT_MODELS[prov] ?? 'xiaomi/mimo-v2.5',
-      backend: selectedPreset.backend,
-    }));
+    const selections = selectionsFromPreset(selectedPreset);
 
     format = options.format === 'yaml' ? 'yaml' : 'json';
     primaryProvider = selections[0]!.provider;
@@ -924,7 +1075,7 @@ export async function runInitInteractive(options: InitOptions): Promise<InitResu
     }
     const language = languageSelection as Language;
 
-    if (selections.length === 1) {
+    if (selections.length === 1 && selectedPreset.backend === 'api') {
       configData = buildCustomConfig({
         provider: primaryProvider,
         model: primaryModel,
@@ -938,6 +1089,12 @@ export async function runInitInteractive(options: InitOptions): Promise<InitResu
         reviewerCount: selectedPreset.reviewerCount,
         discussion: selectedPreset.discussion,
         language,
+        maxRounds: selectedPreset.maxRounds,
+        supporterSelection: selectedPreset.roleSelections?.supporter,
+        devilsAdvocateSelection: selectedPreset.roleSelections?.devilsAdvocate,
+        moderatorSelection: selectedPreset.roleSelections?.moderator,
+        moderatorEnabled: selectedPreset.roleSelections?.moderatorEnabled,
+        headSelection: selectedPreset.roleSelections?.head,
       });
     }
   } else {
@@ -1019,7 +1176,12 @@ export async function runInitInteractive(options: InitOptions): Promise<InitResu
             const modelOptions = topModels.map((m) => formatModelOption(m));
             const msg = ko ? `${backend} CLI \uBAA8\uB378 \uC120\uD0DD` : `Model for ${backend} CLI`;
             const modelSelection = await searchAndSelect(modelOptions, msg, false, ko) as string;
-            selections.push({ provider: backend, model: modelSelection, backend: 'cli' });
+            selections.push({
+              provider: backend,
+              model: modelSelection,
+              backend: 'cli',
+              runtimeProvider: CLI_BACKEND_RUNTIME_PROVIDERS[backend],
+            });
             continue;
           }
         }
@@ -1039,7 +1201,12 @@ export async function runInitInteractive(options: InitOptions): Promise<InitResu
             });
             const msg = ko ? `${backend} CLI \uBAA8\uB378 \uC120\uD0DD` : `Model for ${backend} CLI`;
             const modelSelection = await searchAndSelect(modelOptions, msg, false, ko) as string;
-            selections.push({ provider: backend, model: modelSelection, backend: 'cli' });
+            selections.push({
+              provider: backend,
+              model: modelSelection,
+              backend: 'cli',
+              runtimeProvider: CLI_BACKEND_RUNTIME_PROVIDERS[backend],
+            });
             continue;
           }
         }
@@ -1053,7 +1220,12 @@ export async function runInitInteractive(options: InitOptions): Promise<InitResu
           p.cancel(ko ? '\uC124\uC815\uC774 \uCDE8\uC18C\uB418\uC5C8\uC2B5\uB2C8\uB2E4.' : 'Setup cancelled.');
           throw new UserCancelledError();
         }
-        selections.push({ provider: backend, model: (cliModelInput as string) || backend, backend: 'cli' });
+        selections.push({
+          provider: backend,
+          model: (cliModelInput as string) || CLI_BACKEND_DEFAULT_MODELS[backend] || backend,
+          backend: 'cli',
+          runtimeProvider: CLI_BACKEND_RUNTIME_PROVIDERS[backend],
+        });
         continue;
       }
 

--- a/packages/cli/src/commands/register-init.ts
+++ b/packages/cli/src/commands/register-init.ts
@@ -44,6 +44,7 @@ export function registerInitCommand(program: Command): void {
           if (options.ci && result.created.some(f => f.includes('codeagora-review.yml'))) {
             console.log('Created: .github/workflows/codeagora-review.yml');
             console.log('  Add OPENROUTER_API_KEY to your repository secrets:');
+            console.log('  gh secret set OPENROUTER_API_KEY');
             console.log('  Settings -> Secrets -> Actions -> New repository secret');
           }
           if (result.created.length > 0) printNextSteps();
@@ -90,7 +91,8 @@ export function registerInitCommand(program: Command): void {
         if (result.created.length > 0) console.log('CodeAgora initialized successfully.');
         if (options.ci && result.created.some(f => f.includes('codeagora-review.yml'))) {
           console.log('Created: .github/workflows/codeagora-review.yml');
-          console.log('  Add GROQ_API_KEY to your repository secrets:');
+          console.log('  Add OPENROUTER_API_KEY to your repository secrets:');
+          console.log('  gh secret set OPENROUTER_API_KEY');
           console.log('  Settings -> Secrets -> Actions -> New repository secret');
         }
         if (result.created.length > 0) printNextSteps();

--- a/packages/cli/src/commands/register-init.ts
+++ b/packages/cli/src/commands/register-init.ts
@@ -22,7 +22,7 @@ export function registerInitCommand(program: Command): void {
     .option('--force', 'Overwrite existing files', false)
     .option('-y, --yes', 'Skip prompts, use defaults', false)
     .option('--ci', 'also create GitHub Actions workflow', false)
-    .option('--preset <name>', 'Generate config from preset: quick/free/thorough (or aliases: budget/balanced/premium)')
+    .option('--preset <name>', 'Generate config from preset: quick/free/thorough/cli/action (aliases: budget/balanced/premium/local/gha/github-action)')
     .option('--advanced', 'Full wizard with provider/model/reviewer customization', false)
     .action(async (options: { format: string; force: boolean; yes: boolean; ci: boolean; preset?: string; advanced: boolean }) => {
       try {
@@ -43,7 +43,7 @@ export function registerInitCommand(program: Command): void {
           if (result.created.length > 0) console.log('CodeAgora initialized successfully.');
           if (options.ci && result.created.some(f => f.includes('codeagora-review.yml'))) {
             console.log('Created: .github/workflows/codeagora-review.yml');
-            console.log('  Add GROQ_API_KEY to your repository secrets:');
+            console.log('  Add OPENROUTER_API_KEY to your repository secrets:');
             console.log('  Settings -> Secrets -> Actions -> New repository secret');
           }
           if (result.created.length > 0) printNextSteps();

--- a/packages/cli/src/tests/cli-init-advanced.test.ts
+++ b/packages/cli/src/tests/cli-init-advanced.test.ts
@@ -211,6 +211,35 @@ describe('buildMultiProviderConfig()', () => {
       expect(reviewer.backend).toBe('claude');
       expect(reviewer.provider).toBeUndefined();
     }
+    expect(config.moderator.backend).toBe('claude');
+    expect(config.moderator.provider).toBeUndefined();
+    expect((config.head as Record<string, unknown>)['backend']).toBe('claude');
+  });
+
+  it('preserves runtime provider for opencode CLI selections', () => {
+    const config = buildMultiProviderConfig({
+      selections: [
+        {
+          provider: 'opencode',
+          model: 'deepseek-v4-flash',
+          backend: 'cli',
+          runtimeProvider: 'opencode-go',
+        },
+      ],
+      reviewerCount: 1,
+      discussion: false,
+    });
+
+    expect(config.reviewers[0]).toMatchObject({
+      backend: 'opencode',
+      provider: 'opencode-go',
+      model: 'deepseek-v4-flash',
+    });
+    expect(config.moderator).toMatchObject({
+      backend: 'opencode',
+      provider: 'opencode-go',
+      model: 'deepseek-v4-flash',
+    });
   });
 
   it('respects language parameter', () => {
@@ -251,6 +280,13 @@ describe('generatePresets()', () => {
     'qwen/qwen3-coder-flash',
     'qwen/qwen3-next-80b-a3b-instruct',
   ];
+  const openrouterActionModels = [
+    'qwen/qwen3-235b-a22b-2507',
+    'deepseek/deepseek-v4-flash',
+    'qwen/qwen3.5-9b',
+    'z-ai/glm-4.7-flash',
+    'openai/gpt-oss-120b',
+  ];
 
   it('returns fallback presets when no providers or CLI detected', () => {
     const env = makeEnv([{ name: 'groq', available: false }]);
@@ -258,6 +294,7 @@ describe('generatePresets()', () => {
     // Fallback contains quick/thorough/free
     expect(presets.length).toBeGreaterThan(0);
     const ids = presets.map((p) => p.id);
+    expect(ids).toContain('action');
     expect(ids).toContain('quick');
     const quick = presets.find((p) => p.id === 'quick');
     expect(quick!.reviewerCount).toBe(4);
@@ -324,11 +361,33 @@ describe('generatePresets()', () => {
 
   it('generates a "cli" preset when CLI backends are available', () => {
     const env = makeEnv([]);
-    const cli = [makeCli('claude', true), makeCli('codex', true)];
+    const cli = [makeCli('claude', true), makeCli('codex', true), makeCli('opencode', true)];
     const presets = generatePresets(env, null, cli);
     const cliPreset = presets.find((p) => p.id === 'cli');
     expect(cliPreset).toBeDefined();
     expect(cliPreset!.backend).toBe('cli');
+    expect(cliPreset!.label).toContain('Local CLI ensemble');
+    expect(cliPreset!.providers).toEqual(['codex', 'claude', 'opencode']);
+    expect(cliPreset!.models).toMatchObject({
+      codex: 'gpt-5.4-mini',
+      claude: 'haiku',
+      opencode: 'deepseek-v4-flash',
+    });
+    expect(cliPreset!.runtimeProviders).toMatchObject({
+      opencode: 'opencode-go',
+    });
+    expect(cliPreset!.discussion).toBe(true);
+    expect(cliPreset!.roleSelections).toMatchObject({
+      supporter: { provider: 'codex', model: 'gpt-5.3-codex-spark', backend: 'cli' },
+      devilsAdvocate: {
+        provider: 'opencode',
+        model: 'kimi-k2.7-code',
+        backend: 'cli',
+        runtimeProvider: 'opencode-go',
+      },
+      moderator: { provider: 'codex', model: 'gpt-5.5', backend: 'cli' },
+      head: { provider: 'codex', model: 'gpt-5.5', backend: 'cli' },
+    });
   });
 
   it('does NOT generate "cli" preset when no CLI backends available', () => {
@@ -366,6 +425,33 @@ describe('generatePresets()', () => {
     expect(starter!.reviewerModels).toEqual(openrouterStarterModels);
   });
 
+  it('generates OpenRouter Action preset with cheap reviewers and direct head escalation', () => {
+    const env = makeEnv([{ name: 'openrouter', available: true }]);
+    const presets = generatePresets(env, null);
+    const action = presets.find((p) => p.id === 'action');
+    expect(action).toBeDefined();
+    expect(action!.providers).toEqual(['openrouter']);
+    expect(action!.backend).toBe('api');
+    expect(action!.reviewerCount).toBe(5);
+    expect(action!.reviewerModels).toEqual(openrouterActionModels);
+    expect(action!.discussion).toBe(true);
+    expect(action!.maxRounds).toBe(1);
+    expect(action!.roleSelections).toMatchObject({
+      supporter: { provider: 'openrouter', model: 'z-ai/glm-5.1', backend: 'api' },
+      devilsAdvocate: { provider: 'openrouter', model: 'moonshotai/kimi-k2.5', backend: 'api' },
+      moderator: { provider: 'openrouter', model: 'z-ai/glm-5.1', backend: 'api' },
+      moderatorEnabled: false,
+      head: { provider: 'openrouter', model: 'z-ai/glm-5.1', backend: 'api' },
+    });
+  });
+
+  it('keeps Action preset available even when OpenRouter is not detected in the shell', () => {
+    const env = makeEnv([{ name: 'openai', available: true }]);
+    const cli = [makeCli('codex', true)];
+    const presets = generatePresets(env, null, cli);
+    expect(presets.find((p) => p.id === 'action')).toBeDefined();
+  });
+
   it('includes label with provider name for quick preset', () => {
     const env = makeEnv([{ name: 'anthropic', available: true }]);
     const presets = generatePresets(env, null);
@@ -385,6 +471,8 @@ describe('resolvePresetAlias()', () => {
     expect(resolvePresetAlias('thorough')).toBe('thorough');
     expect(resolvePresetAlias('free')).toBe('free');
     expect(resolvePresetAlias('quick')).toBe('quick');
+    expect(resolvePresetAlias('cli')).toBe('cli');
+    expect(resolvePresetAlias('action')).toBe('action');
   });
 
   it('trims and normalizes case', () => {
@@ -392,6 +480,10 @@ describe('resolvePresetAlias()', () => {
     expect(resolvePresetAlias('fast')).toBe('quick');
     expect(resolvePresetAlias('standard')).toBe('free');
     expect(resolvePresetAlias('deep')).toBe('thorough');
+    expect(resolvePresetAlias('local')).toBe('cli');
+    expect(resolvePresetAlias('local-cli')).toBe('cli');
+    expect(resolvePresetAlias('gha')).toBe('action');
+    expect(resolvePresetAlias('github-action')).toBe('action');
     expect(resolvePresetAlias('  QUICK  ')).toBe('quick');
   });
 

--- a/packages/cli/src/tests/register-init.test.ts
+++ b/packages/cli/src/tests/register-init.test.ts
@@ -47,6 +47,29 @@ describe('registerInitCommand', () => {
     expect(runInitInteractive).not.toHaveBeenCalled();
   });
 
+  it('prints gh secret guidance when action preset creates a workflow', async () => {
+    vi.spyOn(init, 'runInit').mockResolvedValue({
+      created: ['/tmp/.ca/config.json', '/tmp/.github/workflows/codeagora-review.yml'],
+      skipped: [],
+      warnings: [],
+    });
+
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      logs.push(String(message ?? ''));
+    });
+
+    const program = new Command();
+    registerInitCommand(program);
+
+    await program.parseAsync(['node', 'agora', 'init', '--preset', 'action', '--ci', '--yes']);
+
+    const output = logs.join('\n');
+    expect(output).toContain('Created: .github/workflows/codeagora-review.yml');
+    expect(output).toContain('OPENROUTER_API_KEY');
+    expect(output).toContain('gh secret set OPENROUTER_API_KEY');
+  });
+
   it('builds schema-valid generated groq config for non-interactive init paths', () => {
     const generated = init.buildCustomConfig({
       provider: 'groq',

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # core
 
@@ -56,6 +56,9 @@ Core review pipeline implementation for CodeAgora. Contains the full 10-stage re
 - L0-L3 execution flow: user → orchestrator → L1 (parallel) → L2 (debate) → L3 (verdict)
 - Session state is managed by SessionManager
 - Config is loaded via config/loader.ts and cached per session
+- Core owns verdict, finding, confidence, session, degraded/skipped, and config semantics. CLI, GitHub Action, MCP, and Desktop adapt transport only.
+- Keep backend schema/executor/detection parity across `types/config.ts`, config validation, `src/l1/backend.ts`, shared CLI backend detection, generated presets/templates, and tests.
+- Distinguish API-key providers from installed/authenticated CLI backends in validation, dry-run readiness, doctor output, and failure classification.
 
 **Key Entry Points:**
 - `src/index.ts` — public API exports
@@ -112,6 +115,7 @@ Core review pipeline implementation for CodeAgora. Contains the full 10-stage re
 - Mode presets (auto, conservative, aggressive) modify reviewer counts
 - Prompts injected at {{DIFF}} placeholder
 - Credentials from ~/.config/codeagora/credentials (0o600)
+- Provider credentials must never be embedded in config/session artifacts; load through environment or credentials helper and redact everywhere.
 
 **Async Patterns:**
 - Serial for ≤2 items, parallel with pLimit(3) for >2

--- a/packages/core/src/config/AGENTS.md
+++ b/packages/core/src/config/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # config — Configuration Management
 
@@ -43,9 +43,10 @@ None (configuration utilities)
 {
   version: string,
   mode: 'auto' | 'conservative' | 'aggressive',
-  reviewers: [ { model, provider, config: {} } | { auto: true } ],
-  moderator: { enabled, supporter_pool },
-  head: { enabled, model, provider },
+  reviewers: [ { id, backend, provider?, model, enabled, timeout } | { id, auto: true } ],
+  supporters: { pool, pickCount, devilsAdvocate, personaPool },
+  moderator: { backend, provider?, model, enabled, timeout },
+  head: { backend, provider?, model, enabled, timeout },
   rules: [ ... ],
   plugins: [ ... ]
 }
@@ -66,6 +67,7 @@ None (configuration utilities)
 - Invalid enum values → error
 - Type mismatches → error
 - Nested schema validation (reviewers, moderator, head, rules)
+- Backend schema, executor, CLI detection, preset generation, and docs must stay aligned when adding or changing a backend.
 
 **Credentials:**
 - Load from ~/.config/codeagora/credentials
@@ -103,15 +105,9 @@ None (configuration utilities)
 10. Cache for session duration
 
 **Credential Handling:**
-```
-credentials = {
-  openai_api_key: process.env.OPENAI_API_KEY,
-  anthropic_api_key: process.env.ANTHROPIC_API_KEY,
-  openrouter_api_key: process.env.OPENROUTER_API_KEY,
-  opencode_api_key: process.env.OPENCODE_API_KEY,
-  groq_api_key: process.env.GROQ_API_KEY,
-}
-```
+- Use `@codeagora/shared/providers/env-vars` as the source of truth for provider environment variable names.
+- Local saved keys are loaded from `~/.config/codeagora/credentials`.
+- CLI backends may require installed/authenticated tools instead of API keys.
 
 **Mode Preset Logic:**
 - `auto` (default): balanced (5 reviewers)

--- a/packages/core/src/l1/AGENTS.md
+++ b/packages/core/src/l1/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # l1 — Parallel Reviewers
 
@@ -35,6 +35,7 @@ None (single layer execution)
 - `executeReviewers()` — main entry: takes ReviewerInput[], runs all in parallel, returns ReviewOutput[]
 - `parseEvidenceResponse()` — converts reviewer response to findings
 - `executeBackend()` — low-level backend execution (API or CLI)
+- Local CLI backends include tool-specific argument shapes. Keep Codex, Claude, OpenCode, Cursor, Antigravity, and other CLI spawn behavior covered by backend tests/smokes before declaring support.
 
 **Concurrency Model:**
 - Reviewers within a chunk: Promise.allSettled batch (concurrency 5)
@@ -53,6 +54,7 @@ None (single layer execution)
 **Backend Execution:**
 - API backend: mock Vercel AI SDK responses
 - CLI backend: mock spawn execution, validate sanitized args
+- CLI backend changes should also be smoke-tested through `scripts/cli-clean-diff-smoke.mjs` where practical.
 - Timeout handling (skip failed, continue with rest)
 - Error responses (non-zero exit code)
 
@@ -87,6 +89,7 @@ None (single layer execution)
 - Config specifies backend (api or cli)
 - API: direct Vercel AI SDK call
 - CLI: spawn process, read stdout, validate exit code
+- Omit model flags for CLI model values that mean auto/default when the target CLI expects that behavior.
 
 **Evidence Document Structure:**
 ```markdown

--- a/packages/core/src/l1/backend.ts
+++ b/packages/core/src/l1/backend.ts
@@ -115,26 +115,40 @@ function validateArg(arg: string, name: string): string {
   return arg;
 }
 
+function modelArgs(flag: string, model: string, name = 'model'): string[] {
+  if (!model || model === 'auto') {
+    return [];
+  }
+  return [flag, validateArg(model, name)];
+}
+
 // ============================================================================
 // Command Builders (return binary + args, no shell)
 // ============================================================================
 
 function buildCommand(input: BackendInput): CliCommand {
-  const { backend, model, provider } = input;
+  const { backend, model, provider, prompt } = input;
 
   switch (backend) {
     case 'opencode': {
       if (!provider) throw new Error('OpenCode backend requires provider parameter');
       return {
         bin: 'opencode',
-        args: ['run', '-m', `${validateArg(provider, 'provider')}/${validateArg(model, 'model')}`],
+        args: [
+          'run',
+          ...(
+            model && model !== 'auto'
+              ? ['-m', `${validateArg(provider, 'provider')}/${validateArg(model, 'model')}`]
+              : []
+          ),
+        ],
         useStdin: true,
       };
     }
     case 'codex':
       return {
         bin: 'codex',
-        args: ['exec', '-m', validateArg(model, 'model'), '-'],
+        args: ['exec', '--skip-git-repo-check', ...modelArgs('-m', model), '-'],
         useStdin: true,
       };
     case 'gemini':
@@ -152,13 +166,13 @@ function buildCommand(input: BackendInput): CliCommand {
     case 'copilot':
       return {
         bin: 'copilot',
-        args: ['-s', '--allow-all', '--model', validateArg(model, 'model')],
-        useStdin: true,
+        args: ['-s', '--allow-all', ...modelArgs('--model', model), '-p', prompt],
+        useStdin: false,
       };
     case 'cursor':
       return {
         bin: 'agent',
-        args: [],
+        args: ['-p', '--trust'],
         useStdin: true,
       };
     case 'antigravity':

--- a/packages/core/src/l2/AGENTS.md
+++ b/packages/core/src/l2/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # l2 — Discussion & Debate
 
@@ -36,6 +36,7 @@ None (single layer orchestration)
 - `runModerator()` — main entry: takes evidence documents, runs discussion rounds, returns ModeratorReport
 - `applyThreshold()` — filters low-severity/low-agreement issues
 - `deduplicateDiscussions()` — merges redundant findings
+- `ModeratorConfig.enabled === false` means unresolved discussions skip forced moderator decision and escalate directly to L3/head.
 
 **State Management:**
 - Discussion state persisted per session (for resume capability)
@@ -67,6 +68,7 @@ None (single layer orchestration)
 
 **Integration:**
 - Full flow: L1 evidence → dedup → threshold → discussion rounds → L3 verdict
+- Presets may intentionally use one supporter plus devil's advocate for low-cost Action runs; do not assume all production configs have 2-5 supporters.
 
 ### Common Patterns
 

--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -247,6 +247,30 @@ async function runDiscussion(
   }
 
   // Max rounds reached, moderator forces decision
+  if (moderatorConfig.enabled === false) {
+    const verdict: DiscussionVerdict = {
+      discussionId: discussion.id,
+      filePath: discussion.filePath,
+      lineRange: discussion.lineRange,
+      finalSeverity: discussion.severity as DiscussionVerdict['finalSeverity'],
+      reasoning: 'Moderator disabled; unresolved discussion escalated directly to head verdict.',
+      consensusReached: false,
+      rounds: settings.maxRounds,
+    };
+
+    await writeDiscussionVerdict(date, sessionId, verdict);
+
+    emitter?.emitEvent({
+      type: 'discussion-end',
+      discussionId: discussion.id,
+      finalSeverity: verdict.finalSeverity,
+      consensusReached: false,
+      rounds: settings.maxRounds,
+    });
+
+    return { verdict, rounds };
+  }
+
   const finalVerdict = await moderatorForcedDecision(
     discussion,
     rounds,

--- a/packages/core/src/l3/AGENTS.md
+++ b/packages/core/src/l3/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # l3 — Head Verdict
 
@@ -31,6 +31,7 @@ None (final layer, minimal module structure)
 - `makeHeadVerdict()` — main entry: takes ModeratorReport, returns HeadVerdict
 - `groupDiff()` — groups findings by file
 - `scanUnconfirmedQueue()` — identifies findings requiring human review
+- Clean moderator reports with no actionable discussions, suggestions, or unconfirmed issues should remain deterministically ACCEPT; do not call the head model just to reinterpret an empty report.
 
 **Decision Criteria:**
 - LLM verdict: evaluates reasoning quality + confidence metrics
@@ -44,6 +45,7 @@ None (final layer, minimal module structure)
 - Mock LLM response parsing
 - Fallback on timeout/error
 - Verdict confidence extraction
+- Clean-report guard coverage should stay in tests when touching verdict fallback logic.
 
 **Rule-Based Fallback:**
 - Severity weighting (CRITICAL > HIGH > MEDIUM > LOW > WARNING)

--- a/packages/core/src/l3/verdict.ts
+++ b/packages/core/src/l3/verdict.ts
@@ -26,6 +26,10 @@ export async function makeHeadVerdict(
   language?: 'en' | 'ko',
   onBackendCall?: (call: BackendCallRecord) => void,
 ): Promise<HeadVerdict> {
+  if (isCleanModeratorReport(report)) {
+    return ruleBasedVerdict(report, mode);
+  }
+
   // Try LLM-based verdict if configured
   if (headConfig?.enabled !== false && headConfig?.model) {
     try {
@@ -258,6 +262,14 @@ function hasActionableDiscussionLocation(discussion: { filePath: string; lineRan
 
 function hasActionableEvidenceLocation(doc: EvidenceDocument): boolean {
   return doc.filePath !== 'unknown' && hasValidLineRange(doc.lineRange);
+}
+
+function isCleanModeratorReport(report: ModeratorReport): boolean {
+  return (
+    !report.discussions.some(hasActionableDiscussionLocation) &&
+    !report.unconfirmedIssues.some(hasActionableEvidenceLocation) &&
+    !report.suggestions.some(hasActionableEvidenceLocation)
+  );
 }
 
 function parseHeadResponse(response: string, report: ModeratorReport): HeadVerdict {

--- a/packages/core/src/l3/verdict.ts
+++ b/packages/core/src/l3/verdict.ts
@@ -5,7 +5,7 @@
  * rather than just counting severities. Falls back to rule-based logic on failure.
  */
 
-import type { ModeratorReport, HeadVerdict, EvidenceDocument } from '../types/core.js';
+import type { ModeratorReport, HeadVerdict, EvidenceDocument, DiscussionVerdict } from '../types/core.js';
 import type { HeadConfig } from '../types/config.js';
 import type { BackendCallRecord, TokenUsage } from '../pipeline/telemetry.js';
 import { untrustedContentInstruction, wrapUntrustedBlock } from '../security/untrusted-content.js';
@@ -264,6 +264,10 @@ function hasActionableEvidenceLocation(doc: EvidenceDocument): boolean {
   return doc.filePath !== 'unknown' && hasValidLineRange(doc.lineRange);
 }
 
+function isForcedTieBreak(verdict: DiscussionVerdict): boolean {
+  return /tie broken by forced decision/i.test(verdict.reasoning);
+}
+
 function isCleanModeratorReport(report: ModeratorReport): boolean {
   return (
     !report.discussions.some(hasActionableDiscussionLocation) &&
@@ -313,7 +317,7 @@ export function applyHeadVerdictSafety(
     (d) => hasActionableDiscussionLocation(d) && (d.finalSeverity === 'CRITICAL' || d.finalSeverity === 'HARSHLY_CRITICAL')
   );
   const criticalIssues = allCritical.filter(
-    (d) => d.avgConfidence == null || d.avgConfidence > CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD
+    (d) => !isForcedTieBreak(d) && (d.avgConfidence == null || d.avgConfidence > CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD)
   );
   if (criticalIssues.length > 0) {
     if (verdict.decision === 'REJECT') return verdict;
@@ -327,7 +331,7 @@ export function applyHeadVerdictSafety(
   }
 
   const unverifiedCritical = allCritical.filter(
-    (d) => d.avgConfidence != null && d.avgConfidence <= CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD
+    (d) => isForcedTieBreak(d) || (d.avgConfidence != null && d.avgConfidence <= CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD)
   );
   const escalatedIssues = report.discussions.filter((d) => hasActionableDiscussionLocation(d) && !d.consensusReached);
   if (unverifiedCritical.length > 0 || escalatedIssues.length > 0) {
@@ -369,10 +373,10 @@ function ruleBasedVerdict(report: ModeratorReport, mode?: 'strict' | 'pragmatic'
     (d) => hasActionableDiscussionLocation(d) && (d.finalSeverity === 'CRITICAL' || d.finalSeverity === 'HARSHLY_CRITICAL')
   );
   const criticalIssues = allCritical.filter(
-    (d) => d.avgConfidence == null || d.avgConfidence > CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD
+    (d) => !isForcedTieBreak(d) && (d.avgConfidence == null || d.avgConfidence > CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD)
   );
   const unverifiedCritical = allCritical.filter(
-    (d) => d.avgConfidence != null && d.avgConfidence <= CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD
+    (d) => isForcedTieBreak(d) || (d.avgConfidence != null && d.avgConfidence <= CRITICAL_BLOCKING_CONFIDENCE_THRESHOLD)
   );
 
   const escalatedIssues = report.discussions.filter((d) => hasActionableDiscussionLocation(d) && !d.consensusReached);

--- a/packages/core/src/pipeline/AGENTS.md
+++ b/packages/core/src/pipeline/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # pipeline — Orchestrator
 
@@ -47,6 +47,8 @@ Pipeline Orchestrator connects all 4 review layers (L0-L3) into a single cohesiv
 - `estimateCost()` — predicts API costs
 - `runDryrun()` — simulates verdict without execution
 - `checkAutoApprove()` — evaluates auto-merge criteria
+- Dry-run is provider-free: no LLM calls, no live provider quality signal, and no GitHub posting evidence.
+- Dry-run/readiness logic must not over-block CLI backend configs as missing API keys when local CLI tools are the actual runtime dependency.
 
 **State & Session:**
 - SessionManager maintains execution state
@@ -98,6 +100,7 @@ Pipeline Orchestrator connects all 4 review layers (L0-L3) into a single cohesiv
 - Full pipeline: load config → resolve reviewers → chunk diff → execute chunks → deduplicate → discuss → verdict
 - Multi-chunk workflows with parallel execution
 - Resume from partial state
+- Compact output and degraded reason codes are cross-surface contracts for CLI, GitHub Action, MCP, sessions, and Desktop. Keep them backward compatible.
 
 ### Common Patterns
 

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -8,7 +8,7 @@ import { isDeclarativeReviewers, loadConfig, loadConfigFile, normalizeConfig } f
 import { writeAllReviews } from '../l1/writer.js';
 import { applyThreshold } from '../l2/threshold.js';
 import { writeModeratorReport, writeSuggestions } from '../l2/writer.js';
-import { parseDiffFileRanges, readSurroundingContext } from '@codeagora/shared/utils/diff.js';
+import { classifyNoCodeDiffScope, parseDiffFileRanges, readSurroundingContext } from '@codeagora/shared/utils/diff.js';
 import { estimateTokens } from './chunker.js';
 import { createLogger } from '@codeagora/shared/utils/logger.js';
 import { writeHeadVerdict } from '../l3/writer.js';
@@ -150,6 +150,12 @@ async function persistTerminalResult(result: PipelineResult): Promise<PipelineRe
     await writeSessionResult(result.date, result.sessionId, result).catch(() => {});
   }
   return result;
+}
+
+function buildNoCodeReviewReason(scope: 'docs-only' | 'generated-only'): string {
+  return scope === 'docs-only'
+    ? 'No source code changes detected in latest diff: docs-only update.'
+    : 'No source code changes detected in latest diff: generated artifacts only.';
 }
 
 export function applyReviewerSelectionToConfig(
@@ -395,6 +401,72 @@ async function runPipelineInternal(input: PipelineInput, progress?: ProgressEmit
     if (!input.noCache) {
       const cached = await checkAndLoadCache(cacheKey, session);
       if (cached) return cached;
+    }
+
+    const noCodeScope = classifyNoCodeDiffScope(diffContent);
+    if (noCodeScope === 'docs-only' || noCodeScope === 'generated-only') {
+      await session.setMetadata({
+        reviewScope: noCodeScope,
+        newDiffClassification: noCodeScope,
+        codeReviewRequired: false,
+        tsVerificationSkipped: true,
+      }).catch(() => {});
+      await session.setStatus('completed');
+      return persistTerminalResult({
+        sessionId,
+        date,
+        status: 'success',
+        summary: {
+          decision: 'ACCEPT',
+          reasoning: buildNoCodeReviewReason(noCodeScope),
+          totalReviewers: 0,
+          forfeitedReviewers: 0,
+          severityCounts: {},
+          topIssues: [],
+          totalDiscussions: 0,
+          resolved: 0,
+          escalated: 0,
+        },
+        evidenceDocs: [],
+        discussions: [],
+        reviewRun: {
+          l1: {
+            configured: 0,
+            completed: 0,
+            forfeited: 0,
+            errored: 0,
+            reviewers: [],
+            models: [],
+            providers: [],
+          },
+          l2: {
+            supporters: 0,
+            supporterModels: [],
+            discussions: 0,
+            skipped: true,
+          },
+          l3: {
+            skipped: true,
+          },
+          queues: {
+            activeFindings: 0,
+            suggestions: 0,
+            unconfirmed: 0,
+            suppressed: 0,
+            hallucinationRemoved: 0,
+            hallucinationUncertain: 0,
+          },
+          degraded: false,
+          degradedReasons: [],
+        },
+        reviewQueues: {
+          suggestions: [],
+          unconfirmed: [],
+          suppressed: [],
+          hallucinationRemoved: [],
+          hallucinationUncertain: [],
+        },
+      });
     }
 
     // === AUTO-APPROVE: Skip LLM pipeline for trivial diffs ===

--- a/packages/core/src/tests/edge-cases.test.ts
+++ b/packages/core/src/tests/edge-cases.test.ts
@@ -246,6 +246,7 @@ describe('runModerator — maxRounds=0 (8)', () => {
       model: 'claude-3-haiku',
       provider: 'anthropic',
       timeout: 30,
+      enabled: true,
     };
 
     const supporterPoolConfig = {
@@ -277,6 +278,60 @@ describe('runModerator — maxRounds=0 (8)', () => {
     // moderatorForcedDecision is called, returns a verdict.
     expect(result.discussions).toHaveLength(1);
     expect(result.summary.totalDiscussions).toBe(1);
+  });
+
+  it('escalates unresolved discussions directly to head when moderator is disabled', async () => {
+    const discussion = {
+      id: 'disc-no-moderator',
+      issueTitle: 'Escalate Without Moderator',
+      filePath: 'src/foo.ts',
+      lineRange: [1, 10] as [number, number],
+      severity: 'WARNING' as const,
+      evidenceDocs: [],
+      codeSnippet: '',
+      status: 'pending' as const,
+    };
+
+    const moderatorConfig = {
+      backend: 'api' as const,
+      model: 'z-ai/glm-5.1',
+      provider: 'openrouter',
+      timeout: 30,
+      enabled: false,
+    };
+
+    const supporterPoolConfig = {
+      pool: [
+        { id: 's1', backend: 'api' as const, model: 'z-ai/glm-5.1', provider: 'openrouter', enabled: true, timeout: 30, persona: 'supporter' },
+      ],
+      pickCount: 1,
+      pickStrategy: 'random' as const,
+      devilsAdvocate: { id: 'da', backend: 'api' as const, model: 'moonshotai/kimi-k2.5', provider: 'openrouter', enabled: false, timeout: 30, persona: 'devil' },
+      personaPool: ['supporter'],
+      personaAssignment: 'random' as const,
+    };
+
+    const result = await runModerator({
+      config: moderatorConfig,
+      supporterPoolConfig,
+      discussions: [discussion],
+      settings: {
+        enabled: true,
+        maxRounds: 0,
+        registrationThreshold: { HARSHLY_CRITICAL: 1, CRITICAL: 1, WARNING: 2, SUGGESTION: null },
+        codeSnippetRange: 10,
+        objectionTimeout: 60,
+        maxObjectionRounds: 1,
+      },
+      date: '2026-03-21',
+      sessionId: '001',
+    });
+
+    expect(result.discussions).toHaveLength(1);
+    expect(result.discussions[0]!.finalSeverity).toBe('WARNING');
+    expect(result.discussions[0]!.consensusReached).toBe(false);
+    expect(result.discussions[0]!.reasoning).toContain('Moderator disabled');
+    expect(result.summary.escalated).toBe(1);
   });
 });
 

--- a/packages/core/src/tests/l2-supporter-failure.test.ts
+++ b/packages/core/src/tests/l2-supporter-failure.test.ts
@@ -62,6 +62,7 @@ describe('runModerator — supporter backend failure', () => {
         model: 'moderator',
         provider: 'openrouter',
         timeout: 30,
+        enabled: true,
       },
       supporterPoolConfig: {
         pool: [

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -124,6 +124,7 @@ export const ModeratorConfigSchema = z.object({
   provider: z.string().optional(),
   maxOutputTokens: z.number().int().positive().max(32768).optional(),
   timeout: z.number().default(120),
+  enabled: z.boolean().default(true),
   /**
    * Forced-decision output format. Default (undefined/'markdown') uses the
    * existing regex-based parser (structured "severity:" field → JSON-like

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -208,4 +208,12 @@ export interface SessionMetadata {
   configHash?: string;
   /** Machine-readable cache lookup/write metadata. No raw config, providers, or source context. */
   cache?: CacheMetadata;
+  /** Current-run no-code review scope classification for early ACCEPT paths. */
+  reviewScope?: 'docs-only' | 'generated-only' | 'code-change' | 'empty';
+  /** Explicit latest-diff classification used to decide whether code review is required. */
+  newDiffClassification?: 'docs-only' | 'generated-only' | 'code-change' | 'empty';
+  /** Whether the normal reviewer/debate/head pipeline is required for this diff. */
+  codeReviewRequired?: boolean;
+  /** Whether TypeScript suggestion verification/noise surfacing was skipped for a no-code diff. */
+  tsVerificationSkipped?: boolean;
 }

--- a/packages/desktop/AGENTS.md
+++ b/packages/desktop/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-04-27 | Updated: 2026-06-05 -->
+<!-- Generated: 2026-04-27 | Updated: 2026-06-14 -->
 
 # desktop/ (@codeagora/desktop)
 
@@ -13,6 +13,7 @@ The desktop app owns session browsing, session detail display, local review laun
 - Read existing `.ca/sessions` and `.ca/config.json` semantics rather than inventing new storage.
 - Keep signing, notarization, updater, distribution, and support policy explicit in release evidence instead of treating packaging as an implementation detail.
 - Do not add web dashboard, terminal TUI, or external webhook delivery dependencies here.
+- Setup panels for MCP or GitHub Actions are readiness/guidance surfaces, not substitutes for live MCP or live Action evidence.
 
 ## Key Files
 | File | Description |
@@ -27,3 +28,4 @@ The desktop app owns session browsing, session detail display, local review laun
 - Frontend-only changes still need package typecheck/smoke where practical.
 - Any Tauri command, Rust, bridge-contract, packaging, or desktop evidence change requires `pnpm rc:desktop-gate` before release claims.
 - Desktop evidence is a first-class release gate, but it must not substitute for CLI, GitHub Action, or MCP evidence.
+- Signing, notarization, updater, and distribution claims require explicit artifacts; a local dev launch alone is not release evidence.

--- a/packages/desktop/src-tauri/AGENTS.md
+++ b/packages/desktop/src-tauri/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-06-05 | Updated: 2026-06-05 -->
+<!-- Generated: 2026-06-05 | Updated: 2026-06-14 -->
 
 # desktop/src-tauri/
 
@@ -17,9 +17,11 @@ Rust/Tauri backend for native filesystem, process, session/config, and desktop p
 
 ## Conventions
 - Spawn CLI/core behavior through the existing command boundary; desktop must not fork verdict/finding/session/config semantics.
+- Spawn processes safely with explicit args, timeouts, cancellation, and redacted stdout/stderr handling.
 - Normalize errors for the frontend; do not surface raw stack traces or secrets.
 - Keep path access bounded to selected/trusted repositories and known session/config locations.
 - Treat `target/` as build output, not source.
+- WebDriver/debug automation must remain debug-only and covered by desktop gate evidence.
 
 ## Verification
 - Rust, command, capability, or package changes require `pnpm rc:desktop-gate`.

--- a/packages/desktop/src/AGENTS.md
+++ b/packages/desktop/src/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-06-05 | Updated: 2026-06-05 -->
+<!-- Generated: 2026-06-05 | Updated: 2026-06-14 -->
 
 # desktop/src/
 
@@ -20,6 +20,8 @@ Browser-side desktop app: state, rendering, keyboard/theme handling, setup panel
 - Use shared i18n keys from `@codeagora/shared`; update `en.json` and `ko.json` together.
 - Keep frontend state derived from canonical CLI/core/session/config contracts.
 - Desktop copy should present the app as an official supported local UI while staying honest about platform/package limitations.
+- Cockpit/setup/evidence views should surface provider readiness, MCP status, GitHub Action setup, degraded state, and release evidence through canonical contracts.
+- Browser fallback data is illustrative only and must never be treated as product truth or release evidence.
 
 ## Verification
 - UI-only changes need targeted desktop smoke or typecheck where practical.

--- a/packages/github/AGENTS.md
+++ b/packages/github/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # GitHub Package (@codeagora/github)
 
@@ -10,6 +10,9 @@ GitHub integration layer. Handles PR diff fetching, comment posting, SARIF repor
 | File | Description |
 |------|-------------|
 | `action.ts` | GitHub Actions entrypoint; reads env inputs, runs pipeline, posts results |
+| `action-policy.ts` | Degraded/skipped policy, trust boundaries, and next-step guidance |
+| `action-reporting.ts` | GitHub Action outputs, job summary, and reporting helpers |
+| `action-event.ts` | GitHub event parsing and PR context extraction |
 | `client.ts` | Octokit wrapper and URL parsers (PR URL, git remote) |
 | `pr-diff.ts` | Fetch PR diff from GitHub API |
 | `diff-parser.ts` | Parse unified diff into hunks and position index |
@@ -34,6 +37,9 @@ None — all modules are flat in `src/`.
 4. **Finding mapping**: Use `mapToGitHubReview()` to convert review findings to GitHub comment format
 5. **Posting**: Use `postReview()` to POST the review; handles pagination and threading
 6. **Error handling**: Validation errors throw descriptively; network errors are retried
+7. **Action trust boundary**: Fork/untrusted contexts must stop before provider-backed work. Degraded or untrusted runs suppress GitHub writes.
+8. **Action outputs**: Preserve `base-sha`, `head-sha`, `degraded`, and `degraded-reason`; callers and evidence scripts depend on them.
+9. **Bundle discipline**: Action runtime changes require `pnpm build:action` and focused Action tests/evidence before release claims.
 
 ### Common Patterns
 - **Config**: `GitHubConfig` includes `token`, `owner`, `repo`
@@ -42,6 +48,7 @@ None — all modules are flat in `src/`.
 - **Review format**: Findings grouped by file with body text (max 4096 chars per comment)
 - **Dedup**: Multiple findings on same line are merged into one comment
 - **SARIF**: Generated for code scanning dashboard integration
+- **Provider secrets**: `OPENROUTER_API_KEY` is a provider credential, not a GitHub token. It must flow through environment variables and must never be logged or committed.
 
 ### Adding New Functionality
 1. If adding a new GitHub API call, update `client.ts` with Octokit call

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -1,17 +1,20 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-06-05 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # MCP Package (@codeagora/mcp)
 
 ## Purpose
-MCP (Model Context Protocol) server that exposes CodeAgora's multi-LLM code review pipeline as tools for Claude and other AI agents. Wraps the core pipeline with review, dry-run, leaderboard/stats, session/config, and explanation tools. Runs as a CLI subprocess using stdio transport.
+MCP (Model Context Protocol) server that exposes CodeAgora's multi-LLM code review pipeline as tools for MCP-compatible clients, IDEs, and agents. Wraps the core pipeline with review, dry-run, leaderboard/stats, session/config, and explanation tools. Runs as a CLI subprocess using stdio transport.
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
 | `src/index.ts` | MCP server setup — creates McpServer, registers all 9 tools, starts stdio transport |
+| `src/registry.ts` | Central tool registration and catalog metadata |
 | `src/helpers.ts` | Shared logic: `runReviewCompact()`, `runReviewRaw()`, `getStagedDiff()` — core review orchestration |
+| `src/post-actions.ts` | Post-review action helpers |
+| `src/version.ts` | MCP package/runtime version reporting |
 | `src/tools/review-quick.ts` | `review_quick` tool — L1-only (parallel reviewers), no debate, no head verdict |
 | `src/tools/review-full.ts` | `review_full` tool — Full L0→L1→L2→L3 pipeline with debate and consensus |
 | `src/tools/review-pr.ts` | `review_pr` tool — PR-specific review with GitHub integration (issues, comments) |
@@ -53,9 +56,11 @@ MCP (Model Context Protocol) server that exposes CodeAgora's multi-LLM code revi
 
 **Key Commands:**
 - `pnpm vitest run packages/mcp/src/tests/tool-handlers.test.ts packages/mcp/src/tests/tools.test.ts`
+- `pnpm vitest run packages/mcp/src/tests/stdio-startup.test.ts` for startup/tool-list changes
 - `pnpm --filter @codeagora/mcp build`
 - Built binary: `node dist/index.js` or `codeagora-mcp` (via bin entry in package.json)
 - Package smoke is included in `pnpm release:beta-smoke`
+- Do not write logs, banners, or warnings to stdout before/during stdio protocol handling. Use stderr for diagnostics.
 
 ### Common Patterns
 
@@ -90,6 +95,8 @@ server.tool(
 - Preserve stable `status`, `code`, `message`, and optional `details` fields for agent callers.
 - For `repo_path`, tell callers whether to omit it, pass the workspace root, or stay inside the server/repo boundary.
 - Do not leak raw filesystem, provider secret, token, or transport internals into compact responses.
+- Keep errors structured and stable for agent callers: `status`, `code`, `message`, and optional redacted `details`.
+- Verify MCP tool listing/calls through the MCP SDK path; avoid relying on hand-rolled JSON-RPC framing for release claims.
 
 ### Tool Catalog
 
@@ -117,7 +124,7 @@ server.tool(
 - Built-ins: `fs/promises`, `path`, `os` for temp file handling
 
 ### Architecture Notes
-- All tools call `runReviewWithDiff()` or variants in helpers.ts
+- All tools call `runReviewCompact()`, `runReviewRaw()`, `getStagedDiff()`, or related helpers in `helpers.ts`
 - Diff is written to temp file, passed to the shared review path, then cleaned up in finally block
 - Results formatted with compact/shared response helpers for consistent response structure
 - Tools may accept explicit `repo_path`; validate it before reading config/session state

--- a/packages/mcp/src/AGENTS.md
+++ b/packages/mcp/src/AGENTS.md
@@ -1,17 +1,20 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # MCP Source Files
 
 ## Purpose
-MCP server implementation exposing CodeAgora pipeline as tools for Claude and other AI agents.
+MCP server implementation exposing the CodeAgora pipeline as tools for MCP-compatible clients, IDEs, and agents.
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
 | `index.ts` | Server setup — McpServer creation, tool registration, stdio transport start |
+| `registry.ts` | Central tool registration source |
 | `helpers.ts` | Core review logic — `runReviewCompact()`, `runReviewRaw()`, `getStagedDiff()` |
+| `post-actions.ts` | Post-review action helpers |
+| `version.ts` | Version reporting |
 
 ## Subdirectories
 
@@ -23,22 +26,24 @@ MCP server implementation exposing CodeAgora pipeline as tools for Claude and ot
 
 ### Working In This Directory
 - Add new tools as separate files in `tools/`
-- Each tool: register with `server.tool()` in its export function
+- Register tools through `registry.ts` so startup, listing, and docs stay aligned.
 - Call helpers from `helpers.ts` for pipeline execution
 - Keep tool implementations focused (one tool = one file)
 - Use zod for input validation schemas
+- Use shared response/schema helpers for stable success and error paths.
+- Keep stdout reserved for MCP protocol traffic; diagnostics belong on stderr.
 
 ### Common Patterns
 - **Tool template:** `export function register<ToolName>(server: McpServer): void { server.tool(...) }`
 - **Input validation:** Use zod `z.string()`, `z.number()`, etc. with `.describe()`
-- **Pipeline execution:** Call `runReviewWithDiff(diff, options)` or variants
+- **Pipeline execution:** Call `runReviewCompact()`, `runReviewRaw()`, `getStagedDiff()`, or related helpers
 - **Response format:** `{ content: [{ type: 'text' as const, text: JSON.stringify(...) }] }`
 - **Error handling:** Return error decision in response, do not throw
 
 ### Tool Structure
 Each tool file exports a single register function that:
 1. Validates input with zod schema
-2. Calls helper function (`runReviewCompact()`, `runReviewRaw()`, etc.)
+2. Calls helper function (`runReviewCompact()`, `runReviewRaw()`, `getStagedDiff()`, etc.)
 3. Formats result with `formatCompact()` if needed
 4. Returns MCP-compatible response
 

--- a/packages/shared/src/utils/diff.ts
+++ b/packages/shared/src/utils/diff.ts
@@ -197,6 +197,43 @@ export function extractFileListFromDiff(diffContent: string): string[] {
   return files;
 }
 
+export type NoCodeDiffScope = 'docs-only' | 'generated-only' | 'code-change' | 'empty';
+
+const DOCS_PATH_RE = /(?:^|\/)(docs?|documentation|changelog|changesets?)\//i;
+const DOCS_FILE_RE = /(?:^|\/)(README|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|LICENSE)(?:\.[^/]*)?$/i;
+const DOCS_EXT_RE = /\.(md|mdx|txt|rst|adoc|rdoc)$/i;
+const GENERATED_PATH_RE = /(?:^|\/)(dist|build|coverage|generated|gen|vendor)\//i;
+const GENERATED_FILE_RE = /(?:^|\/)(action|bundle|index)\.(?:min\.)?js(?:\.map)?$/i;
+const GENERATED_EXT_RE = /\.(?:map|min\.js)$/i;
+
+export function isDocsOnlyDiffPath(filePath: string): boolean {
+  return DOCS_PATH_RE.test(filePath) || DOCS_FILE_RE.test(filePath) || DOCS_EXT_RE.test(filePath);
+}
+
+export function isGeneratedDiffPath(filePath: string): boolean {
+  return GENERATED_PATH_RE.test(filePath) ||
+    GENERATED_FILE_RE.test(filePath) ||
+    GENERATED_EXT_RE.test(filePath);
+}
+
+/**
+ * Classify whether a unified diff contains source changes that need LLM review.
+ * This is intentionally path based and conservative: mixed docs/generated/source
+ * diffs return code-change so the normal review pipeline still runs.
+ */
+export function classifyNoCodeDiffScope(diffContent: string): NoCodeDiffScope {
+  const files = extractFileListFromDiff(diffContent);
+  if (files.length === 0) return 'empty';
+
+  const allDocs = files.every(isDocsOnlyDiffPath);
+  if (allDocs) return 'docs-only';
+
+  const allGenerated = files.every(isGeneratedDiffPath);
+  if (allGenerated) return 'generated-only';
+
+  return 'code-change';
+}
+
 /**
  * Find best matching file path from a list using fuzzy matching
  */

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-06-05 | Updated: 2026-06-05 -->
+<!-- Generated: 2026-06-05 | Updated: 2026-06-14 -->
 
 # scripts/
 
@@ -22,6 +22,27 @@ Repository automation for action bundles, release/package smoke, evidence manife
 - Prefer structured parsing and explicit exits over log scraping.
 - Keep generated artifacts out of source unless the release process explicitly requires them.
 - If a script changes release evidence, update the related docs under `docs/archived/RELEASE_EVIDENCE.md` or current rc evidence notes.
+
+## Action-Source Change Checklist
+
+If action source or bundled dependencies change, expected local verification is:
+
+```bash
+pnpm build:action
+git diff -- dist/action.js
+pnpm release:beta-smoke
+pnpm evidence:github-security
+```
+
+`pnpm build:action` is required after edits that affect `packages/github/src/action.ts`, `packages/github/src/**` code reachable from the Action bundle, `packages/core/src/**`, `packages/shared/src/**`, `action.yml`, or `scripts/build-action.mjs`. Review the `dist/action.js` diff intentionally; do not silently rewrite it.
+
+## Evidence Boundaries
+
+- `pnpm release:beta-smoke` is provider-free package/MCP/Action runtime smoke coverage.
+- `pnpm bench:ci` is deterministic benchmark/reference validation, not live provider evidence.
+- `pnpm evidence:github-security` records token/fork/security policy evidence for RC manifests.
+- `pnpm evidence:github-action-pr-smoke` is valid live Action evidence only from an actual GitHub Actions `pull_request` context with CodeAgora Action outputs.
+- Do not use deterministic tests, skipped provider paths, or local dry-runs as stable live-provider or live-GitHub-posting evidence. Stable or RC promotion claims must follow `docs/archived/RELEASE_EVIDENCE.md`.
 
 ## Anti-Patterns
 - Do not make live provider/network evidence a substitute for `pnpm bench:ci`.

--- a/scripts/cli-clean-diff-smoke.mjs
+++ b/scripts/cli-clean-diff-smoke.mjs
@@ -23,6 +23,17 @@ const PROVIDER_DEFAULT_MODELS = {
   openai: 'gpt-4.1-mini',
   openrouter: 'xiaomi/mimo-v2.5',
 };
+const REVIEW_BACKENDS = new Set(['api', 'claude', 'codex', 'gemini', 'antigravity', 'copilot', 'cursor', 'opencode', 'pi']);
+const BACKEND_DEFAULT_MODELS = {
+  claude: 'sonnet',
+  codex: 'auto',
+  gemini: 'gemini-2.5-pro',
+  antigravity: 'auto',
+  copilot: 'auto',
+  cursor: 'auto',
+  opencode: 'deepseek-v4-flash',
+  pi: 'auto',
+};
 
 const CLEAN_FIXTURE_DIFF = [
   'diff --git a/src/math.ts b/src/math.ts',
@@ -47,7 +58,9 @@ const FIXTURE_KINDS = new Set(['clean-diff', 'staged-diff', 'patch-file', 'inval
 
 function parseArgs(argv) {
   const options = {
+    backend: process.env.CODEAGORA_SMOKE_BACKEND || 'api',
     provider: process.env.CODEAGORA_SMOKE_PROVIDER || 'openrouter',
+    providerExplicit: Boolean(process.env.CODEAGORA_SMOKE_PROVIDER),
     model: process.env.CODEAGORA_SMOKE_MODEL || '',
     cli: process.env.CODEAGORA_SMOKE_CLI || '',
     output: '',
@@ -69,8 +82,14 @@ function parseArgs(argv) {
       options.keepTemp = true;
     } else if (arg === '--provider') {
       options.provider = argv[++index] ?? options.provider;
+      options.providerExplicit = true;
     } else if (arg?.startsWith('--provider=')) {
       options.provider = arg.slice('--provider='.length);
+      options.providerExplicit = true;
+    } else if (arg === '--backend') {
+      options.backend = argv[++index] ?? options.backend;
+    } else if (arg?.startsWith('--backend=')) {
+      options.backend = arg.slice('--backend='.length);
     } else if (arg === '--model') {
       options.model = argv[++index] ?? options.model;
     } else if (arg?.startsWith('--model=')) {
@@ -110,6 +129,9 @@ function parseArgs(argv) {
   if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
     throw new Error(`Invalid --timeout-ms value: ${options.timeoutMs}`);
   }
+  if (!REVIEW_BACKENDS.has(options.backend)) {
+    throw new Error(`Invalid --backend value: ${options.backend}. Expected one of: ${Array.from(REVIEW_BACKENDS).join(', ')}.`);
+  }
   if (options.patchFile && options.fixture === 'clean-diff') {
     options.fixture = 'patch-file';
   }
@@ -122,8 +144,14 @@ function parseArgs(argv) {
   if (options.patchFile) {
     options.patchFile = path.resolve(options.patchFile);
   }
+  if ((options.fixture === 'missing-provider-key' || options.fixture === 'provider-failure') && options.backend !== 'api') {
+    throw new Error(`--fixture ${options.fixture} requires --backend api.`);
+  }
+  if (options.backend === 'opencode' && !options.providerExplicit) {
+    options.provider = 'opencode-go';
+  }
   if (!options.model) {
-    options.model = PROVIDER_DEFAULT_MODELS[options.provider] || 'auto';
+    options.model = defaultModelForOptions(options);
   }
 
   return options;
@@ -137,6 +165,7 @@ function printHelp() {
     '',
     'Options:',
     '  --dry-run              Validate runner and fixture plumbing without provider calls',
+    '  --backend <name>       Review backend for live config: api, claude, codex, gemini, antigravity, copilot, cursor, opencode, or pi (default: api)',
     '  --provider <name>      Provider for live review config (default: openrouter)',
     '  --model <name>         Reviewer/head model for live review config (default: auto)',
     '  --cli <path>           CLI entrypoint or binary to execute',
@@ -151,6 +180,13 @@ function printHelp() {
 
 function providerEnvVar(provider) {
   return PROVIDER_ENV[provider] ?? `${provider.toUpperCase().replace(/-/g, '_')}_API_KEY`;
+}
+
+function defaultModelForOptions(options) {
+  if (options.backend === 'api') {
+    return PROVIDER_DEFAULT_MODELS[options.provider] || 'auto';
+  }
+  return BACKEND_DEFAULT_MODELS[options.backend] || 'auto';
 }
 
 function defaultCredentialsPath() {
@@ -192,11 +228,20 @@ function loadCredentialStoreIntoEnv(credentialsPath = defaultCredentialsPath(), 
 }
 
 function fixtureRequiresProviderCredentials(options) {
-  return !options.dryRun && options.fixture !== 'invalid-config' && options.fixture !== 'missing-provider-key' && options.fixture !== 'provider-failure';
+  return options.backend === 'api'
+    && !options.dryRun
+    && options.fixture !== 'invalid-config'
+    && options.fixture !== 'missing-provider-key'
+    && options.fixture !== 'provider-failure';
 }
 
 function fixtureRecordsRequiredEnvVar(options) {
-  return fixtureRequiresProviderCredentials(options) || options.fixture === 'missing-provider-key' || options.fixture === 'provider-failure';
+  return options.backend === 'api'
+    && (fixtureRequiresProviderCredentials(options) || options.fixture === 'missing-provider-key' || options.fixture === 'provider-failure');
+}
+
+function fixtureIsolatesUserHome(options) {
+  return options.backend === 'api';
 }
 
 function reviewTimeoutSeconds(options) {
@@ -210,19 +255,23 @@ function hasNoExpectedReviewDecision(fixture) {
 }
 
 function createSmokeConfig(options) {
-  const model = options.model || PROVIDER_DEFAULT_MODELS[options.provider] || 'auto';
+  const model = options.model || defaultModelForOptions(options);
   const timeoutSeconds = reviewTimeoutSeconds(options);
+  const backend = options.backend;
+  const includeProvider = backend === 'api' || backend === 'opencode';
   const agent = {
     id: 'clean-diff-smoke-reviewer',
     model,
-    backend: 'api',
-    provider: options.provider,
+    backend,
     enabled: true,
     timeout: timeoutSeconds,
     maxOutputTokens: 2048,
   };
+  if (includeProvider) {
+    agent.provider = options.provider;
+  }
 
-  return {
+  const config = {
     mode: 'pragmatic',
     language: 'en',
     reviewers: [agent],
@@ -235,8 +284,7 @@ function createSmokeConfig(options) {
       personaAssignment: 'random',
     },
     moderator: {
-      backend: 'api',
-      provider: options.provider,
+      backend,
       model,
       timeout: timeoutSeconds,
       maxOutputTokens: 2048,
@@ -253,8 +301,7 @@ function createSmokeConfig(options) {
       codeSnippetRange: 10,
     },
     head: {
-      backend: 'api',
-      provider: options.provider,
+      backend,
       model,
       enabled: true,
       timeout: timeoutSeconds,
@@ -268,6 +315,11 @@ function createSmokeConfig(options) {
       enabled: false,
     },
   };
+  if (includeProvider) {
+    config.moderator.provider = options.provider;
+    config.head.provider = options.provider;
+  }
+  return config;
 }
 
 function resolveCliCommand(options) {
@@ -598,11 +650,18 @@ function evaluateOutcome({ options, childResult, parsed, parseError, missingEnvV
     const diagnosticLine = errorLines.find((line) => /auth|user not found|quota|rate limit/i.test(line))
       ?? errorLines.find((line) => /api|provider|forfeit/i.test(line))
       ?? errorLines.find((line) => line);
-    if (diagnosticLine && /auth|api|provider|quota|rate limit|user not found|forfeit/i.test(errorText)) {
+    if (options.backend === 'api' && diagnosticLine && /auth|api|provider|quota|rate limit|user not found|forfeit/i.test(errorText)) {
       return {
         status: 'fail',
         passed: false,
         reason: `Live provider check failed with saved ${providerEnvVar(options.provider)} from ${defaultCredentialsPath()}: ${diagnosticLine}`,
+      };
+    }
+    if (options.backend !== 'api' && diagnosticLine) {
+      return {
+        status: 'fail',
+        passed: false,
+        reason: `Live ${options.backend} CLI backend check failed: ${diagnosticLine}`,
       };
     }
     return { status: 'fail', passed: false, reason: `CLI exited with ${childResult.exitCode}` };
@@ -671,6 +730,7 @@ function buildTranscript({ result, childResult, command }) {
     `smokeSchemaVersion: ${result.schemaVersion}`,
     `surface: ${result.surface}`,
     `mode: ${result.mode}`,
+    `backend: ${result.backend}`,
     `provider: ${result.provider}`,
     `model: ${result.model}`,
     `command: ${command}`,
@@ -798,15 +858,17 @@ async function runSmoke(options) {
     const command = buildCommandPreview(cli.file, reviewArgs);
     const env = {
       ...process.env,
-      HOME: fixtureDir,
-      USERPROFILE: fixtureDir,
       TMPDIR: fixtureDir,
-      XDG_CONFIG_HOME: fixtureDir,
       NODE_ENV: 'production',
       CODEAGORA_LANG: 'en',
       LANG: 'en_US.UTF-8',
       CI: '1',
     };
+    if (fixtureIsolatesUserHome(options)) {
+      env.HOME = fixtureDir;
+      env.USERPROFILE = fixtureDir;
+      env.XDG_CONFIG_HOME = fixtureDir;
+    }
     if (options.fixture === 'missing-provider-key') {
       delete env[requiredEnvVar];
     } else if (options.fixture === 'provider-failure') {
@@ -848,6 +910,7 @@ async function runSmoke(options) {
           : ['src/math.ts'],
       },
       mode: options.dryRun ? 'dry-run' : 'live',
+      backend: options.backend,
       provider: options.provider,
       model: options.model,
       requiredEnvVar: fixtureRecordsRequiredEnvVar(options) ? requiredEnvVar : null,

--- a/src/tests/AGENTS.md
+++ b/src/tests/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-06-14 -->
 
 # tests
 
@@ -60,6 +60,24 @@ Tests are **centralized**, not colocated with source. This enables:
 ```bash
 pnpm test           # Run root and package-local tests through vitest.config.ts
 ```
+
+**GitHub Action verification:**
+
+When touching `packages/github/src/action.ts`, `packages/github/src/action-policy.ts`, `action.yml`, `.github/workflows/*`, Action SARIF/diff handling, or provider-secret policy, run focused Action coverage before broader tests:
+
+```bash
+pnpm vitest run src/tests/github-action-parse-args.test.ts packages/github/src/tests/action-runtime.test.ts src/tests/github-actions-runtime.test.ts
+pnpm vitest run src/tests/github-action-diff-path-security.test.ts src/tests/github-action-sarif-path.test.ts src/tests/github-action-pr-smoke-recorder.test.ts
+pnpm vitest run packages/github/src/tests/action-event.test.ts packages/github/src/tests/action-reporting.test.ts packages/github/src/tests/github-poster.test.ts packages/github/src/tests/sarif.test.ts
+```
+
+For token, fork, permission, or secret-boundary changes, also run the relevant security/evidence scripts where practical. These tests are deterministic coverage; they do not prove live provider quality or live GitHub posting.
+
+**Preset and backend verification:**
+
+- `agora init --preset` changes need focused init/preset tests and generated-config smoke.
+- L1 CLI backend changes need `src/tests/l1-backend.test.ts` plus clean-diff smoke coverage.
+- L2/L3 moderation or clean-report changes need focused edge-case/verdict tests.
 
 **Vitest configuration** (`vitest.config.ts` at repo root):
 - **Globals enabled**: `describe`, `it`, `expect`, `beforeEach`, `afterEach` available without imports

--- a/src/tests/cli-clean-diff-smoke.test.ts
+++ b/src/tests/cli-clean-diff-smoke.test.ts
@@ -53,7 +53,7 @@ describe('CLI clean-diff smoke runner', () => {
     expect(CLEAN_FIXTURE_DIFF).not.toMatch(/token|password|secret|api[_-]?key/i);
   });
 
-  it('builds a single-reviewer provider config for the smoke run', () => {
+  it('builds a single-reviewer API provider config for the smoke run', () => {
     const options = parseArgs(['--provider', 'groq', '--model', 'llama-3.3-70b-versatile']);
     const config = createSmokeConfig(options);
 
@@ -64,12 +64,73 @@ describe('CLI clean-diff smoke runner', () => {
       model: 'llama-3.3-70b-versatile',
       backend: 'api',
     });
+    expect(config.moderator).toMatchObject({
+      provider: 'groq',
+      model: 'llama-3.3-70b-versatile',
+      backend: 'api',
+    });
     expect(config.discussion.enabled).toBe(false);
     expect(config.errorHandling.maxRetries).toBe(0);
   });
 
+  it('builds a provider-free CLI backend config for the smoke run', () => {
+    const options = parseArgs(['--backend', 'claude', '--model', 'sonnet']);
+    const config = createSmokeConfig(options);
+
+    expect(options).toMatchObject({
+      backend: 'claude',
+      provider: 'openrouter',
+      model: 'sonnet',
+    });
+    expect(config.reviewers[0]).toMatchObject({
+      id: 'clean-diff-smoke-reviewer',
+      model: 'sonnet',
+      backend: 'claude',
+    });
+    expect(config.reviewers[0]).not.toHaveProperty('provider');
+    expect(config.moderator).toMatchObject({
+      model: 'sonnet',
+      backend: 'claude',
+    });
+    expect(config.moderator).not.toHaveProperty('provider');
+    expect(config.head).toMatchObject({
+      model: 'sonnet',
+      backend: 'claude',
+    });
+    expect(config.head).not.toHaveProperty('provider');
+  });
+
+  it('defaults installed CLI backends to locally usable model/provider combinations', () => {
+    expect(parseArgs(['--backend', 'codex'])).toMatchObject({
+      backend: 'codex',
+      model: 'auto',
+      provider: 'openrouter',
+    });
+    expect(parseArgs(['--backend', 'copilot'])).toMatchObject({
+      backend: 'copilot',
+      model: 'auto',
+      provider: 'openrouter',
+    });
+    expect(parseArgs(['--backend', 'cursor'])).toMatchObject({
+      backend: 'cursor',
+      model: 'auto',
+      provider: 'openrouter',
+    });
+    expect(parseArgs(['--backend', 'antigravity'])).toMatchObject({
+      backend: 'antigravity',
+      model: 'auto',
+      provider: 'openrouter',
+    });
+    expect(parseArgs(['--backend', 'opencode'])).toMatchObject({
+      backend: 'opencode',
+      model: 'deepseek-v4-flash',
+      provider: 'opencode-go',
+    });
+  });
+
   it('accepts the pnpm argument separator before smoke options', () => {
     expect(parseArgs(['--', '--dry-run'])).toMatchObject({
+      backend: 'api',
       dryRun: true,
       provider: 'openrouter',
       model: 'xiaomi/mimo-v2.5',
@@ -248,6 +309,32 @@ describe('CLI clean-diff smoke runner', () => {
     expect(outcome.reason).toContain('User not found');
   });
 
+  it('reports CLI backend runtime failures without blaming saved provider credentials', () => {
+    const outcome = evaluateOutcome({
+      options: parseArgs(['--backend', 'codex']),
+      childResult: {
+        exitCode: 3,
+        signal: null,
+        timedOut: false,
+        stdout: '',
+        stderr: '',
+        durationMs: 10,
+      },
+      parsed: {
+        status: 'error',
+        error: 'All reviewers failed.\n- clean-diff-smoke-reviewer (codex/auto): Backend error: not trusted',
+      },
+      parseError: null,
+      missingEnvVar: null,
+    });
+
+    expect(outcome).toMatchObject({
+      status: 'fail',
+      passed: false,
+      reason: 'Live codex CLI backend check failed: All reviewers failed.',
+    });
+  });
+
   it('executes dry-run mode and returns a structured run result', async () => {
     const result = await runSmoke(parseArgs(['--dry-run']));
 
@@ -271,6 +358,93 @@ describe('CLI clean-diff smoke runner', () => {
     });
     expect(result.parsed.includedFiles).toContain('src/math.ts');
     expect(result.cli.exitCode).toBe(0);
+  });
+
+  it('does not require provider credentials for CLI backend live smoke runs', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeagora-cli-backend-smoke-'));
+    const cliPath = path.join(dir, 'fake-cli.mjs');
+    const capturePath = path.join(dir, 'fake-cli-capture.json');
+    const originalKey = process.env.OPENROUTER_API_KEY;
+    const originalCapture = process.env.CODEAGORA_FAKE_CAPTURE;
+
+    try {
+      delete process.env.OPENROUTER_API_KEY;
+      fs.writeFileSync(
+        cliPath,
+        [
+          '#!/usr/bin/env node',
+          'import fs from "node:fs";',
+          'import path from "node:path";',
+          'const config = JSON.parse(fs.readFileSync(".ca/config.json", "utf-8"));',
+          'const sessionDir = path.join(process.cwd(), ".ca", "sessions", "2026-06-11", "cli-backend-session");',
+          'fs.mkdirSync(sessionDir, { recursive: true });',
+          'fs.writeFileSync(path.join(sessionDir, "result.json"), JSON.stringify({ schemaVersion: "codeagora.session.v1" }));',
+          'fs.writeFileSync(process.env.CODEAGORA_FAKE_CAPTURE, JSON.stringify({',
+          '  argv: process.argv.slice(2),',
+          '  openrouterPresent: Boolean(process.env.OPENROUTER_API_KEY),',
+          '  reviewer: config.reviewers[0],',
+          '  moderator: config.moderator,',
+          '  head: config.head',
+          '}));',
+          'console.log(JSON.stringify({',
+          '  schemaVersion: "codeagora.review.v1",',
+          '  status: "success",',
+          '  sessionId: "cli-backend-session",',
+          '  date: "2026-06-11",',
+          '  summary: { decision: "ACCEPT", severityCounts: {} },',
+          '  evidenceDocs: []',
+          '}));',
+          '',
+        ].join('\n'),
+        'utf-8',
+      );
+      fs.chmodSync(cliPath, 0o755);
+      process.env.CODEAGORA_FAKE_CAPTURE = capturePath;
+
+      const result = await runSmoke(parseArgs(['--backend', 'codex', '--cli', cliPath]));
+      const captured = JSON.parse(fs.readFileSync(capturePath, 'utf-8'));
+
+      expect(result).toMatchObject({
+        mode: 'live',
+        backend: 'codex',
+        provider: 'openrouter',
+        model: 'auto',
+        requiredEnvVar: null,
+        passed: true,
+        outcome: {
+          status: 'pass',
+          passed: true,
+        },
+      });
+      expect(captured.openrouterPresent).toBe(false);
+      expect(captured.reviewer).toMatchObject({
+        backend: 'codex',
+        model: 'auto',
+      });
+      expect(captured.reviewer).not.toHaveProperty('provider');
+      expect(captured.moderator).toMatchObject({
+        backend: 'codex',
+        model: 'auto',
+      });
+      expect(captured.moderator).not.toHaveProperty('provider');
+      expect(captured.head).toMatchObject({
+        backend: 'codex',
+        model: 'auto',
+      });
+      expect(captured.head).not.toHaveProperty('provider');
+    } finally {
+      if (originalKey === undefined) {
+        delete process.env.OPENROUTER_API_KEY;
+      } else {
+        process.env.OPENROUTER_API_KEY = originalKey;
+      }
+      if (originalCapture === undefined) {
+        delete process.env.CODEAGORA_FAKE_CAPTURE;
+      } else {
+        process.env.CODEAGORA_FAKE_CAPTURE = originalCapture;
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('executes staged-diff mode in an isolated git fixture and records the observed CLI exit code', async () => {

--- a/src/tests/cli-commands.test.ts
+++ b/src/tests/cli-commands.test.ts
@@ -168,6 +168,18 @@ describe('runDoctor()', () => {
     expect(result.summary).toHaveProperty('warn');
   });
 
+  it('shows copy-pasteable OpenRouter Action setup commands for a keyless new repo', async () => {
+    const result = await runDoctor(tmpDir);
+    const steps = result.nextSteps ?? [];
+    const joined = steps.join('\n');
+
+    expect(joined).toContain('agora env set openrouter');
+    expect(joined).toContain('agora init --preset action --ci');
+    expect(joined).toContain('gh secret set OPENROUTER_API_KEY');
+    expect(joined.indexOf('agora env set openrouter')).toBeLessThan(joined.indexOf('agora init --preset action --ci'));
+    expect(joined.indexOf('agora init --preset action --ci')).toBeLessThan(joined.indexOf('gh secret set OPENROUTER_API_KEY'));
+  });
+
   it('includes a Node.js version check', async () => {
     const result = await runDoctor(tmpDir);
     const nodeCheck = result.checks.find((c) => c.name === 'Node.js version');
@@ -374,8 +386,9 @@ describe('formatDoctorReport()', () => {
     };
 
     const report = stripAnsi(formatDoctorReport(result));
-    expect(report).toContain('agora env set openrouter <api-key>');
-    expect(report).toContain('agora doctor --live');
+    expect(report).toContain('agora env set openrouter');
+    expect(report).toContain('agora init --preset action --ci');
+    expect(report).toContain('gh secret set OPENROUTER_API_KEY');
   });
 });
 

--- a/src/tests/critical-core-errors-orchestrator.test.ts
+++ b/src/tests/critical-core-errors-orchestrator.test.ts
@@ -91,6 +91,7 @@ vi.mock('../../packages/core/src/l0/quality-tracker.js', () => ({
 }));
 
 vi.mock('../../packages/shared/src/utils/diff.js', () => ({
+  classifyNoCodeDiffScope: vi.fn().mockReturnValue('code-change'),
   extractMultipleSnippets: vi.fn(),
   extractFileListFromDiff: vi.fn().mockReturnValue([]),
   parseDiffFileRanges: vi.fn().mockReturnValue([]),

--- a/src/tests/diff-scope.test.ts
+++ b/src/tests/diff-scope.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { classifyNoCodeDiffScope } from '@codeagora/shared/utils/diff.js';
+
+function diffFor(filePath: string, addedLine = 'new line'): string {
+  return [
+    `diff --git a/${filePath} b/${filePath}`,
+    'index 1111111..2222222 100644',
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+    '@@ -1 +1 @@',
+    '-old line',
+    `+${addedLine}`,
+    '',
+  ].join('\n');
+}
+
+describe('classifyNoCodeDiffScope()', () => {
+  it('classifies markdown and docs paths as docs-only', () => {
+    const diff = `${diffFor('README.md')}\n${diffFor('docs/setup.md')}`;
+
+    expect(classifyNoCodeDiffScope(diff)).toBe('docs-only');
+  });
+
+  it('classifies generated bundle artifacts as generated-only', () => {
+    const diff = `${diffFor('dist/action.js')}\n${diffFor('packages/cli/dist/index.js.map')}`;
+
+    expect(classifyNoCodeDiffScope(diff)).toBe('generated-only');
+  });
+
+  it('keeps mixed docs and source diffs on the normal code-change path', () => {
+    const diff = `${diffFor('README.md')}\n${diffFor('packages/core/src/index.ts', 'export const value = 1;')}`;
+
+    expect(classifyNoCodeDiffScope(diff)).toBe('code-change');
+  });
+});

--- a/src/tests/e2e-mock-scenarios.test.ts
+++ b/src/tests/e2e-mock-scenarios.test.ts
@@ -88,6 +88,7 @@ vi.mock('../../packages/core/src/l0/quality-tracker.js', () => ({
   })),
 }));
 vi.mock('../../packages/shared/src/utils/diff.js', () => ({
+  classifyNoCodeDiffScope: vi.fn().mockReturnValue('code-change'),
   extractMultipleSnippets: vi.fn(),
   extractFileListFromDiff: vi.fn().mockReturnValue([]),
   parseDiffFileRanges: vi.fn().mockReturnValue([]),

--- a/src/tests/github-actions-runtime.test.ts
+++ b/src/tests/github-actions-runtime.test.ts
@@ -103,7 +103,13 @@ describe('GitHub Actions runtime readiness', () => {
     expect(review).toContain('OPENROUTER_API_KEY');
     expect(review).toContain('provider=openrouter');
     expect(review).not.toContain('provider=groq');
-    expect(review).toContain('qwen/qwen3.7-max');
+    expect(review).toContain('qwen/qwen3-235b-a22b-2507');
+    expect(review).toContain('deepseek/deepseek-v4-flash');
+    expect(review).toContain('qwen/qwen3.5-9b');
+    expect(review).toContain('z-ai/glm-4.7-flash');
+    expect(review).toContain('openai/gpt-oss-120b');
+    expect(review).toContain('moonshotai/kimi-k2.5');
+    expect(review).toContain('"enabled": false');
     expect(bench).not.toContain('models: read');
     expect(bench).toContain('config.openrouter-low-cost-5x2.json');
     expect(bench).toContain('OPENROUTER_API_KEY');

--- a/src/tests/init-multiselect.test.ts
+++ b/src/tests/init-multiselect.test.ts
@@ -118,7 +118,7 @@ function makeCatalog(): ModelsCatalog {
 }
 
 function makeCli(available: string[]): DetectedCli[] {
-  const all = ['claude', 'codex', 'gemini', 'copilot', 'opencode'];
+  const all = ['claude', 'codex', 'gemini', 'copilot', 'cursor', 'antigravity', 'opencode'];
   return all.map((backend) => ({
     backend,
     bin: backend,
@@ -141,25 +141,33 @@ describe('generatePresets()', () => {
     'qwen/qwen3-coder-flash',
     'qwen/qwen3-next-80b-a3b-instruct',
   ];
+  const openrouterActionModels = [
+    'qwen/qwen3-235b-a22b-2507',
+    'deepseek/deepseek-v4-flash',
+    'qwen/qwen3.5-9b',
+    'z-ai/glm-4.7-flash',
+    'openai/gpt-oss-120b',
+  ];
 
   it('returns fallback presets when no providers or CLIs detected', () => {
     const presets = generatePresets(makeEmptyEnv(), null);
-    expect(presets).toHaveLength(3);
-    expect(presets[0]!.id).toBe('quick');
-    expect(presets[1]!.id).toBe('thorough');
-    expect(presets[2]!.id).toBe('free');
+    expect(presets).toHaveLength(4);
+    expect(presets[0]!.id).toBe('action');
+    expect(presets[1]!.id).toBe('quick');
+    expect(presets[2]!.id).toBe('thorough');
+    expect(presets[3]!.id).toBe('free');
     // Fallback presets use the OpenRouter starter lineup.
     for (const p of presets) {
       expect(p.providers).toContain('openrouter');
     }
-    expect(presets[0]!.reviewerCount).toBe(4);
-    expect(presets[0]!.reviewerModels).toEqual(openrouterFastModels);
+    expect(presets[1]!.reviewerCount).toBe(4);
+    expect(presets[1]!.reviewerModels).toEqual(openrouterFastModels);
   });
 
   it('returns fallback presets when no providers detected and no CLI available', () => {
     const presets = generatePresets(makeEmptyEnv(), null, makeCli([]));
-    expect(presets).toHaveLength(3);
-    expect(presets[0]!.id).toBe('quick');
+    expect(presets).toHaveLength(4);
+    expect(presets[0]!.id).toBe('action');
   });
 
   it('generates quick preset from first detected provider', () => {
@@ -187,6 +195,30 @@ describe('generatePresets()', () => {
     expect(starter!.providers).toEqual(['openrouter']);
     expect(starter!.reviewerCount).toBe(2);
     expect(starter!.reviewerModels).toEqual(openrouterStarterModels);
+  });
+
+  it('generates OpenRouter Action preset with cheap reviewers and direct head escalation', () => {
+    const presets = generatePresets(makeEnv(['openrouter']), null);
+    const action = presets.find((p) => p.id === 'action');
+    expect(action).toBeDefined();
+    expect(action!.providers).toEqual(['openrouter']);
+    expect(action!.backend).toBe('api');
+    expect(action!.reviewerCount).toBe(5);
+    expect(action!.reviewerModels).toEqual(openrouterActionModels);
+    expect(action!.discussion).toBe(true);
+    expect(action!.maxRounds).toBe(1);
+    expect(action!.roleSelections).toMatchObject({
+      supporter: { provider: 'openrouter', model: 'z-ai/glm-5.1', backend: 'api' },
+      devilsAdvocate: { provider: 'openrouter', model: 'moonshotai/kimi-k2.5', backend: 'api' },
+      moderator: { provider: 'openrouter', model: 'z-ai/glm-5.1', backend: 'api' },
+      moderatorEnabled: false,
+      head: { provider: 'openrouter', model: 'z-ai/glm-5.1', backend: 'api' },
+    });
+  });
+
+  it('keeps Action preset available even when OpenRouter is not detected in the shell', () => {
+    const presets = generatePresets(makeEnv(['openai']), null, makeCli(['codex']));
+    expect(presets.find((p) => p.id === 'action')).toBeDefined();
   });
 
   it('does not generate free preset when groq is detected', () => {
@@ -226,11 +258,33 @@ describe('generatePresets()', () => {
   });
 
   it('generates CLI preset when CLI backends available', () => {
-    const presets = generatePresets(makeEnv(['groq']), null, makeCli(['claude']));
+    const presets = generatePresets(makeEnv(['groq']), null, makeCli(['claude', 'codex', 'opencode']));
     const cli = presets.find((p) => p.id === 'cli');
     expect(cli).toBeDefined();
-    expect(cli!.providers).toContain('claude');
+    expect(cli!.label).toContain('Local CLI ensemble');
+    expect(cli!.providers).toEqual(['codex', 'claude', 'opencode']);
+    expect(cli!.models).toMatchObject({
+      codex: 'gpt-5.4-mini',
+      claude: 'haiku',
+      opencode: 'deepseek-v4-flash',
+    });
+    expect(cli!.runtimeProviders).toMatchObject({
+      opencode: 'opencode-go',
+    });
+    expect(cli!.reviewerCount).toBe(3);
+    expect(cli!.discussion).toBe(true);
     expect(cli!.backend).toBe('cli');
+    expect(cli!.roleSelections).toMatchObject({
+      supporter: { provider: 'codex', model: 'gpt-5.3-codex-spark', backend: 'cli' },
+      devilsAdvocate: {
+        provider: 'opencode',
+        model: 'kimi-k2.7-code',
+        backend: 'cli',
+        runtimeProvider: 'opencode-go',
+      },
+      moderator: { provider: 'codex', model: 'gpt-5.5', backend: 'cli' },
+      head: { provider: 'codex', model: 'gpt-5.5', backend: 'cli' },
+    });
   });
 
   it('does not generate CLI preset when no CLI backends available', () => {
@@ -490,7 +544,71 @@ describe('buildMultiProviderConfig()', () => {
     });
 
     expect(config.reviewers[0]!.backend).toBe('claude');
-    expect(config.moderator.backend).toBe('cli');
+    expect(config.reviewers[0]!.provider).toBeUndefined();
+    expect(config.moderator.backend).toBe('claude');
+    expect(config.moderator.provider).toBeUndefined();
+    expect((config.head as Record<string, unknown>)['backend']).toBe('claude');
+  });
+
+  it('supports opencode CLI runtime provider', () => {
+    const config = buildMultiProviderConfig({
+      selections: [
+        { provider: 'opencode', model: 'deepseek-v4-flash', backend: 'cli', runtimeProvider: 'opencode-go' },
+      ],
+      reviewerCount: 1,
+      discussion: false,
+    });
+
+    expect(config.reviewers[0]).toMatchObject({
+      backend: 'opencode',
+      provider: 'opencode-go',
+      model: 'deepseek-v4-flash',
+    });
+    expect(config.moderator).toMatchObject({
+      backend: 'opencode',
+      provider: 'opencode-go',
+      model: 'deepseek-v4-flash',
+    });
+  });
+
+  it('supports explicit local CLI role selections', () => {
+    const config = buildMultiProviderConfig({
+      selections: [
+        { provider: 'codex', model: 'gpt-5.4-mini', backend: 'cli' },
+        { provider: 'claude', model: 'haiku', backend: 'cli' },
+        { provider: 'opencode', model: 'deepseek-v4-flash', backend: 'cli', runtimeProvider: 'opencode-go' },
+      ],
+      reviewerCount: 3,
+      discussion: true,
+      supporterSelection: { provider: 'codex', model: 'gpt-5.3-codex-spark', backend: 'cli' },
+      devilsAdvocateSelection: {
+        provider: 'opencode',
+        model: 'kimi-k2.7-code',
+        backend: 'cli',
+        runtimeProvider: 'opencode-go',
+      },
+      moderatorSelection: { provider: 'codex', model: 'gpt-5.5', backend: 'cli' },
+      headSelection: { provider: 'codex', model: 'gpt-5.5', backend: 'cli' },
+    });
+
+    expect(config.supporters.pool[0]).toMatchObject({
+      backend: 'codex',
+      model: 'gpt-5.3-codex-spark',
+    });
+    expect(config.supporters.devilsAdvocate).toMatchObject({
+      backend: 'opencode',
+      provider: 'opencode-go',
+      model: 'kimi-k2.7-code',
+    });
+    expect(config.moderator).toMatchObject({
+      backend: 'codex',
+      model: 'gpt-5.5',
+    });
+    expect(config.head).toMatchObject({
+      backend: 'codex',
+      model: 'gpt-5.5',
+    });
+    expect(config.discussion.enabled).toBe(true);
   });
 
   it('passes mode and language through', () => {

--- a/src/tests/l1-backend.test.ts
+++ b/src/tests/l1-backend.test.ts
@@ -105,8 +105,8 @@ describe('executeBackend() CLI backends – successful execution', () => {
     expect(writeSpy).toHaveBeenCalledWith('test prompt');
   });
 
-  it('writes prompt to stdin for all CLI backends (prompt not embedded in args)', async () => {
-    const stdinBackends = ['copilot', 'cursor', 'antigravity', 'pi'] as const;
+  it('writes prompt to stdin for stdin-based CLI backends', async () => {
+    const stdinBackends = ['cursor', 'antigravity', 'pi'] as const;
     for (const backend of stdinBackends) {
       const child = createMockChild('ok', '', 0);
       const writeSpy = vi.spyOn(child.stdin, 'write');
@@ -114,6 +114,20 @@ describe('executeBackend() CLI backends – successful execution', () => {
       await executeBackend(makeInput({ backend, provider: undefined, prompt: 'test' }));
       expect(writeSpy).toHaveBeenCalledWith('test');
     }
+  });
+
+  it('embeds the prompt as a direct arg for copilot because its CLI requires --prompt text', async () => {
+    const child = createMockChild('ok', '', 0);
+    const writeSpy = vi.spyOn(child.stdin, 'write');
+    mockSpawn.mockReturnValue(child);
+    await executeBackend(makeInput({ backend: 'copilot', provider: undefined, prompt: 'test prompt', model: 'auto' }));
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'copilot',
+      ['-s', '--allow-all', '-p', 'test prompt'],
+      expect.any(Object),
+    );
   });
 
   it('throws when exit code is non-zero and stdout is empty', async () => {
@@ -153,7 +167,16 @@ describe('executeBackend() dispatches correct CLI command per backend', () => {
     await executeBackend(makeInput({ backend: 'codex', model: 'o3', provider: undefined }));
     expect(mockSpawn).toHaveBeenCalledWith(
       'codex',
-      ['exec', '-m', 'o3', '-'],
+      ['exec', '--skip-git-repo-check', '-m', 'o3', '-'],
+      expect.any(Object)
+    );
+  });
+
+  it('spawns codex without -m when model is auto so the installed CLI can pick its default', async () => {
+    await executeBackend(makeInput({ backend: 'codex', model: 'auto', provider: undefined }));
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'codex',
+      ['exec', '--skip-git-repo-check', '-'],
       expect.any(Object)
     );
   });
@@ -176,20 +199,29 @@ describe('executeBackend() dispatches correct CLI command per backend', () => {
     );
   });
 
-  it('spawns copilot CLI for copilot backend (prompt via stdin, not args)', async () => {
-    await executeBackend(makeInput({ backend: 'copilot', model: 'gpt-4o', provider: undefined }));
+  it('spawns copilot CLI with direct prompt args', async () => {
+    await executeBackend(makeInput({ backend: 'copilot', model: 'gpt-4o', provider: undefined, prompt: 'Review this code' }));
     expect(mockSpawn).toHaveBeenCalledWith(
       'copilot',
-      ['-s', '--allow-all', '--model', 'gpt-4o'],
+      ['-s', '--allow-all', '--model', 'gpt-4o', '-p', 'Review this code'],
       expect.any(Object)
     );
   });
 
-  it('spawns agent binary for cursor backend (prompt via stdin)', async () => {
+  it('spawns copilot without --model when model is auto', async () => {
+    await executeBackend(makeInput({ backend: 'copilot', model: 'auto', provider: undefined, prompt: 'Review this code' }));
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'copilot',
+      ['-s', '--allow-all', '-p', 'Review this code'],
+      expect.any(Object)
+    );
+  });
+
+  it('spawns agent binary for cursor backend in trusted print mode', async () => {
     await executeBackend(makeInput({ backend: 'cursor', model: 'gpt-4o', provider: undefined }));
     expect(mockSpawn).toHaveBeenCalledWith(
       'agent',
-      [],
+      ['-p', '--trust'],
       expect.any(Object)
     );
   });

--- a/src/tests/l3-verdict.test.ts
+++ b/src/tests/l3-verdict.test.ts
@@ -330,6 +330,25 @@ describe('makeHeadVerdict()', () => {
       expect(verdict.decision).toBe('REJECT');
     });
 
+    it('routes forced tie-break critical discussions to human review even above the confidence boundary', async () => {
+      const report = makeReport({
+        discussions: [
+          makeVerdict({
+            discussionId: 'd-forced-tie',
+            finalSeverity: 'CRITICAL',
+            consensusReached: true,
+            avgConfidence: 59,
+            reasoning: 'Tie broken by forced decision on last round (1 agree, 1 disagree)',
+          }),
+        ],
+      });
+
+      const verdict = await makeHeadVerdict(report);
+
+      expect(verdict.decision).toBe('NEEDS_HUMAN');
+      expect(verdict.questionsForHuman?.[0]).toContain('d-forced-tie');
+    });
+
     it('does not block on critical discussions with unknown:0 locations', async () => {
       const report = makeReport({
         discussions: [
@@ -514,6 +533,28 @@ describe('applyHeadVerdictSafety()', () => {
 
     expect(verdict.decision).toBe('NEEDS_HUMAN');
     expect(verdict.questionsForHuman?.[0]).toContain('d-low-confidence');
+  });
+
+  it('overrides REJECT to NEEDS_HUMAN for forced tie-break critical discussions', () => {
+    const report = makeReport({
+      discussions: [
+        makeVerdict({
+          discussionId: 'd-forced-tie',
+          finalSeverity: 'CRITICAL',
+          consensusReached: true,
+          avgConfidence: 59,
+          reasoning: 'Tie broken by forced decision on last round (1 agree, 1 disagree)',
+        }),
+      ],
+    });
+
+    const verdict = applyHeadVerdictSafety({
+      decision: 'REJECT',
+      reasoning: 'LLM rejected a forced tie-break critical.',
+    }, report);
+
+    expect(verdict.decision).toBe('NEEDS_HUMAN');
+    expect(verdict.questionsForHuman?.[0]).toContain('d-forced-tie');
   });
 
   it('does not let invalid critical locations override an LLM accept verdict', () => {

--- a/src/tests/l3-verdict.test.ts
+++ b/src/tests/l3-verdict.test.ts
@@ -69,6 +69,23 @@ describe('makeHeadVerdict()', () => {
       expect(verdict.decision).toBe('ACCEPT');
     });
 
+    it('does not call LLM head for a clean report with no actionable findings', async () => {
+      mockExecuteBackend.mockResolvedValue(
+        'DECISION: NEEDS_HUMAN\nREASONING: No issues were provided.\nQUESTIONS: inspect manually',
+      );
+      const report = makeReport();
+
+      const verdict = await makeHeadVerdict(report, {
+        backend: 'api',
+        model: 'head-model',
+        provider: 'test-provider',
+        enabled: true,
+      });
+
+      expect(verdict.decision).toBe('ACCEPT');
+      expect(mockExecuteBackend).not.toHaveBeenCalled();
+    });
+
     it('returns ACCEPT when all discussions are consensus and none are critical', async () => {
       const report = makeReport({
         discussions: [

--- a/src/tests/orchestrator-branches.test.ts
+++ b/src/tests/orchestrator-branches.test.ts
@@ -86,6 +86,7 @@ vi.mock('../../packages/core/src/l0/quality-tracker.js', () => ({
 }));
 
 vi.mock('../../packages/shared/src/utils/diff.js', () => ({
+  classifyNoCodeDiffScope: vi.fn().mockReturnValue('code-change'),
   extractMultipleSnippets: vi.fn(),
   extractFileListFromDiff: vi.fn().mockReturnValue([]),
   parseDiffFileRanges: vi.fn().mockReturnValue([]),
@@ -124,7 +125,7 @@ import { makeHeadVerdict, scanUnconfirmedQueue } from '@codeagora/core/l3/verdic
 import { writeHeadVerdict } from '@codeagora/core/l3/writer.js';
 import { resolveReviewers, getBanditStore } from '@codeagora/core/l0/index.js';
 import { QualityTracker } from '@codeagora/core/l0/quality-tracker.js';
-import { extractMultipleSnippets } from '@codeagora/shared/utils/diff.js';
+import { classifyNoCodeDiffScope, extractMultipleSnippets } from '@codeagora/shared/utils/diff.js';
 import { createLogger } from '@codeagora/shared/utils/logger.js';
 import { chunkDiff } from '@codeagora/core/pipeline/chunker.js';
 import fs from 'fs/promises';
@@ -197,6 +198,7 @@ function setupDefaultMocks() {
   (writeAllReviews as Mock).mockResolvedValue([]);
   (applyThreshold as Mock).mockReturnValue({ discussions: [], unconfirmed: [], suggestions: [] });
   (deduplicateDiscussions as Mock).mockReturnValue({ deduplicated: [], mergedCount: 0 });
+  (classifyNoCodeDiffScope as Mock).mockReturnValue('code-change');
   (extractMultipleSnippets as Mock).mockReturnValue(new Map());
   (runModerator as Mock).mockResolvedValue({ ...mockModeratorReport });
   (writeModeratorReport as Mock).mockResolvedValue(undefined);
@@ -427,6 +429,41 @@ describe('Orchestrator Branches', () => {
     // Should have completed without calling executeReviewers
     expect(result.status).toBe('success');
     expect(executeReviewers).not.toHaveBeenCalled();
+  });
+
+  it('docs-only latest diff returns ACCEPT without calling reviewers', async () => {
+    (classifyNoCodeDiffScope as Mock).mockReturnValue('docs-only');
+
+    const result = await runPipeline({ diffPath: '/tmp/test.diff' });
+
+    expect(result.status).toBe('success');
+    expect(result.summary?.decision).toBe('ACCEPT');
+    expect(result.summary?.reasoning).toContain('docs-only');
+    expect(result.summary?.totalReviewers).toBe(0);
+    expect(executeReviewers).not.toHaveBeenCalled();
+    expect(chunkDiff).not.toHaveBeenCalled();
+    expect(mockSession.setMetadata).toHaveBeenCalledWith(expect.objectContaining({
+      reviewScope: 'docs-only',
+      newDiffClassification: 'docs-only',
+      codeReviewRequired: false,
+      tsVerificationSkipped: true,
+    }));
+  });
+
+  it('generated-only latest diff returns ACCEPT without L1, L2, or L3 calls', async () => {
+    (classifyNoCodeDiffScope as Mock).mockReturnValue('generated-only');
+
+    const result = await runPipeline({ diffPath: '/tmp/test.diff' });
+
+    expect(result.status).toBe('success');
+    expect(result.summary?.decision).toBe('ACCEPT');
+    expect(result.summary?.reasoning).toContain('generated artifacts only');
+    expect(result.reviewRun?.l1.completed).toBe(0);
+    expect(result.reviewRun?.l2.skipped).toBe(true);
+    expect(result.reviewRun?.l3.skipped).toBe(true);
+    expect(executeReviewers).not.toHaveBeenCalled();
+    expect(runModerator).not.toHaveBeenCalled();
+    expect(makeHeadVerdict).not.toHaveBeenCalled();
   });
 
   // --------------------------------------------------------------------------

--- a/src/tests/pipeline-chunk-parallel.test.ts
+++ b/src/tests/pipeline-chunk-parallel.test.ts
@@ -86,6 +86,7 @@ vi.mock('../../packages/core/src/l0/quality-tracker.js', () => ({
 }));
 
 vi.mock('../../packages/shared/src/utils/diff.js', () => ({
+  classifyNoCodeDiffScope: vi.fn().mockReturnValue('code-change'),
   extractMultipleSnippets: vi.fn(),
   extractFileListFromDiff: vi.fn().mockReturnValue([]),
   parseDiffFileRanges: vi.fn().mockReturnValue([]),


### PR DESCRIPTION
## Summary
- add a GitHub Actions OpenRouter cheap preset and wire review.yml to the agreed model lineup
- support direct head escalation by disabling L2 moderator forced decisions
- stabilize local CLI backends and clean-diff smoke coverage

## Verification
- pnpm exec vitest run packages/github/src/tests/action-runtime.test.ts src/tests/github-actions-runtime.test.ts packages/core/src/tests/edge-cases.test.ts src/tests/init-multiselect.test.ts packages/cli/src/tests/cli-init-advanced.test.ts --no-file-parallelism
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm build:action
- git diff --check

## Action test
This PR is intentionally opened to verify the real GitHub Actions path with OPENROUTER_API_KEY configured.