### PR TITLE
fix: point MCP development exports to published files

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -23,11 +23,11 @@
   "main": "./dist/index.js",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "development": "./dist/index.js",
       "import": "./dist/index.js"
     },
     "./version.js": {
-      "development": "./src/version.ts",
+      "development": "./dist/version.js",
       "import": "./dist/version.js"
     }
   },


### PR DESCRIPTION
## Summary
- point the `@codeagora/mcp` `development` export conditions at the same published JS files as `import`
- avoid resolving package exports to unpublished TypeScript source files

## Why
`@codeagora/mcp@0.1.2` publishes `dist/index.js` and `dist/version.js`, but not `src/index.ts` or `src/version.ts`. Consumers/tools running with the `development` condition can resolve those missing source files from the published package.

## Validation
- `npm pack @codeagora/mcp@0.1.2 --silent` confirmed `package/src/index.ts` and `package/src/version.ts` are absent while `package/dist/index.js` and `package/dist/version.js` exist
- `node -e "const p=require('./packages/mcp/package.json'); if(p.exports['.'].development!=='./dist/index.js') process.exit(1); if(p.exports['./version.js'].development!=='./dist/version.js') process.exit(2)"`
- `git diff --check`