### PR TITLE
Stabilize forced tie verdict signals

### DIFF
--- a/packages/core/src/l2/moderator.ts
+++ b/packages/core/src/l2/moderator.ts
@@ -69,6 +69,7 @@ export async function runModerator(input: ModeratorInput): Promise<ModeratorRepo
         reasoning: `Discussion failed: ${errorMessage}`,
         consensusReached: false,
         rounds: 0,
+        resolutionSource: 'discussion-failed',
       };
       verdicts.push(errorVerdict);
       roundsPerDiscussion[discussions[i].id] = [];
@@ -122,6 +123,7 @@ async function runDiscussion(
       reasoning: 'No supporters available — discussion skipped',
       consensusReached: false,
       rounds: 0,
+      resolutionSource: 'discussion-skipped',
     };
     await writeDiscussionVerdict(date, sessionId, skippedVerdict);
     return { verdict: skippedVerdict, rounds };
@@ -229,6 +231,7 @@ async function runDiscussion(
         reasoning: consensus.reasoning!,
         consensusReached: true,
         rounds: roundNum,
+        resolutionSource: consensus.resolutionSource ?? 'supporter-consensus',
       };
 
       // Write verdict file
@@ -256,6 +259,7 @@ async function runDiscussion(
       reasoning: 'Moderator disabled; unresolved discussion escalated directly to head verdict.',
       consensusReached: false,
       rounds: settings.maxRounds,
+      resolutionSource: 'moderator-disabled',
     };
 
     await writeDiscussionVerdict(date, sessionId, verdict);
@@ -286,6 +290,7 @@ async function runDiscussion(
     reasoning: finalVerdict.reasoning,
     consensusReached: false,
     rounds: settings.maxRounds,
+    resolutionSource: 'moderator-forced',
   };
 
   emitter?.emitEvent({
@@ -485,6 +490,7 @@ interface ConsensusResult {
   reached: boolean;
   severity?: 'HARSHLY_CRITICAL' | 'CRITICAL' | 'WARNING' | 'SUGGESTION' | 'DISMISSED';
   reasoning?: string;
+  resolutionSource?: DiscussionVerdict['resolutionSource'];
 }
 
 export function checkConsensus(round: DiscussionRound, discussion: Discussion, isLastRound = false): ConsensusResult {
@@ -502,6 +508,7 @@ export function checkConsensus(round: DiscussionRound, discussion: Discussion, i
       reached: true,
       severity: discussion.severity as ConsensusResult['severity'],
       reasoning: 'All supporters agreed on the issue',
+      resolutionSource: 'supporter-consensus',
     };
   }
 
@@ -515,12 +522,14 @@ export function checkConsensus(round: DiscussionRound, discussion: Discussion, i
         reached: true,
         severity: 'CRITICAL',
         reasoning: 'All supporters rejected HARSHLY_CRITICAL claim — downgraded to CRITICAL for human review',
+        resolutionSource: 'supporter-consensus',
       };
     }
     return {
       reached: true,
       severity: 'DISMISSED',
       reasoning: 'All supporters rejected the issue',
+      resolutionSource: 'supporter-consensus',
     };
   }
 
@@ -534,6 +543,7 @@ export function checkConsensus(round: DiscussionRound, discussion: Discussion, i
       reached: true,
       severity: discussion.severity as ConsensusResult['severity'],
       reasoning: `Majority consensus (${agreeCount}/${supporters.length} agree)`,
+      resolutionSource: 'supporter-consensus',
     };
   }
 
@@ -544,12 +554,14 @@ export function checkConsensus(round: DiscussionRound, discussion: Discussion, i
         reached: true,
         severity: 'CRITICAL',
         reasoning: `Majority rejected HARSHLY_CRITICAL claim (${disagreeCount}/${supporters.length} disagree) — downgraded to CRITICAL`,
+        resolutionSource: 'supporter-consensus',
       };
     }
     return {
       reached: true,
       severity: 'DISMISSED',
       reasoning: `Majority rejected (${disagreeCount}/${supporters.length} disagree)`,
+      resolutionSource: 'supporter-consensus',
     };
   }
 
@@ -559,6 +571,7 @@ export function checkConsensus(round: DiscussionRound, discussion: Discussion, i
       reached: true,
       severity: discussion.severity as ConsensusResult['severity'],
       reasoning: `Tie broken by forced decision on last round (${agreeCount} agree, ${disagreeCount} disagree)`,
+      resolutionSource: 'forced-tie-break',
     };
   }
 

--- a/packages/core/src/l2/writer.ts
+++ b/packages/core/src/l2/writer.ts
@@ -177,6 +177,9 @@ function formatVerdict(verdict: DiscussionVerdict): string {
   lines.push(`**Final Severity:** ${verdict.finalSeverity}`);
   lines.push(`**Consensus Reached:** ${verdict.consensusReached ? 'Yes' : 'No (Escalated)'}`);
   lines.push(`**Rounds:** ${verdict.rounds}`);
+  if (verdict.resolutionSource) {
+    lines.push(`**Resolution Source:** ${verdict.resolutionSource}`);
+  }
   lines.push('');
 
   lines.push('## Reasoning');

--- a/packages/core/src/l3/verdict.ts
+++ b/packages/core/src/l3/verdict.ts
@@ -111,8 +111,11 @@ function buildHeadPrompt(report: ModeratorReport, language?: 'en' | 'ko'): strin
     const confStr = d.avgConfidence != null
       ? (isKo ? `, 신뢰도: ${d.avgConfidence}%` : `, confidence: ${d.avgConfidence}%`)
       : '';
+    const sourceStr = d.resolutionSource
+      ? (isKo ? `, 판정 출처: ${d.resolutionSource}` : `, resolution source: ${d.resolutionSource}`)
+      : '';
     return [
-      `- [${d.finalSeverity}] ${d.discussionId} (${d.filePath}:${d.lineRange[0]}) — ${consensus}, ${d.rounds} ${isKo ? '라운드' : 'round(s)'}${confStr}`,
+      `- [${d.finalSeverity}] ${d.discussionId} (${d.filePath}:${d.lineRange[0]}) — ${consensus}, ${d.rounds} ${isKo ? '라운드' : 'round(s)'}${confStr}${sourceStr}`,
       wrapUntrustedBlock(`moderator_reasoning_${d.discussionId}`, d.reasoning),
     ].join('\n');
   }).join('\n');
@@ -265,7 +268,8 @@ function hasActionableEvidenceLocation(doc: EvidenceDocument): boolean {
 }
 
 function isForcedTieBreak(verdict: DiscussionVerdict): boolean {
-  return /tie broken by forced decision/i.test(verdict.reasoning);
+  return verdict.resolutionSource === 'forced-tie-break' ||
+    /tie broken by forced decision/i.test(verdict.reasoning);
 }
 
 function isCleanModeratorReport(report: ModeratorReport): boolean {

--- a/packages/core/src/pipeline/confidence.ts
+++ b/packages/core/src/pipeline/confidence.ts
@@ -7,6 +7,8 @@ export interface DiscussionVerdictLike {
   consensusReached: boolean;
   finalSeverity: string;
   rounds: number;
+  resolutionSource?: string;
+  reasoning?: string;
 }
 
 /**
@@ -145,6 +147,12 @@ export function adjustConfidenceFromDiscussion(
   verdict: DiscussionVerdictLike
 ): number {
   let adjusted = baseConfidence;
+  const forcedTieBreak = verdict.resolutionSource === 'forced-tie-break' ||
+    /tie broken by forced decision/i.test(verdict.reasoning ?? '');
+  if (forcedTieBreak) {
+    adjusted -= 10;
+    return Math.max(0, Math.min(100, adjusted));
+  }
   if (verdict.consensusReached) {
     if (verdict.finalSeverity === 'DISMISSED') {
       return 0;

--- a/packages/core/src/tests/l2-hc-debate.test.ts
+++ b/packages/core/src/tests/l2-hc-debate.test.ts
@@ -49,6 +49,7 @@ describe('checkConsensus — HARSHLY_CRITICAL all agree', () => {
     const result = checkConsensus(round, discussion);
     expect(result.reached).toBe(true);
     expect(result.severity).toBe('HARSHLY_CRITICAL');
+    expect(result.resolutionSource).toBe('supporter-consensus');
   });
 });
 
@@ -139,6 +140,7 @@ describe('checkConsensus — HARSHLY_CRITICAL tie', () => {
     const result = checkConsensus(round, discussion, /* isLastRound */ true);
     expect(result.reached).toBe(true);
     expect(result.severity).toBe('HARSHLY_CRITICAL');
+    expect(result.resolutionSource).toBe('forced-tie-break');
   });
 
   it('does not reach consensus on tie during non-last round', () => {

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -135,6 +135,13 @@ export interface DiscussionVerdict {
   reasoning: string;
   consensusReached: boolean;
   rounds: number;
+  resolutionSource?:
+    | 'supporter-consensus'
+    | 'forced-tie-break'
+    | 'moderator-forced'
+    | 'moderator-disabled'
+    | 'discussion-skipped'
+    | 'discussion-failed';
   /** Average confidence (0-100) of the underlying evidence docs, computed after L2 */
   avgConfidence?: number;
 }

--- a/src/tests/confidence.test.ts
+++ b/src/tests/confidence.test.ts
@@ -121,6 +121,18 @@ describe('adjustConfidenceFromDiscussion', () => {
     expect(adjustConfidenceFromDiscussion(50, verdict4)).toBe(80);
   });
 
+  it('does not boost confidence for forced tie-break decisions', () => {
+    const verdict = {
+      filePath: 'src/foo.ts',
+      lineRange: [10, 12] as [number, number],
+      consensusReached: true,
+      finalSeverity: 'CRITICAL',
+      rounds: 1,
+      resolutionSource: 'forced-tie-break',
+    };
+    expect(adjustConfidenceFromDiscussion(60, verdict)).toBe(50);
+  });
+
   it('clamps between 0 and 100', () => {
     const verdictHigh = {
       filePath: 'src/foo.ts',

--- a/src/tests/l2-writer.test.ts
+++ b/src/tests/l2-writer.test.ts
@@ -244,6 +244,13 @@ describe('writeDiscussionVerdict()', () => {
     expect(content).toContain('5');
   });
 
+  it('writes the resolution source when present', async () => {
+    await writeDiscussionVerdict(DATE, SESSION_ID, makeVerdict({ resolutionSource: 'forced-tie-break' }));
+    const [, content] = mockWriteMarkdown.mock.calls[0];
+    expect(content).toContain('Resolution Source');
+    expect(content).toContain('forced-tie-break');
+  });
+
   it('includes the reasoning text in the content', async () => {
     const reasoning = 'The panel reached a clear agreement.';
     await writeDiscussionVerdict(DATE, SESSION_ID, makeVerdict({ reasoning }));

--- a/src/tests/l3-verdict.test.ts
+++ b/src/tests/l3-verdict.test.ts
@@ -338,6 +338,7 @@ describe('makeHeadVerdict()', () => {
             finalSeverity: 'CRITICAL',
             consensusReached: true,
             avgConfidence: 59,
+            resolutionSource: 'forced-tie-break',
             reasoning: 'Tie broken by forced decision on last round (1 agree, 1 disagree)',
           }),
         ],
@@ -347,6 +348,26 @@ describe('makeHeadVerdict()', () => {
 
       expect(verdict.decision).toBe('NEEDS_HUMAN');
       expect(verdict.questionsForHuman?.[0]).toContain('d-forced-tie');
+    });
+
+    it('uses resolutionSource instead of parsing reasoning for forced tie-break criticals', async () => {
+      const report = makeReport({
+        discussions: [
+          makeVerdict({
+            discussionId: 'd-forced-source',
+            finalSeverity: 'CRITICAL',
+            consensusReached: true,
+            avgConfidence: 59,
+            resolutionSource: 'forced-tie-break',
+            reasoning: 'Moderator summarized a split vote.',
+          }),
+        ],
+      });
+
+      const verdict = await makeHeadVerdict(report);
+
+      expect(verdict.decision).toBe('NEEDS_HUMAN');
+      expect(verdict.questionsForHuman?.[0]).toContain('d-forced-source');
     });
 
     it('does not block on critical discussions with unknown:0 locations', async () => {
@@ -412,7 +433,12 @@ describe('makeHeadVerdict()', () => {
       mockExecuteBackend.mockResolvedValue('DECISION: ACCEPT\nREASONING: Only actionable discussions remain.\nQUESTIONS: none');
       const report = makeReport({
         discussions: [
-          makeVerdict({ discussionId: 'd-actionable-warning', finalSeverity: 'WARNING', consensusReached: true }),
+          makeVerdict({
+            discussionId: 'd-actionable-warning',
+            finalSeverity: 'WARNING',
+            consensusReached: true,
+            resolutionSource: 'supporter-consensus',
+          }),
           makeVerdict({
             discussionId: 'd-invalid-critical',
             filePath: 'unknown',
@@ -452,6 +478,7 @@ describe('makeHeadVerdict()', () => {
       expect(backendInput?.prompt).not.toContain('unknown:0');
       expect(backendInput?.prompt).toContain('CRITICAL: 0 issues');
       expect(backendInput?.prompt).toContain('Total discussions: 1');
+      expect(backendInput?.prompt).toContain('resolution source: supporter-consensus');
     });
   });
 });
@@ -543,6 +570,7 @@ describe('applyHeadVerdictSafety()', () => {
           finalSeverity: 'CRITICAL',
           consensusReached: true,
           avgConfidence: 59,
+          resolutionSource: 'forced-tie-break',
           reasoning: 'Tie broken by forced decision on last round (1 agree, 1 disagree)',
         }),
       ],


### PR DESCRIPTION
## Summary
- Add structured resolutionSource metadata to L2 discussion verdicts
- Route forced tie-break criticals through explicit metadata instead of reasoning-string parsing
- Avoid confidence boosts for forced tie-break decisions and expose resolution source in L3 prompts/artifacts

## Verification
- pnpm exec vitest run packages/core/src/tests/l2-hc-debate.test.ts src/tests/l3-verdict.test.ts src/tests/confidence.test.ts src/tests/l2-writer.test.ts --no-file-parallelism
- pnpm typecheck
- pnpm lint
- pnpm build:action
- node --check dist/action.js
- pnpm test -- --no-file-parallelism